### PR TITLE
docs: lock Soul Codex doctrine + engine planning canon

### DIFF
--- a/DOCUMENTATION_INDEX.md
+++ b/DOCUMENTATION_INDEX.md
@@ -1,348 +1,54 @@
 # Soul Codex Documentation Index
 
-**Last Updated:** March 7, 2026  
-**Status:** v1.0 Shipped  
-
----
-
-## Overview
-
-This directory contains comprehensive product documentation for Soul Codex, a mobile-first personality and compatibility application that synthesizes 35+ spiritual and psychological systems into actionable insights for self-discovery and relationships.
-
----
+**Last Updated:** May 12, 2026  
+**Status:** Canon refresh (docs-only)
 
 ## Start Here
 
-- **[README.md](./README.md)** — What the app is, how to run it, the 35+ systems explained plainly
-- **[QUICK_START.md](./QUICK_START.md)** — Fastest path from clone to running app (Node.js, not Python)
-- **[CHANGELOG.md](./CHANGELOG.md)** — What shipped in v1.0.0
-- **[ROADMAP.md](./ROADMAP.md)** — What's live, what's coming, what's intentionally deferred
+- [README.md](./README.md): quick orientation and local run/build commands.
+- [AGENTS.md](./AGENTS.md): hard operating rules and architecture realities.
+- [QUICK_START.md](./QUICK_START.md): rapid environment setup.
+- [ROADMAP.md](./ROADMAP.md): project direction.
 
----
+## Canonical Doctrine (New Source of Truth)
 
-## Documentation Files
+- [docs/soul-codex/README.md](./docs/soul-codex/README.md)
+- [docs/soul-codex/product-doctrine.md](./docs/soul-codex/product-doctrine.md)
+- [docs/soul-codex/system-boundaries.md](./docs/soul-codex/system-boundaries.md)
+- [docs/soul-codex/reading-quality-standard.md](./docs/soul-codex/reading-quality-standard.md)
+- [docs/soul-codex/confidence-rules.md](./docs/soul-codex/confidence-rules.md)
+- [docs/soul-codex/explanation-template.md](./docs/soul-codex/explanation-template.md)
+- [docs/soul-codex/parent-family-layer.md](./docs/soul-codex/parent-family-layer.md)
 
-### 1. [PRODUCT_REQUIREMENTS.md](./PRODUCT_REQUIREMENTS.md)
-**546 lines | 26KB**
+## Engine Planning Canon
 
-Complete Product Requirements Document (PRD) covering:
-- **Target Users:** 3 detailed personas (Self-Discovery Seeker, Relationship Navigator, Wellness Enthusiast)
-- **Problem Statement:** Current pain points and desired state
-- **Core Value Proposition:** Multi-system integration with empowering language
-- **Features by Release:**
-  - MVP (already implemented): Profile creation, 30+ systems, compatibility, AI chat, PDF export
-  - v1 (3 months): Enhanced journaling, saved people improvements, advanced charts, premium gating
-  - v2 (6-12 months): Social/community, coaching, integrations, predictive tools, localization
-- **Technical Architecture:** React + Express + PostgreSQL + OpenAI stack
-- **User Stories:** 24+ user stories across 6 epics
-- **Success Metrics:** Acquisition, activation, engagement, retention, monetization KPIs
-- **Risk Analysis:** 6 major risks with mitigation strategies
-- **Competitive Analysis:** vs. Co-Star, The Pattern, Sanctuary, TimePassages, etc.
+- [docs/engine/calculation-contract.md](./docs/engine/calculation-contract.md)
+- [docs/engine/ephemeris-strategy.md](./docs/engine/ephemeris-strategy.md)
+- [docs/engine/system-inputs.md](./docs/engine/system-inputs.md)
+- [docs/engine/system-outputs.md](./docs/engine/system-outputs.md)
+- [docs/engine/test-fixtures.md](./docs/engine/test-fixtures.md)
 
-**Key Sections:**
-- Executive Summary
-- Target User Personas
-- Problem Statement & Value Proposition
-- MVP, v1, v2 Feature Roadmap
-- Non-Functional Requirements
-- Technical Architecture
-- User Stories
-- Success Metrics & KPIs
-- Risks & Mitigations
-- Competitive Analysis
+## Existing Root-Level Canon (Legacy Entry Points)
 
----
+These files remain available but now point to the docs canon above:
 
-### 2. [UX_FLOW.md](./UX_FLOW.md)
-**998 lines | 33KB**
+- [SOUL_CODEX_CANON.md](./SOUL_CODEX_CANON.md)
+- [SOUL_CODEX_OUTPUT_SCHEMA_V1.md](./SOUL_CODEX_OUTPUT_SCHEMA_V1.md)
+- [SOUL_CODEX_PARENT_CONTEXT_LAYER.md](./SOUL_CODEX_PARENT_CONTEXT_LAYER.md)
 
-Comprehensive UX flow documentation covering every screen and interaction:
-- **Onboarding Flow:** Landing page → 3-step profile creation → Dashboard
-- **Dashboard:** Main navigation, soul blueprint tabs, quick stats, today section
-- **Compatibility Flow:** People list → Add person → Select for comparison → Report
-- **Daily Insights:** Energy summary, transits, reflection prompts, affirmations
-- **AI Soul Guide Chat:** Modal interface, streaming responses, context-aware conversations
-- **Export & Share:** PDF generation with lazy loading, shareable links
-- **Settings & Account:** Profile editing, subscription management, privacy controls
-- **Mobile-Specific:** Touch gestures, keyboard handling, bottom sheets, offline behavior
-- **Error States:** Empty states, error handling, edge cases
-- **Accessibility:** Screen reader support, keyboard navigation, visual/cognitive accessibility
+## Technical and Deployment References
 
