### PR TITLE
fix(routes): add compatibility route alias

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -127,6 +127,7 @@ export default function App() {
             <Route path="/guide" component={SoulGuidePage} />
             <Route path="/tracker" component={TrackerPage} />
             <Route path="/compat" component={CompatibilityPage} />
+            <Route path="/compatibility" component={CompatibilityPage} />
             <Route path="/timeline" component={TimelinePage} />
             <Route path="/horoscope" component={DailyHoroscopePage} />
             <Route path="/poster" component={PosterPage} />


### PR DESCRIPTION
## Summary
Adds `/compatibility` as a route alias to the existing `CompatibilityPage` while preserving the current `/compat` route.

## Scope
- Adds one client route alias in `client/src/App.tsx`
- Keeps `/compat` working
- No UI redesign
- No onboarding changes
- No astrology/math changes
- No settings/privacy surface changes

## Validation Needed
Run before merge:

```bash
npm run check --workspaces --if-present
npm run test --workspaces --if-present
npm run build
```

## Risk
Low. One-purpose route patch only.