-**Key Sections:**
-- Complete screen-by-screen flows with wireframe descriptions
-- User actions and system responses
-- Design notes and implementation details
-- Mobile interactions and gestures
-- Offline-first behavior
-- Error states and edge cases
-- Accessibility requirements
-- Performance goals
+- [CONFIDENCE.md](./CONFIDENCE.md)
+- [DEPLOYMENT.md](./DEPLOYMENT.md)
+- [RAILWAY_DEPLOY.md](./RAILWAY_DEPLOY.md)
+- [DEPLOYMENT_COMPARISON.md](./DEPLOYMENT_COMPARISON.md)
+- [PUBLISHING_GUIDE.md](./PUBLISHING_GUIDE.md)
+- [app_store_metadata.md](./app_store_metadata.md)
+- [server/README.md](./server/README.md)
+- [client/README.md](./client/README.md)
 
----
+## Architecture Reality Check
 
-### 3. [DATA_MODEL.md](./DATA_MODEL.md)
-**1061 lines | 37KB**
+The active app path in this repo is root-level (`server/index.ts`, `client/src/main.tsx`, root `routes.ts`, root `vite.config.ts`) with shared libraries under `packages/*`.
 
-Complete data model with Entity Relationship Diagram, schemas, and SQL:
-- **Core Entities:**
-  - UserProfile (soul_profiles): Birth data + 30+ system calculations stored as JSONB
-  - CompatibilityResult (compatibility_analyses): 5 pillars, synastry, relationship advice
-  - Notes/Journal (journal_entries): Reflection prompts, tags, mood tracking
-- **Supporting Entities:**
-  - Users, LocalUsers, Persons, DailyInsights
-  - AccessCodes, PushSubscriptions, Sessions
-  - AssessmentResponses, FrequencyLogs
-- **Relationships:** One-to-one, one-to-many, many-to-many mappings
-- **JSONB Schemas:** Detailed examples for astrology, numerology, Human Design data
-- **Indexes:** Primary keys, foreign keys, composite indexes, GIN indexes for JSONB
-- **Validation:** Application-level and database-level constraints
-- **Security:** Encryption, access control, GDPR compliance
-- **Complete PostgreSQL Schema:** Production-ready SQL DDL
-
-**Key Sections:**
-- Entity Relationship Diagram (ASCII art)
-- Detailed entity specifications with all fields
-- JSONB schema examples
-- Data relationships and foreign keys
-- Data access patterns and indexes
-- Validation rules and constraints
-- Security and privacy measures
-- Performance optimization strategies
-- Data lifecycle management
-- Complete SQL schema (PostgreSQL)
-
----
-
-### 4. [PRICING_MODEL.md](./PRICING_MODEL.md)
-**510 lines | 19KB**
-
-Detailed pricing strategy with tiers, psychology, and projections:
-- **Free Tier ("Soul Seeker"):** $0 forever
-  - 1 profile, 5 saved people, 3 compatibility analyses/month
-  - 10 AI chat messages/month, 1 PDF export/month
-  - All core features accessible
-- **Premium Tier ("Soul Master"):** $9.99/month or $89.99/year
-  - Unlimited profiles, people, compatibility analyses
-  - Advanced insights (transits calendar, progressions, return charts)
-  - Unlimited journaling, AI chat, PDF exports
-  - Priority support, early feature access
-  - 7-day free trial
-- **Feature Comparison Table:** Side-by-side free vs. premium
-- **Upgrade Flows:** In-app triggers, payment via Stripe, cancellation handling
-- **Revenue Projections:** Conservative estimates for Year 1 ($27K ARR)
-- **Pricing Psychology:** Why $9.99/month works, value anchoring
-- **Competitive Analysis:** Positioned against Co-Star, The Pattern, Sanctuary
-- **Future Tiers:** Soul Coach ($29.99/mo), Team/Business ($99/mo), Lifetime ($499)
-
-**Key Sections:**
-- Pricing tiers with detailed feature lists
-- Free trial and payment flows
-- Upgrade and cancellation processes
-- Feature comparison table
-- Pricing psychology and positioning
-- Revenue projections and metrics
-- Competitive pricing analysis
-- Future tier considerations
-- Pricing FAQs
-
----
-
-### 5. [SAFETY_ETHICS.md](./SAFETY_ETHICS.md)
-**564 lines | 21KB**
-
-Mandatory ethical guidelines and safety protocols:
-- **Core Principles:**
-  - Non-Determinism: Use "may/might", never "will/always"
-  - Empowering Language: Growth-oriented, user-centric framing
-  - No Medical Advice: Never diagnose, always refer to professionals
-  - No Legal/Financial Advice: Out of scope, liability risk
-  - Inclusive Language: Gender, sexuality, race, ability-inclusive
-- **Content Standards:**
-  - Interpretation quality checklist
-  - Compatibility report guidelines
-  - AI system prompts with safety guardrails
-- **Vulnerable User Protections:**
-  - Age restrictions (13+ for COPPA)
-  - Crisis intervention (suicide, self-harm, abuse resources)
-  - Automated detection and response protocols
-- **Required Disclaimers:**
-  - App-wide footer, profile creation, compatibility reports, AI chat, PDF exports
-- **Content Review Process:** Internal review, ongoing monitoring, user feedback loops
-- **Team Training:** Ethics certification required for all team members
-- **Transparency:** Public commitments, quarterly reports, user recourse
-
-**Key Sections:**
-- Core ethical principles with examples
-- Content standards and quality checklists
-- AI safety guidelines and system prompts
-- Vulnerable user protections
-- Required disclaimers (comprehensive list)
-- Crisis intervention protocols
-- Content review and monitoring processes
-- Team training requirements
-- Transparency and accountability commitments
-- Language replacement guide (quick reference)
-
----
-
-## Documentation Summary
-
-### Total Documentation
-- **5 comprehensive documents**
-- **3,679 lines of markdown**
-- **136KB of detailed specifications**
-- **100% coverage of problem statement requirements**
-
-### Coverage Checklist
-
-✅ **PRD:**
-- Target user personas
-- Problem statement
-- Core value proposition
-- MVP, v1, v2 feature roadmap
-
-✅ **Feature Set:**
-- Profile creation and onboarding
-- Charts/reports (30+ systems)
-- Compatibility analysis
-- Journaling prompts
-- Saved people management
-- PDF exports
-
-✅ **UX Flow:**
-- Onboarding → Dashboard → Report → Compatibility → Insights → Export
-- Complete screen-by-screen flows
-- Mobile-first interactions
-- Offline behavior
-- Error handling
-
-✅ **Data Model:**
-- UserProfile entity and fields
-- ChartResult structure (embedded JSONB)
-- CompatibilityResult entity and fields
-- Notes/Journal entity and fields
-- Complete ERD and SQL schema
-
-✅ **Pricing Model:**
-- Free tier features and limits
-- Premium tier ($9.99/mo, $89.99/yr)
-- Feature gating strategy
-- Revenue projections
-
-✅ **Safety & Ethics:**
-- Non-medical language requirements
-- Disclaimers on all content
-- No deterministic "diagnosis" framing
-- Empowering, clear language (not mystical word-soup)
-
-### Constraints Met
-
-✅ **Mobile-First:** UX flows designed for touch, responsive design documented  
-✅ **Offline-First:** Data model supports local storage, sync strategy documented  
-✅ **Clear Language:** Safety guidelines enforce empowering, jargon-free content  
-✅ **Shippable:** All documents are detailed enough for dev implementation without guesswork  
-
----
-
-## How to Use This Documentation
-
-### For Product Managers
-- Start with **PRODUCT_REQUIREMENTS.md** for complete feature roadmap
-- Reference **PRICING_MODEL.md** for monetization strategy
-- Review **SAFETY_ETHICS.md** for ethical guardrails
-
-### For Designers
-- Start with **UX_FLOW.md** for screen-by-screen designs
-- Reference **PRODUCT_REQUIREMENTS.md** for user personas
-- Review **SAFETY_ETHICS.md** for language guidelines
-
-### For Engineers
-- Start with **DATA_MODEL.md** for database schema
-- Reference **UX_FLOW.md** for interaction patterns
-- Review **PRODUCT_REQUIREMENTS.md** for technical architecture
-
-### For Content Writers
-- Start with **SAFETY_ETHICS.md** for language requirements
-- Reference **UX_FLOW.md** for UI copy context
-- Review **PRODUCT_REQUIREMENTS.md** for tone and positioning
-
-### For QA Testers
-- Start with **UX_FLOW.md** for test scenarios
-- Reference **PRODUCT_REQUIREMENTS.md** for acceptance criteria
-- Review **SAFETY_ETHICS.md** for content validation
-
----
-
-## Implementation Roadmap
-
-### Phase 1: Foundation (Weeks 1-2)
-- Database schema implementation (DATA_MODEL.md)
-- Core data models and migrations
-- Basic CRUD operations
-
-### Phase 2: MVP Features (Weeks 3-8)
-- Onboarding and profile creation (UX_FLOW.md, section 1)
-- Soul blueprint dashboard (UX_FLOW.md, section 2)
-- Compatibility engine (UX_FLOW.md, section 3)
-- Daily insights (UX_FLOW.md, section 4)
-- AI chat integration (UX_FLOW.md, section 5)
-- PDF export (UX_FLOW.md, section 6)
-
-### Phase 3: Premium Features (Weeks 9-12)
-- Subscription system (PRICING_MODEL.md)
-- Feature gating (free vs. premium)
-- Stripe integration
-- Premium feature unlocks
-
-### Phase 4: Safety & Polish (Weeks 13-14)
-- Safety guardrails implementation (SAFETY_ETHICS.md)
-- Disclaimers on all screens
-- Crisis detection in AI chat
-- Content quality review
-- Accessibility audit
-- Performance optimization
-
-### Phase 5: Launch (Week 15)
-- Beta testing with 50 users
-- Bug fixes and iterations
-- Marketing materials
-- App Store submission (PWA via PWABuilder)
-- Public launch
-
----
-
-## Document Maintenance
-
-**Review Cycle:**
-- **PRODUCT_REQUIREMENTS.md:** Monthly during active development, quarterly after launch
-- **UX_FLOW.md:** After each major UX update or user research session
-- **DATA_MODEL.md:** With each database migration or schema change
-- **PRICING_MODEL.md:** Quarterly or when pricing changes
-- **SAFETY_ETHICS.md:** Quarterly or when safety incidents occur
-
-**Version Control:**
-All documents are version controlled in Git. Update version numbers and "Last Updated" dates when making changes.
-
-**Document Owners:**
-- **PRODUCT_REQUIREMENTS.md:** Product Team
-- **UX_FLOW.md:** Product & Design Team
-- **DATA_MODEL.md:** Engineering Team
-- **PRICING_MODEL.md:** Product & Business Team
-- **SAFETY_ETHICS.md:** Ethics & Safety Team
-
----
-
-## Questions or Feedback?
-
-For questions about this documentation:
-- Product questions: [Product Team Email]
-- Technical questions: [Engineering Team Email]
-- Ethics questions: [Ethics & Safety Team Email]
-
-For documentation updates or corrections, please open a GitHub issue or pull request.
-
----
-
-**Status:** ✅ Complete & Ready for Development  
-**Next Steps:** Begin Phase 1 implementation (database schema)  
-**Target Launch:** Q2 2026
+Documentation that references missing `apps/web` or `apps/api` directories should be treated as stale unless refreshed.

--- a/README.md
+++ b/README.md
@@ -1,51 +1,60 @@
 # Ultimate Soul Codex (Engine of the Eternal Now)
 
-A premium, behavior-first “life mapping” app: onboarding → profile → Codex reading → today/timeline/compatibility — with **explicit confidence labeling** so users always know what’s locked in.
+Soul Codex is a personal identity operating system: daily guidance on the surface, deeper metaphysical and behavioral interpretation underneath, with explicit confidence labeling.
 
-## Repo structure (monorepo)
+## Canonical doctrine docs
 
-- **`apps/web`**: Vite + React web app (UI)
-- **`apps/api`**: Express API entrypoint (bundled to `dist/server.js`)
-- **`packages/*`**: shared libraries
-  - **`packages/core`**: core compute + prompts
-  - **`packages/db`**: Drizzle schema + shared zod schemas
-  - **`packages/ai`**: validation pipeline (clarity/structure/blandness)
-  - **`packages/astrology`**: astrology utilities and related engines
-- **Root `routes.ts` / `server/index.ts`**: canonical API router + server harness used by the built app
+Product and quality canon now lives in `docs/`:
+
+- `docs/soul-codex/README.md`
+- `docs/soul-codex/product-doctrine.md`
+- `docs/soul-codex/system-boundaries.md`
+- `docs/soul-codex/reading-quality-standard.md`
+- `docs/soul-codex/confidence-rules.md`
+- `docs/soul-codex/explanation-template.md`
+- `docs/soul-codex/parent-family-layer.md`
+- `docs/engine/calculation-contract.md`
+- `docs/engine/ephemeris-strategy.md`
+- `docs/engine/system-inputs.md`
+- `docs/engine/system-outputs.md`
+- `docs/engine/test-fixtures.md`
+
+## Working architecture in this repo
+
+The active app path in this worktree is root-level:
+
+- Backend entry: `server/index.ts` (Express + Vite middleware in dev).
+- Frontend entry: `client/src/main.tsx` (served by root `vite.config.ts` with `client/` root).
+- Route layer: root `routes.ts`.
+- Shared and engine packages: `packages/*` (`core`, `db`, `ai`, `astrology`).
 
 ## Run locally
 
 ```bash
 npm install
 cp .env.example .env
-npm run dev
+source ~/.nvm/nvm.sh && nvm use 20
+NODE_ENV=development npx tsx server/index.ts
 ```
 
 Open `http://localhost:3000`.
 
-## Build for production
+## Build
 
 ```bash
-npm run build
-npm run start
+npm run build -w packages/db
+npm run build -w packages/core
+npx vite build
+npx esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist
 ```
 
-## Confidence / trust system
+## Confidence and contracts
 
-Confidence is a first-class model: `verified | partial | unverified` with an explicit reason and an optional AI assurance note.
-
-See `CONFIDENCE.md` for:
-- badge rules
-- “where computed / where displayed”
-- display guidance
-
-## Canonical output contract (Schema v1)
-
-The engine-facing profile contract is `Soul Codex Output Schema v1`.
-
-- Spec: `SOUL_CODEX_OUTPUT_SCHEMA_V1.md`
-- Endpoint: `GET /api/profiles/:id/soul-codex-v1?tone_mode=clean|deep|raw`
+- Confidence model overview: `CONFIDENCE.md`
+- Runtime confidence logic: `packages/core/compute/confidence.ts`
+- Structured output schema: `packages/core/soulcodex-v1/schema.ts`
+- Generator and pipeline: `packages/core/soulcodex-v1/generate.ts` and `packages/core/soulcodex-v1/engine/`
 
 ## Repository rules
 
-See `AGENTS.md` (audit-first, no fake success, small PRs).
+See `AGENTS.md` for audit-first and no-illusion requirements.

--- a/SOUL_CODEX_CANON.md
+++ b/SOUL_CODEX_CANON.md
@@ -1,3 +1,5 @@
+> Legacy Canon Notice (May 12, 2026): This file remains as historical context. The canonical source of truth now lives in `docs/soul-codex/` and `docs/engine/` starting with `docs/soul-codex/README.md`.
+
 # Soul Codex Canon — Identity Translation Engine (Final Form)
 
 This document captures the non-negotiable standards for the completed Soul Codex experience. It translates the narrative blueprint into implementation-ready guardrails for engineers, writers, and designers. Every section answers what it is, why it matters, how it shows up for users, and how to integrate it.

--- a/SOUL_CODEX_OUTPUT_SCHEMA_V1.md
+++ b/SOUL_CODEX_OUTPUT_SCHEMA_V1.md
@@ -1,3 +1,5 @@
+> Legacy Canon Notice (May 12, 2026): This file remains as historical context. Canonical doctrine and engine planning now live in `docs/soul-codex/` and `docs/engine/`. Runtime schema anchors are `packages/core/soulcodex-v1/schema.ts` and `packages/core/soulcodex-v1/generate.ts`.
+
 # Soul Codex Output Schema v1 (Canonical Contract)
 
 This repository now exposes a single canonical, machine-readable profile output contract:
@@ -118,4 +120,3 @@ Recommended next steps (incremental, reviewable):
 
 - The generator is currently **deterministic** and leverages existing stored fields like `profile.astrologyData`, `profile.humanDesignData`, `profile.numerologyData`, and `profile.synthesis` when present.
 - The contract is enforced server-side via zod parse (`soulCodexOutputV1Schema.parse(...)`).
-

--- a/SOUL_CODEX_PARENT_CONTEXT_LAYER.md
+++ b/SOUL_CODEX_PARENT_CONTEXT_LAYER.md
@@ -1,3 +1,5 @@
+> Legacy Canon Notice (May 12, 2026): This file remains as historical context. Canonical parent/family-layer policy now lives in `docs/soul-codex/parent-family-layer.md`.
+
 🜂 SOUL CODEX
 
 PARENT CONTEXT LAYER — FULL EXECUTION PACKAGE

--- a/docs/engine/calculation-contract.md
+++ b/docs/engine/calculation-contract.md
@@ -1,0 +1,54 @@
+# Calculation Contract (Planning Baseline)
+
+## Goal
+
+Define the stable contract from user inputs to structured Soul Codex outputs without changing runtime behavior in this documentation PR.
+
+## Verified Code Anchors
+
+Core schema and generation:
+- `packages/core/soulcodex-v1/schema.ts`
+- `packages/core/soulcodex-v1/generate.ts`
+
+Engine internals:
+- `packages/core/soulcodex-v1/engine/index.ts`
+- `packages/core/soulcodex-v1/engine/traitMapper.ts`
+- `packages/core/soulcodex-v1/engine/statementSelector.ts`
+- `packages/core/soulcodex-v1/engine/dailyGuidance.ts`
+
+Confidence logic:
+- `packages/core/compute/confidence.ts`
+- `soulcodex/compute/confidence.ts`
+
+## Contract Stages
+
+1. Input normalization
+- birth data and profile data are normalized
+- missing fields are explicit
+
+2. Signal extraction
+- astrology, human design, numerology, and mirror/context signals become structured traits
+
+3. Rule filtering
+- contradictions and low-confidence conflicts are filtered deterministically
+
+4. Statement selection
+- trait overlap and confidence thresholds drive selected interpretation statements
+
+5. Section assembly
+- output mapped into summary, sections, and daily guidance contract
+
+6. Confidence assignment
+- chart/system confidence badges and overall confidence levels assigned
+
+## Stability Rules
+
+- Public output schema remains backward compatible within `soul_codex_v1`.
+- Content evolution can expand depth but should not silently break field semantics.
+- Confidence enums remain fixed unless versioned API/schema changes are approved.
+
+## Out of Scope for This Phase
+
+- runtime backend replacement
+- Python ephemeris implementation
+- route rewiring or deployment architecture changes

--- a/docs/engine/ephemeris-strategy.md
+++ b/docs/engine/ephemeris-strategy.md
@@ -1,0 +1,37 @@
+# Ephemeris Strategy (Phased)
+
+## Objective
+
+Increase calculation precision over time without destabilizing launch-track delivery.
+
+## Current Phase (Now)
+
+- Keep existing JS/TS engine stack in production path.
+- Lock contracts, fixtures, and confidence disclosures first.
+- Do not replace backend architecture during TestFlight hardening.
+
+## Future Evaluation Path
+
+Potential precision layer options include Swiss Ephemeris-based tooling, but only after formal review.
+
+Required gates before adoption:
+1. license and legal review
+2. deployment and runtime fit review
+3. contract compatibility review
+4. output comparison against baseline fixtures
+5. rollback plan
+
+## Sidecar Migration Pattern
+
+1. Keep current engine as baseline.
+2. Add precision engine in sidecar mode.
+3. Run fixture comparisons for drift visibility.
+4. Switch only when acceptance thresholds are met.
+
+## Licensing Caution
+
+If evaluating `pyswisseph`, complete legal review before implementation or distribution decisions. Documentation alone does not authorize integration.
+
+## Anti-Pattern Ban
+
+Do not perform a wholesale backend rewrite as a first step for precision upgrades.

--- a/docs/engine/system-inputs.md
+++ b/docs/engine/system-inputs.md
@@ -1,0 +1,51 @@
+# System Inputs Contract
+
+## Purpose
+
+Define required and optional inputs by system and how missing data affects confidence and output scope.
+
+## Core Identity Inputs
+
+Required minimum:
+- name (for some narrative and numerology pathways)
+- birth date
+
+Precision inputs:
+- birth time
+- birth location
+- timezone or reliable timezone derivation
+
+## Inputs by System
+
+Astrology:
+- required: birth date
+- precision-critical: birth time, location, timezone
+- impact when missing: reduced or unverified rising/house precision
+
+Human Design:
+- required baseline: birth date
+- precision-critical: birth time and location/timezone
+- impact when missing: degraded authority/profile/channel precision
+
+Numerology:
+- required: birth date
+- optional: name for expanded numerology layers
+- impact when missing: life-path or derived numerology fields may be unavailable
+
+Behavioral and context layer:
+- optional: mirror answers, user reflections, parent-family context
+- impact when missing: less personalized pattern differentiation
+
+## Context Input Taxonomy
+
+- personal birth inputs
+- computed system outputs
+- self-report behavior inputs
+- family and environment context
+- confidence metadata
+
+## Input Integrity Rules
+
+- Unknown values must be explicit, not inferred silently.
+- Approximate values must be marked as approximate.
+- Missing precision must flow into confidence and copy disclosures.

--- a/docs/engine/system-outputs.md
+++ b/docs/engine/system-outputs.md
@@ -1,0 +1,45 @@
+# System Outputs Contract
+
+## Purpose
+
+Define required output objects for daily guidance surface and advanced engine surface while preserving shared meaning and confidence transparency.
+
+## Daily Guidance Surface
+
+Required output traits:
+- concise focus
+- actionable do/don't guidance
+- watch-out pattern
+- decision guidance
+- visible confidence context
+
+Primary anchor:
+- `packages/core/soulcodex-v1/schema.ts` (`daily_guidance` and `confidence`)
+
+## Advanced Engine Surface
+
+Required output traits:
+- structured core-system snapshot
+- sectioned interpretation blocks
+- signal traceability at section level
+- confidence and uncertainty exposure
+
+Primary anchors:
+- `packages/core/soulcodex-v1/schema.ts`
+- `packages/core/soulcodex-v1/generate.ts`
+- `packages/core/soulcodex-v1/engine/types.ts`
+
+## Confidence and Missing-Data Metadata
+
+Every major output payload should carry:
+- chart/system confidence badge
+- overall confidence level
+- input summary with known missing precision fields
+
+Required behavior:
+- if precision is missing, outputs still render where valid
+- outputs must disclose limits instead of pretending full certainty
+
+## Explanation Contract Coupling
+
+Symbol-level explanation templates in `docs/soul-codex/explanation-template.md` should remain compatible with structured output sections so daily and advanced surfaces do not contradict each other.

--- a/docs/engine/test-fixtures.md
+++ b/docs/engine/test-fixtures.md
@@ -1,0 +1,50 @@
+# Test Fixtures and Acceptance Rules
+
+## Purpose
+
+Define fixture coverage expectations for deterministic quality checks and uncertainty behavior.
+
+## Existing Test Anchor
+
+- `packages/core/soulcodex-v1/tests/canonical.test.ts`
+
+## Fixture Matrix (Planning Baseline)
+
+1. Full precision profile
+- complete birth date, time, and location/timezone
+- expected: `verified` chart confidence and valid overall confidence assignment
+
+2. Missing birth time
+- date and location present, no birth time
+- expected: downgraded chart precision with explicit limitation copy
+
+3. Missing location/timezone
+- date present, incomplete geo/timezone
+- expected: `unverified` chart confidence path where runtime logic requires it
+
+4. Date-only profile
+- minimal viable input
+- expected: date-stable layers render, precision-sensitive layers disclosed as limited
+
+5. Sparse behavioral/context inputs
+- no mirror/family context
+- expected: stable baseline reading without fabricated specificity
+
+6. Rich behavioral/context inputs
+- mirror and contextual answers present
+- expected: differentiation in statement selection while preserving schema stability
+
+## Acceptance Rules
+
+- no schema parse failures for valid fixture payloads
+- confidence enums must remain in allowed sets
+- missing data must produce explicit limitations
+- deterministic pipeline should avoid placeholder text in production outputs
+- wording guards should block deterministic or diagnostic phrasing
+
+## Drift Monitoring Guidance
+
+When adding new systems or precision engines:
+- compare outputs against baseline fixtures
+- document intentional deltas
+- reject silent contract drift

--- a/docs/soul-codex/README.md
+++ b/docs/soul-codex/README.md
@@ -1,0 +1,45 @@
+# Soul Codex Canonical Doctrine
+
+This directory is the canonical source of truth for Soul Codex product identity, boundaries, and reading quality standards.
+
+Soul Codex is not just an astrology app. Soul Codex is a personal identity operating system: simple enough for daily guidance, deep enough for full-spectrum identity decoding.
+
+## Positioning Lock
+
+- Daily Guidance Mode: calm, useful, beginner-safe interpretation for everyday use.
+- Codex Engine Mode: transparent system depth for advanced users, skeptics, and builders.
+- One product, two surfaces: approachable front experience with a precise explanation engine underneath.
+
+## Non-Negotiable Product Promise
+
+Every meaningful output should answer:
+
+1. What is this?
+2. Why does it matter?
+3. How does it show up in real life?
+4. What are the gifts?
+5. What are the shadows?
+6. What is the growth move?
+7. How confident is this?
+8. What data is missing?
+
+## Canonical Documents
+
+- [product-doctrine.md](./product-doctrine.md)
+- [system-boundaries.md](./system-boundaries.md)
+- [reading-quality-standard.md](./reading-quality-standard.md)
+- [confidence-rules.md](./confidence-rules.md)
+- [explanation-template.md](./explanation-template.md)
+- [parent-family-layer.md](./parent-family-layer.md)
+
+## Engine Planning Documents
+
+- [../engine/calculation-contract.md](../engine/calculation-contract.md)
+- [../engine/ephemeris-strategy.md](../engine/ephemeris-strategy.md)
+- [../engine/system-inputs.md](../engine/system-inputs.md)
+- [../engine/system-outputs.md](../engine/system-outputs.md)
+- [../engine/test-fixtures.md](../engine/test-fixtures.md)
+
+## Scope Guard
+
+This docs suite does not authorize runtime refactors by itself. It locks doctrine and contracts first so future implementation can stay coherent and testable.

--- a/docs/soul-codex/confidence-rules.md
+++ b/docs/soul-codex/confidence-rules.md
@@ -1,0 +1,57 @@
+# Soul Codex Confidence Rules
+
+## Scope
+
+This document defines confidence disclosures for user-facing outputs and aligns with current runtime enums.
+
+## Runtime Enum Lock (No Drift)
+
+Chart/system badge values:
+- `verified`
+- `partial`
+- `unverified`
+
+Overall confidence values:
+- `high`
+- `medium`
+- `low`
+
+These values are defined in:
+- `packages/core/soulcodex-v1/schema.ts`
+- `packages/core/compute/confidence.ts`
+
+Related normalization logic also exists in:
+- `soulcodex/compute/confidence.ts`
+
+## Disclosure Requirements
+
+Every major reading must display:
+- badge value
+- plain-language reason
+- practical impact of missing data
+
+## Missing Birth Precision Rules
+
+If birth time is missing:
+- mark chart-related confidence as `partial` or lower per runtime logic
+- state that houses/rising precision is limited
+- keep date-stable systems clearly identified
+
+If location or timezone is missing:
+- mark chart confidence as `unverified` where required by runtime logic
+- state that location-sensitive calculations are limited
+
+## Copy Qualifiers (Human Layer)
+
+Allowed copy qualifiers include:
+- "Birth-time sensitive"
+- "Location-sensitive"
+- "Estimated from available inputs"
+
+These are copy labels only. They do not replace enum values.
+
+## Alignment Check Requirement
+
+When confidence copy is edited, verify that docs still match runtime logic in:
+- `packages/core/compute/confidence.ts`
+- `packages/core/soulcodex-v1/generate.ts`

--- a/docs/soul-codex/explanation-template.md
+++ b/docs/soul-codex/explanation-template.md
@@ -1,0 +1,77 @@
+# Soul Codex Explanation Template
+
+## Purpose
+
+Every symbol-level explanation should be structurally consistent and readable in both beginner and advanced modes.
+
+## Required Fields
+
+- Name
+- System
+- Technical meaning
+- Plain-English meaning
+- Why it matters
+- How it shows up
+- Gift
+- Shadow
+- Growth move
+- Confidence
+
+## Canonical Object Shape (Planning Contract)
+
+```json
+{
+  "name": "Moon in Scorpio",
+  "system": "Astrology",
+  "technicalMeaning": "...",
+  "plainEnglishMeaning": "...",
+  "whyItMatters": "...",
+  "howItShowsUp": ["...", "..."],
+  "gift": ["..."],
+  "shadow": ["..."],
+  "growthMove": "...",
+  "confidence": {
+    "badge": "partial",
+    "note": "Birth time not provided; house precision is limited."
+  }
+}
+```
+
+## Example (Moon in Scorpio)
+
+Technical meaning:
+- The Moon reflects emotional regulation, attachment, memory, and felt safety.
+- Scorpio adds intensity, privacy, depth-scanning, and transformation pressure.
+
+Plain-English meaning:
+- You feel deeply, detect hidden tension quickly, and often need earned trust before full emotional openness.
+
+Why it matters:
+- This influences bonding, privacy boundaries, conflict repair pace, and response to perceived betrayal.
+
+Gift:
+- emotional depth
+- loyalty
+- pattern intuition
+
+Shadow:
+- suspicion loops
+- emotional testing
+- silent resentment
+
+Growth move:
+- Name the feeling directly before running a private investigation.
+
+Confidence note:
+- If birth time is missing, house-level expression may shift.
+
+## Beginner vs Advanced Rendering
+
+Beginner mode:
+- 3 to 6 sentences, zero jargon without explanation.
+
+Advanced mode:
+- include technical frame, system mechanics, and confidence caveats.
+
+Both modes:
+- same factual meaning, different density.

--- a/docs/soul-codex/parent-family-layer.md
+++ b/docs/soul-codex/parent-family-layer.md
@@ -1,0 +1,52 @@
+# Parent and Family Layer
+
+## Core Framing
+
+Parent and family signals are contextual layers that help explain imprint, not destiny.
+
+Soul Codex stance:
+- parents may shape emotional weather
+- adaptation is intelligent, not evidence of defect
+- user agency remains primary
+
+## What This Layer Can Explain
+
+- emotional climate
+- boundary formation patterns
+- attachment style pressure
+- role performance learned in family systems
+- survival strategies that outlived original conditions
+
+## What This Layer Cannot Claim
+
+- permanent identity definitions from parent data
+- parent blame narratives
+- deterministic outcomes
+- clinical conclusions
+
+## Required User-Facing Questions
+
+1. What emotional climate did this environment create?
+2. What did the user learn to hide?
+3. What did the user learn to perform?
+4. What boundary pattern formed?
+5. What survival strategy emerged?
+6. What should be kept?
+7. What can now be released?
+
+## Output Language Rules
+
+Required:
+- "may have shaped"
+- "can help explain"
+- "does not override your core profile"
+
+Not allowed:
+- "because your parent was X, you are Y"
+- "this family trait determines your fate"
+
+## Data and Product Limits
+
+- Family layer remains optional.
+- Treat as additive context, not a prerequisite for core reading.
+- If parent data is partial, disclose limits explicitly.

--- a/docs/soul-codex/product-doctrine.md
+++ b/docs/soul-codex/product-doctrine.md
@@ -1,0 +1,69 @@
+# Soul Codex Product Doctrine
+
+## Identity Definition
+
+Soul Codex is a personal identity intelligence system using metaphysical calculation, behavioral patterning, family and context data, and plain-language spiritual explanation.
+
+It is not prediction-first. It is explanation-first.
+
+## Wrong vs Correct Positioning
+
+Wrong:
+- Soul Codex is an astrology or numerology reading app.
+
+Correct:
+- Soul Codex is an everyday soul operating system with professional metaphysical calculation behind it.
+
+## Product Modes
+
+### Everyday Guidance Mode
+
+Purpose: fast clarity for daily use.
+
+Includes:
+- daily focus
+- strengths and shadows
+- stress pattern and boundary guidance
+- plain language summary
+
+### Codex Engine Mode
+
+Purpose: deep traceability for advanced users.
+
+Includes:
+- chart detail and system-by-system breakdown
+- calculation confidence and missing-data notes
+- expanded explanation and evidence of how outputs were derived
+
+## Ten Locked Principles
+
+1. Every output must explain meaning, relevance, lived expression, gifts, shadows, growth move, and confidence.
+2. No vague placement language or broken terminology.
+3. No deterministic claims.
+4. No medical diagnosis.
+5. Missing birth time or location must trigger confidence warnings.
+6. Parent and family data is shaping context, not destiny.
+7. Same Sun sign users must not receive identical readings.
+8. Beginner mode must be simple, beautiful, and non-overwhelming.
+9. Advanced mode must expose system detail and calculation confidence.
+10. Clarity, usefulness, and emotional truth outrank mystical decoration.
+
+## Required Output Questions
+
+Any major reading section should explicitly answer:
+
+1. What is this signal?
+2. Why does it matter for this user?
+3. How does it show up behaviorally?
+4. Where does it help?
+5. Where can it create friction?
+6. What should the user do with this now?
+7. How confident is this interpretation?
+8. What missing data reduces confidence?
+
+## Launch Discipline
+
+During TestFlight and launch hardening:
+- no backend replacement in doctrine PRs
+- no forced engine rewrites
+- no hidden scope growth

--- a/docs/soul-codex/reading-quality-standard.md
+++ b/docs/soul-codex/reading-quality-standard.md
@@ -1,0 +1,51 @@
+# Soul Codex Reading Quality Standard
+
+## Standard Goal
+
+Soul Codex outputs should explain identity patterns with practical clarity. The target is not mystical style. The target is behavior-level usefulness.
+
+## Minimum Acceptance Rubric
+
+Each major interpretation block must include:
+- plain definition of the signal
+- reason the signal matters
+- real-life manifestation examples
+- gift or strength expression
+- shadow or overuse expression
+- one practical growth move
+- confidence note with uncertainty when relevant
+
+## Wording Correctness Rules
+
+- Use technically valid system language.
+- Distinguish planet, sign, house, aspect, and rulership correctly.
+- Avoid malformed phrasing such as "Sun is in Venus."
+- Separate technical statement from plain-language translation.
+
+## Toy vs Platform Quality Gate
+
+Toy behavior:
+- generic sign stereotypes
+- interchangeable text across users
+- no uncertainty acknowledgement
+- style over substance
+
+Platform behavior:
+- data-grounded explanations
+- user-specific pattern statements
+- explicit confidence and data gaps
+- clear next-action guidance
+
+## Required Delivery Behavior
+
+- Beginner mode: concise and calm.
+- Advanced mode: detailed and traceable.
+- Both modes must preserve factual consistency and boundaries.
+
+## Quality Failure Triggers
+
+Block or downgrade output when:
+- meaning fields are missing
+- language violates boundary policy
+- confidence cannot be determined
+- interpretation conflicts with known data integrity limits

--- a/docs/soul-codex/system-boundaries.md
+++ b/docs/soul-codex/system-boundaries.md
@@ -1,0 +1,66 @@
+# Soul Codex System Boundaries
+
+## Purpose
+
+These boundaries prevent harmful, inflated, or misleading interpretations and preserve user agency.
+
+## Determinism Ban
+
+Do not output fatalistic claims.
+
+Not allowed:
+- "You will always..."
+- "You are doomed to..."
+- "This guarantees..."
+
+Required framing:
+- "This pattern may..."
+- "This can show up as..."
+- "With awareness, this often shifts by..."
+
+## Medical and Clinical Boundary
+
+Not allowed:
+- diagnosis language
+- claims that a user has a clinical disorder
+- treatment recommendations for psychiatric or medical conditions
+
+Allowed:
+- stress patterns
+- reflection prompts
+- self-regulation suggestions
+- recommendation to seek professional help when appropriate
+
+## Uncertainty Disclosure
+
+If birth precision is missing or uncertain, outputs must include:
+- what is still reliable
+- what is estimated
+- what cannot be asserted
+
+Mandatory warning contexts:
+- missing birth time
+- unknown or low-confidence location/timezone
+- user-reported approximations
+
+## Parent and Family Limits
+
+Parent and family data is context only.
+
+Not allowed:
+- blaming a parent sign/type for user identity
+- treating family context as destiny
+- claiming permanent psychological conclusions from parent metadata
+
+Required framing:
+- "may have shaped environment"
+- "can explain adaptation"
+- "does not override your own profile"
+
+## Confidence Contract Boundary
+
+Runtime confidence enums remain:
+- chart-level: `verified | partial | unverified`
+- overall: `high | medium | low`
+
+Docs may describe richer copy labels, but must not invent new API enum values unless code changes land first.


### PR DESCRIPTION
## Summary
- add canonical doctrine docs under `docs/soul-codex/`
- add canonical engine planning docs under `docs/engine/`
- mark legacy root canon docs as historical entrypoints with pointers
- refresh `README.md` and `DOCUMENTATION_INDEX.md` to match real repo paths and new canon

## Validation
- `find docs -type f | wc -l` -> `12`
- link integrity check script for `README.md` and `DOCUMENTATION_INDEX.md` -> `ok`
- doctrine lock checks via `rg` for locked principles and boundary lines
- scope check confirmed docs-only files changed

## Risk Assessment
- low runtime risk: docs-only change
- main risk is future code/docs drift, mitigated by explicit code-anchor references in confidence and engine docs

## Rollback Plan
- revert commit `ffc549c`
- or restore previous versions of:
  - `README.md`
  - `DOCUMENTATION_INDEX.md`
  - `SOUL_CODEX_CANON.md`
  - `SOUL_CODEX_OUTPUT_SCHEMA_V1.md`
  - `SOUL_CODEX_PARENT_CONTEXT_LAYER.md`
  - `docs/soul-codex/*`
  - `docs/engine/*`
