### PR TITLE
feat(evidence): add evidence ledger for engine outputs

### DIFF
--- a/client/src/components/EvidenceViewer.tsx
+++ b/client/src/components/EvidenceViewer.tsx
@@ -1,0 +1,235 @@
+import { useState } from 'react';
+import {
+  groupEvidenceByEngine,
+  formatConfidenceAsPercent,
+  formatConfidenceExplanation,
+  type EvidenceEntry,
+  type EngineType,
+} from '@soulcodex/core';
+
+interface EvidenceViewerProps {
+  entries: EvidenceEntry[];
+  compact?: boolean;
+}
+
+export default function EvidenceViewer({ entries, compact = false }: EvidenceViewerProps) {
+  const [expandedEntries, setExpandedEntries] = useState<Set<string>>(new Set());
+
+  if (entries.length === 0) {
+    return null;
+  }
+
+  const toggleExpanded = (id: string) => {
+    const updated = new Set(expandedEntries);
+    if (updated.has(id)) {
+      updated.delete(id);
+    } else {
+      updated.add(id);
+    }
+    setExpandedEntries(updated);
+  };
+
+  const grouped = groupEvidenceByEngine(entries);
+  const engineOrder: EngineType[] = [
+    'numerology',
+    'astrology',
+    'human-design',
+    'behavior',
+    'pattern',
+    'timeline',
+    'predictive',
+  ];
+
+  return (
+    <div
+      style={{
+        padding: compact ? '1rem' : '1.5rem',
+        background: 'rgba(255,255,255,0.02)',
+        borderRadius: '12px',
+        border: '1px solid rgba(255,255,255,0.08)',
+      }}
+    >
+      <h3
+        style={{
+          fontSize: compact ? '0.85rem' : '0.95rem',
+          textTransform: 'uppercase',
+          color: 'var(--sc-stone)',
+          marginTop: 0,
+          marginBottom: compact ? '0.75rem' : '1rem',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.5rem',
+        }}
+      >
+        <span>📋</span>
+        Evidence Ledger
+      </h3>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: compact ? '0.5rem' : '1rem' }}>
+        {engineOrder.map(engine => {
+          const engineEntries = grouped[engine];
+          if (!engineEntries || engineEntries.length === 0) return null;
+
+          const avgConfidence =
+            engineEntries.reduce((sum, e) => sum + e.confidence, 0) / engineEntries.length;
+
+          return (
+            <div
+              key={engine}
+              style={{
+                padding: compact ? '0.75rem' : '1rem',
+                background: 'rgba(255,255,255,0.04)',
+                borderRadius: '8px',
+                border: '1px solid rgba(255,255,255,0.05)',
+              }}
+            >
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  cursor: 'pointer',
+                }}
+                onClick={() => {
+                  // Toggle all entries for this engine
+                  const updated = new Set(expandedEntries);
+                  const allExpanded = engineEntries.every(e => updated.has(e.id));
+                  engineEntries.forEach(e => {
+                    if (allExpanded) {
+                      updated.delete(e.id);
+                    } else {
+                      updated.add(e.id);
+                    }
+                  });
+                  setExpandedEntries(updated);
+                }}
+              >
+                <div>
+                  <div
+                    style={{
+                      fontSize: compact ? '0.8rem' : '0.85rem',
+                      textTransform: 'capitalize',
+                      color: 'var(--sc-ivory)',
+                      fontWeight: 600,
+                      marginBottom: '0.25rem',
+                    }}
+                  >
+                    {engine.replace('-', ' ')}
+                  </div>
+                  <div
+                    style={{
+                      fontSize: compact ? '0.7rem' : '0.75rem',
+                      color: 'var(--sc-stone)',
+                    }}
+                  >
+                    {engineEntries.length} claim{engineEntries.length !== 1 ? 's' : ''}
+                  </div>
+                </div>
+                <div
+                  style={{
+                    fontSize: compact ? '0.8rem' : '0.9rem',
+                    fontWeight: 600,
+                    color: avgConfidence >= 80 ? 'var(--sc-teal)' : 'var(--sc-gold)',
+                  }}
+                >
+                  {formatConfidenceAsPercent(avgConfidence)}
+                </div>
+              </div>
+
+              {engineEntries.map(entry => (
+                <div
+                  key={entry.id}
+                  style={{
+                    marginTop: '0.75rem',
+                    paddingLeft: '1rem',
+                    borderLeft: '2px solid rgba(212,168,95,0.2)',
+                  }}
+                >
+                  <div
+                    style={{
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      alignItems: 'flex-start',
+                      cursor: 'pointer',
+                    }}
+                    onClick={() => toggleExpanded(entry.id)}
+                  >
+                    <div
+                      style={{
+                        flex: 1,
+                        fontSize: compact ? '0.75rem' : '0.8rem',
+                        color: 'var(--sc-ivory)',
+                      }}
+                    >
+                      {entry.claim}
+                    </div>
+                    <div
+                      style={{
+                        fontSize: compact ? '0.7rem' : '0.75rem',
+                        color: 'var(--sc-stone)',
+                        marginLeft: '0.5rem',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {formatConfidenceAsPercent(entry.confidence)}
+                    </div>
+                  </div>
+
+                  {expandedEntries.has(entry.id) && (
+                    <div
+                      style={{
+                        marginTop: '0.5rem',
+                        paddingTop: '0.5rem',
+                        borderTop: '1px solid rgba(255,255,255,0.05)',
+                        fontSize: compact ? '0.7rem' : '0.75rem',
+                        color: 'var(--sc-stone)',
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: '0.35rem',
+                      }}
+                    >
+                      <div>
+                        <strong>Status:</strong> {entry.confidenceLabel}
+                      </div>
+                      {entry.reasoning.length > 0 && (
+                        <div>
+                          <strong>Reasoning:</strong>
+                          <div style={{ marginLeft: '0.5rem', whiteSpace: 'pre-wrap' }}>
+                            {entry.reasoning.join(' → ')}
+                          </div>
+                        </div>
+                      )}
+                      {entry.limitations.length > 0 && (
+                        <div>
+                          <strong>Limitations:</strong>
+                          <ul style={{ margin: '0.25rem 0 0 0.5rem', paddingLeft: '1rem' }}>
+                            {entry.limitations.map((limit, idx) => (
+                              <li key={idx}>{limit}</li>
+                            ))}
+                          </ul>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          );
+        })}
+      </div>
+
+      <div
+        style={{
+          marginTop: compact ? '0.75rem' : '1rem',
+          paddingTop: compact ? '0.75rem' : '1rem',
+          borderTop: '1px solid rgba(255,255,255,0.05)',
+          fontSize: compact ? '0.65rem' : '0.7rem',
+          color: 'var(--sc-stone)',
+          fontStyle: 'italic',
+        }}
+      >
+        Evidence levels: verified (100%), high (85%), moderate (70%), partial (55%), low (35%), unverified (15%)
+      </div>
+    </div>
+  );
+}

--- a/packages/core/evidence-ledger/__tests__/evidence-ledger.test.ts
+++ b/packages/core/evidence-ledger/__tests__/evidence-ledger.test.ts
@@ -1,0 +1,236 @@
+import { test } from 'node:test';
+import * as assert from 'node:assert';
+import {
+  createEvidenceEntry,
+  createLedger,
+  groupEvidenceByEngine,
+  findLowConfidenceClaims,
+  findConflictingClaims,
+  summarizeEvidenceLedger,
+  calculateConfidenceLabel,
+  isHighConfidence,
+  isLowConfidence,
+  formatConfidenceAsPercent,
+  formatEvidenceEntry,
+  formatSummaryAsText,
+  type EvidenceEntry,
+} from '../index.js';
+
+test('createEvidenceEntry - basic creation', () => {
+  const entry = createEvidenceEntry(
+    'numerology',
+    'Personal Year',
+    5,
+    85,
+    'high',
+    {
+      inputsUsed: ['birth_date_verified'],
+      reasoning: ['8 + 15 + 2026 = 49 → 4 + 9 = 13 → 1 + 3 = 4... wait that should be 5'],
+    }
+  );
+
+  assert.ok(entry.id);
+  assert.equal(entry.engine, 'numerology');
+  assert.equal(entry.claim, 'Personal Year');
+  assert.equal(entry.value, 5);
+  assert.equal(entry.confidence, 85);
+  assert.equal(entry.confidenceLabel, 'high');
+  assert.equal(entry.inputsUsed.length, 1);
+  assert.equal(entry.version, '1.0');
+});
+
+test('createEvidenceEntry - confidence clamping', () => {
+  const entry1 = createEvidenceEntry('astrology', 'Test', 'value', 150, 'high');
+  assert.equal(entry1.confidence, 100);
+
+  const entry2 = createEvidenceEntry('astrology', 'Test', 'value', -50, 'low');
+  assert.equal(entry2.confidence, 0);
+});
+
+test('calculateConfidenceLabel - verified inputs', () => {
+  const label = calculateConfidenceLabel(95, 'verified', 85);
+  assert.equal(label, 'verified');
+});
+
+test('calculateConfidenceLabel - partial inputs', () => {
+  const label = calculateConfidenceLabel(75, 'partial', 60);
+  assert.equal(label, 'moderate');
+});
+
+test('calculateConfidenceLabel - estimated inputs', () => {
+  const label = calculateConfidenceLabel(50, 'estimated', 40);
+  assert.equal(label, 'low');
+});
+
+test('isHighConfidence and isLowConfidence', () => {
+  assert.ok(isHighConfidence('verified'));
+  assert.ok(isHighConfidence('high'));
+  assert.ok(!isHighConfidence('moderate'));
+
+  assert.ok(isLowConfidence('low'));
+  assert.ok(isLowConfidence('unverified'));
+  assert.ok(!isLowConfidence('moderate'));
+});
+
+test('createLedger - structure', () => {
+  const entries = [
+    createEvidenceEntry('numerology', 'Personal Day', 3, 90, 'high'),
+    createEvidenceEntry('astrology', 'Moon Sign', 'Cancer', 85, 'high'),
+  ];
+
+  const ledger = createLedger(entries, 'test-reading-123');
+
+  assert.equal(ledger.readingId, 'test-reading-123');
+  assert.equal(ledger.entries.length, 2);
+  assert.equal(ledger.version, '1.0');
+});
+
+test('groupEvidenceByEngine', () => {
+  const entries: EvidenceEntry[] = [
+    createEvidenceEntry('numerology', 'Personal Year', 5, 90, 'high'),
+    createEvidenceEntry('numerology', 'Personal Month', 3, 85, 'high'),
+    createEvidenceEntry('astrology', 'Sun Sign', 'Leo', 95, 'verified'),
+  ];
+
+  const grouped = groupEvidenceByEngine(entries);
+
+  assert.equal(grouped.numerology?.length, 2);
+  assert.equal(grouped.astrology?.length, 1);
+  assert.equal(Object.keys(grouped).length, 2);
+});
+
+test('findLowConfidenceClaims', () => {
+  const entries: EvidenceEntry[] = [
+    createEvidenceEntry('numerology', 'High confidence', 5, 90, 'high'),
+    createEvidenceEntry('numerology', 'Low confidence', 3, 25, 'low'),
+    createEvidenceEntry('numerology', 'Unverified', 2, 10, 'unverified'),
+  ];
+
+  const lowConfidence = findLowConfidenceClaims(entries);
+
+  assert.equal(lowConfidence.length, 2);
+  assert.ok(lowConfidence.every(e => e.confidenceLabel === 'low' || e.confidenceLabel === 'unverified'));
+});
+
+test('findConflictingClaims - no conflicts', () => {
+  const entries: EvidenceEntry[] = [
+    createEvidenceEntry('numerology', 'Personal Year', 5, 90, 'high'),
+    createEvidenceEntry('astrology', 'Sun Sign', 'Leo', 95, 'verified'),
+  ];
+
+  const conflicts = findConflictingClaims(entries);
+
+  assert.equal(conflicts.length, 0);
+});
+
+test('findConflictingClaims - with conflicts', () => {
+  const entries: EvidenceEntry[] = [
+    createEvidenceEntry('numerology', 'Strength', 'High', 90, 'high'),
+    createEvidenceEntry('behavior', 'Strength', 'Low', 80, 'high'),
+  ];
+
+  const conflicts = findConflictingClaims(entries);
+
+  assert.equal(conflicts.length, 1);
+  assert.equal(conflicts[0].engines.length, 2);
+  assert.equal(conflicts[0].conflicts.length, 2);
+});
+
+test('summarizeEvidenceLedger - basic summary', () => {
+  const entries: EvidenceEntry[] = [
+    createEvidenceEntry('numerology', 'Personal Year', 5, 95, 'verified'),
+    createEvidenceEntry('numerology', 'Personal Month', 3, 85, 'high'),
+    createEvidenceEntry('astrology', 'Sun Sign', 'Leo', 80, 'moderate'),
+  ];
+
+  const summary = summarizeEvidenceLedger(entries);
+
+  assert.equal(summary.totalClaims, 3);
+  assert.equal(summary.averageConfidence, 87);
+  assert.equal(summary.byConfidenceLevel.verified, 1);
+  assert.equal(summary.byConfidenceLevel.high, 1);
+  assert.equal(summary.byConfidenceLevel.moderate, 1);
+  assert.equal(summary.byEngine.numerology, 2);
+  assert.equal(summary.byEngine.astrology, 1);
+});
+
+test('summarizeEvidenceLedger - empty ledger', () => {
+  const summary = summarizeEvidenceLedger([]);
+
+  assert.equal(summary.totalClaims, 0);
+  assert.equal(summary.averageConfidence, 0);
+  assert.equal(summary.lowConfidenceClaims.length, 0);
+  assert.equal(summary.conflictingClaims.length, 0);
+});
+
+test('summarizeEvidenceLedger - low confidence detection', () => {
+  const entries: EvidenceEntry[] = [
+    createEvidenceEntry('numerology', 'Claim 1', 'value', 90, 'high'),
+    createEvidenceEntry('numerology', 'Claim 2', 'value', 30, 'low'),
+    createEvidenceEntry('numerology', 'Claim 3', 'value', 10, 'unverified'),
+  ];
+
+  const summary = summarizeEvidenceLedger(entries);
+
+  assert.equal(summary.lowConfidenceClaims.length, 2);
+});
+
+test('formatConfidenceAsPercent', () => {
+  assert.equal(formatConfidenceAsPercent(85.6), '86%');
+  assert.equal(formatConfidenceAsPercent(50), '50%');
+});
+
+test('formatEvidenceEntry', () => {
+  const entry = createEvidenceEntry('numerology', 'Personal Year', 5, 90, 'high', {
+    inputsUsed: ['birth_date_verified'],
+    reasoning: ['Sum reduced to single digit'],
+    limitations: ['No birth time'],
+  });
+
+  const formatted = formatEvidenceEntry(entry);
+
+  assert.equal(formatted.claim, 'Personal Year');
+  assert.equal(formatted.value, '5');
+  assert.equal(formatted.confidence, '90% (high)');
+  assert.equal(formatted.inputs, 'birth_date_verified');
+  assert.equal(formatted.reasoning, 'Sum reduced to single digit');
+  assert.equal(formatted.limitations, 'No birth time');
+});
+
+test('formatSummaryAsText', () => {
+  const entries: EvidenceEntry[] = [
+    createEvidenceEntry('numerology', 'Personal Year', 5, 95, 'verified'),
+    createEvidenceEntry('numerology', 'Low confidence', 3, 25, 'low'),
+  ];
+
+  const summary = summarizeEvidenceLedger(entries);
+  const text = formatSummaryAsText(summary);
+
+  assert.ok(text.includes('Total Claims: 2'));
+  assert.ok(text.includes('Average Confidence: 60%'));
+  assert.ok(text.includes('Low Confidence Claims'));
+  assert.ok(text.includes('numerology'));
+});
+
+test('deterministic output - same inputs produce same results', () => {
+  const entry1 = createEvidenceEntry('numerology', 'Test', 'value', 75, 'moderate', {
+    inputsUsed: ['birth_date'],
+    reasoning: ['Test reasoning'],
+    limitations: ['Test limitation'],
+  });
+
+  const entry2 = createEvidenceEntry('numerology', 'Test', 'value', 75, 'moderate', {
+    inputsUsed: ['birth_date'],
+    reasoning: ['Test reasoning'],
+    limitations: ['Test limitation'],
+  });
+
+  assert.equal(entry1.engine, entry2.engine);
+  assert.equal(entry1.claim, entry2.claim);
+  assert.equal(entry1.value, entry2.value);
+  assert.equal(entry1.confidence, entry2.confidence);
+  assert.equal(entry1.confidenceLabel, entry2.confidenceLabel);
+  assert.deepEqual(entry1.inputsUsed, entry2.inputsUsed);
+  assert.deepEqual(entry1.reasoning, entry2.reasoning);
+  assert.deepEqual(entry1.limitations, entry2.limitations);
+});

--- a/packages/core/evidence-ledger/confidence.ts
+++ b/packages/core/evidence-ledger/confidence.ts
@@ -1,0 +1,57 @@
+/**
+ * Confidence Calculation & Labeling
+ *
+ * Converts raw confidence scores (0-100) to human-readable labels
+ * based on input quality and reasoning strength.
+ */
+
+import type { EvidenceConfidenceLevel } from './types.js';
+
+export function calculateConfidenceLabel(
+  confidenceScore: number,
+  inputQuality: 'verified' | 'partial' | 'estimated' | 'unverified',
+  reasoningStrength: number // 0-100, based on pattern match or statistical support
+): EvidenceConfidenceLevel {
+  // Verified inputs with strong reasoning → high confidence
+  if (inputQuality === 'verified' && reasoningStrength >= 80) {
+    return confidenceScore >= 90 ? 'verified' : 'high';
+  }
+
+  // Verified inputs but weaker reasoning → moderate
+  if (inputQuality === 'verified' && reasoningStrength >= 50) {
+    return confidenceScore >= 75 ? 'high' : 'moderate';
+  }
+
+  // Partial inputs (e.g., birth date but no time) → partial/moderate
+  if (inputQuality === 'partial') {
+    return confidenceScore >= 70 ? 'moderate' : 'partial';
+  }
+
+  // Estimated inputs → low/partial
+  if (inputQuality === 'estimated') {
+    return confidenceScore >= 60 ? 'partial' : 'low';
+  }
+
+  // Unverified inputs → low/unverified
+  return confidenceScore >= 40 ? 'low' : 'unverified';
+}
+
+export function isHighConfidence(label: EvidenceConfidenceLevel): boolean {
+  return label === 'verified' || label === 'high';
+}
+
+export function isLowConfidence(label: EvidenceConfidenceLevel): boolean {
+  return label === 'low' || label === 'unverified';
+}
+
+export function confidenceLabelToScore(label: EvidenceConfidenceLevel): number {
+  const scores: Record<EvidenceConfidenceLevel, number> = {
+    verified: 95,
+    high: 85,
+    moderate: 70,
+    partial: 55,
+    low: 35,
+    unverified: 15,
+  };
+  return scores[label];
+}

--- a/packages/core/evidence-ledger/format.ts
+++ b/packages/core/evidence-ledger/format.ts
@@ -1,0 +1,91 @@
+/**
+ * Evidence Formatting & Display
+ *
+ * Helpers for presenting evidence to users in a readable way.
+ */
+
+import type { EvidenceEntry, EvidenceSummary } from './types.js';
+
+export function formatConfidenceAsPercent(confidence: number): string {
+  return `${Math.round(confidence)}%`;
+}
+
+export function formatConfidenceExplanation(label: string): string {
+  const explanations: Record<string, string> = {
+    verified:
+      'Verified from reliable sources (birth certificate, exact birth time). Highest confidence.',
+    high: 'Calculated from verified inputs with strong patterns.',
+    moderate: 'Calculated from verified core data with some estimation.',
+    partial: 'Estimated inputs or limited historical patterns.',
+    low: 'Multiple unknowns or weak pattern matches.',
+    unverified: 'Not enough reliable data to form confident conclusion.',
+  };
+  return explanations[label] || 'Confidence level unknown';
+}
+
+export function formatEvidenceEntry(entry: EvidenceEntry): {
+  claim: string;
+  value: string;
+  confidence: string;
+  inputs: string;
+  reasoning: string;
+  limitations: string;
+} {
+  return {
+    claim: entry.claim,
+    value: formatValue(entry.value),
+    confidence: `${formatConfidenceAsPercent(entry.confidence)} (${entry.confidenceLabel})`,
+    inputs: entry.inputsUsed.join(', ') || 'No inputs tracked',
+    reasoning: entry.reasoning.join(' → ') || 'No reasoning provided',
+    limitations: entry.limitations.join('; ') || 'No known limitations',
+  };
+}
+
+export function formatValue(value: string | number | boolean | Record<string, unknown>): string {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No';
+  if (typeof value === 'number') return value.toString();
+  return JSON.stringify(value);
+}
+
+export function formatSummaryAsText(summary: EvidenceSummary): string {
+  const lines: string[] = [];
+
+  lines.push(`Total Claims: ${summary.totalClaims}`);
+  lines.push(`Average Confidence: ${formatConfidenceAsPercent(summary.averageConfidence)}`);
+  lines.push('');
+
+  lines.push('By Confidence Level:');
+  for (const [level, count] of Object.entries(summary.byConfidenceLevel)) {
+    if (count > 0) {
+      lines.push(`  ${level}: ${count}`);
+    }
+  }
+  lines.push('');
+
+  lines.push('By Engine:');
+  for (const [engine, count] of Object.entries(summary.byEngine)) {
+    lines.push(`  ${engine}: ${count}`);
+  }
+
+  if (summary.lowConfidenceClaims.length > 0) {
+    lines.push('');
+    lines.push(`Low Confidence Claims (${summary.lowConfidenceClaims.length}):`);
+    for (const claim of summary.lowConfidenceClaims.slice(0, 5)) {
+      lines.push(
+        `  - ${claim.claim} (${formatConfidenceAsPercent(claim.confidence)}, ${claim.confidenceLabel})`
+      );
+    }
+  }
+
+  if (summary.conflictingClaims.length > 0) {
+    lines.push('');
+    lines.push(`Conflicting Claims (${summary.conflictingClaims.length}):`);
+    for (const conflict of summary.conflictingClaims.slice(0, 5)) {
+      lines.push(`  - ${conflict.claim}`);
+      lines.push(`    Engines: ${conflict.engines.join(', ')}`);
+    }
+  }
+
+  return lines.join('\n');
+}

--- a/packages/core/evidence-ledger/index.ts
+++ b/packages/core/evidence-ledger/index.ts
@@ -32,3 +32,9 @@ export {
   formatValue,
   formatSummaryAsText,
 } from './format.js';
+
+export {
+  calcPersonalDayWithEvidence,
+  calcPersonalYearWithEvidence,
+  calcPersonalMonthWithEvidence,
+} from './integrations.js';

--- a/packages/core/evidence-ledger/index.ts
+++ b/packages/core/evidence-ledger/index.ts
@@ -1,0 +1,34 @@
+/**
+ * Evidence Ledger
+ *
+ * Observability infrastructure for Soul Codex engines.
+ * Every major output carries traceable evidence metadata.
+ */
+
+export type {
+  EngineType,
+  EvidenceConfidenceLevel,
+  EvidenceEntry,
+  EvidenceLedger,
+  EvidenceGroupedByEngine,
+  EvidenceSummary,
+} from './types.js';
+
+export {
+  createEvidenceEntry,
+  createLedger,
+  groupEvidenceByEngine,
+  findLowConfidenceClaims,
+  findConflictingClaims,
+  summarizeEvidenceLedger,
+} from './ledger.js';
+
+export { calculateConfidenceLabel, isHighConfidence, isLowConfidence, confidenceLabelToScore } from './confidence.js';
+
+export {
+  formatConfidenceAsPercent,
+  formatConfidenceExplanation,
+  formatEvidenceEntry,
+  formatValue,
+  formatSummaryAsText,
+} from './format.js';

--- a/packages/core/evidence-ledger/integrations.ts
+++ b/packages/core/evidence-ledger/integrations.ts
@@ -1,0 +1,122 @@
+/**
+ * Evidence Ledger Integrations
+ *
+ * Lightweight wrappers for high-value engine outputs.
+ * Each integration emits evidence metadata alongside the calculation.
+ */
+
+import {
+  createEvidenceEntry,
+  type EvidenceEntry,
+} from './index.js';
+import { calcPersonalDay, calcPersonalMonth, calcPersonalYear } from '../compute/personal-numbers.js';
+
+export function calcPersonalDayWithEvidence(
+  birthDate: string,
+  targetDate: Date = new Date()
+): {
+  value: number;
+  evidence: EvidenceEntry;
+} {
+  const personalDay = calcPersonalDay(birthDate, targetDate);
+
+  const birth = new Date(birthDate);
+  const birthDay = birth.getDate();
+  const birthMonth = birth.getMonth() + 1;
+  const targetDay = targetDate.getDate();
+  const targetMonth = targetDate.getMonth() + 1;
+  const targetYear = targetDate.getFullYear();
+
+  const evidence = createEvidenceEntry(
+    'numerology',
+    'Personal Day',
+    personalDay,
+    90, // birth date verified produces high confidence
+    'high',
+    {
+      inputsUsed: [
+        `birth_day_${birthDay}`,
+        `birth_month_${birthMonth}`,
+        `target_day_${targetDay}`,
+        `target_month_${targetMonth}`,
+        `target_year_${targetYear}`,
+      ],
+      reasoning: [
+        `Birth day ${birthDay} + birth month ${birthMonth} + current day ${targetDay} + current month ${targetMonth} + current year ${targetYear}`,
+        'All values reduced to single digits',
+        `Sum reduced to single digit = Day ${personalDay}`,
+      ],
+      limitations: [],
+    }
+  );
+
+  return { value: personalDay, evidence };
+}
+
+export function calcPersonalYearWithEvidence(
+  birthDate: string,
+  targetYear: number
+): {
+  value: number;
+  evidence: EvidenceEntry;
+} {
+  const personalYear = calcPersonalYear(birthDate, targetYear);
+
+  const birth = new Date(birthDate);
+  const birthMonth = birth.getMonth() + 1;
+  const birthDay = birth.getDate();
+
+  const evidence = createEvidenceEntry(
+    'numerology',
+    'Personal Year',
+    personalYear,
+    90,
+    'high',
+    {
+      inputsUsed: [
+        `birth_date_verified`,
+        `target_year_${targetYear}`,
+      ],
+      reasoning: [
+        `Birth month ${birthMonth} + birth day ${birthDay} + target year ${targetYear}`,
+        'All values reduced to single digits',
+        `Sum reduced to single digit = Year ${personalYear}`,
+      ],
+      limitations: [],
+    }
+  );
+
+  return { value: personalYear, evidence };
+}
+
+export function calcPersonalMonthWithEvidence(
+  personalYear: number,
+  targetMonth: number
+): {
+  value: number;
+  evidence: EvidenceEntry;
+} {
+  const personalMonth = calcPersonalMonth(personalYear, targetMonth);
+
+  const evidence = createEvidenceEntry(
+    'numerology',
+    'Personal Month',
+    personalMonth,
+    90,
+    'high',
+    {
+      inputsUsed: [
+        `personal_year_${personalYear}`,
+        `calendar_month_${targetMonth}`,
+      ],
+      reasoning: [
+        `Personal Year ${personalYear} + calendar month ${targetMonth}`,
+        'Both reduced to single digits',
+        `Sum reduced to single digit = Month ${personalMonth}`,
+      ],
+      limitations: [],
+    }
+  );
+
+  return { value: personalMonth, evidence };
+}

--- a/packages/core/evidence-ledger/ledger.ts
+++ b/packages/core/evidence-ledger/ledger.ts
@@ -1,0 +1,142 @@
+/**
+ * Evidence Ledger Operations
+ *
+ * Core functions for creating, managing, and analyzing evidence entries.
+ */
+
+import type {
+  EvidenceEntry,
+  EvidenceLedger,
+  EvidenceGroupedByEngine,
+  EvidenceSummary,
+  EngineType,
+  EvidenceConfidenceLevel,
+} from './types.js';
+import { isLowConfidence } from './confidence.js';
+
+function generateId(): string {
+  return Math.random().toString(36).substring(2, 10);
+}
+
+export function createEvidenceEntry(
+  engine: EngineType,
+  claim: string,
+  value: string | number | boolean | Record<string, unknown>,
+  confidence: number,
+  confidenceLabel: EvidenceConfidenceLevel,
+  options: {
+    inputsUsed?: string[];
+    limitations?: string[];
+    reasoning?: string[];
+  } = {}
+): EvidenceEntry {
+  return {
+    id: generateId(),
+    engine,
+    claim,
+    value,
+    confidence: Math.min(100, Math.max(0, confidence)),
+    confidenceLabel,
+    inputsUsed: options.inputsUsed || [],
+    limitations: options.limitations || [],
+    reasoning: options.reasoning || [],
+    generatedAt: new Date().toISOString(),
+    version: '1.0',
+  };
+}
+
+export function createLedger(entries: EvidenceEntry[], readingId?: string): EvidenceLedger {
+  return {
+    readingId: readingId || generateId(),
+    entries,
+    generatedAt: new Date().toISOString(),
+    version: '1.0',
+  };
+}
+
+export function groupEvidenceByEngine(entries: EvidenceEntry[]): EvidenceGroupedByEngine {
+  const grouped: EvidenceGroupedByEngine = {};
+
+  for (const entry of entries) {
+    if (!grouped[entry.engine]) {
+      grouped[entry.engine] = [];
+    }
+    grouped[entry.engine]!.push(entry);
+  }
+
+  return grouped;
+}
+
+export function findLowConfidenceClaims(entries: EvidenceEntry[]): EvidenceEntry[] {
+  return entries.filter(entry => isLowConfidence(entry.confidenceLabel));
+}
+
+export function findConflictingClaims(entries: EvidenceEntry[]): Array<{
+  engines: EngineType[];
+  claim: string;
+  conflicts: EvidenceEntry[];
+}> {
+  const conflictMap = new Map<string, EvidenceEntry[]>();
+
+  for (const entry of entries) {
+    const key = entry.claim.toLowerCase();
+    if (!conflictMap.has(key)) {
+      conflictMap.set(key, []);
+    }
+    conflictMap.get(key)!.push(entry);
+  }
+
+  const conflicts: Array<{
+    engines: EngineType[];
+    claim: string;
+    conflicts: EvidenceEntry[];
+  }> = [];
+
+  for (const [claim, entries] of conflictMap.entries()) {
+    const engines = [...new Set(entries.map(e => e.engine))];
+    if (engines.length > 1) {
+      // Multiple engines claim something about the same topic
+      const valueDifferences = [...new Set(entries.map(e => JSON.stringify(e.value)))];
+      if (valueDifferences.length > 1) {
+        // And they have different values → conflict
+        conflicts.push({
+          engines,
+          claim,
+          conflicts: entries,
+        });
+      }
+    }
+  }
+
+  return conflicts;
+}
+
+export function summarizeEvidenceLedger(ledger: EvidenceLedger | EvidenceEntry[]): EvidenceSummary {
+  const entries = Array.isArray(ledger) ? ledger : ledger.entries;
+
+  const summary: EvidenceSummary = {
+    totalClaims: entries.length,
+    averageConfidence:
+      entries.length > 0
+        ? Math.round(entries.reduce((sum, e) => sum + e.confidence, 0) / entries.length)
+        : 0,
+    byConfidenceLevel: {
+      verified: 0,
+      high: 0,
+      moderate: 0,
+      partial: 0,
+      low: 0,
+      unverified: 0,
+    },
+    byEngine: {} as Record<EngineType, number>,
+    lowConfidenceClaims: findLowConfidenceClaims(entries),
+    conflictingClaims: findConflictingClaims(entries),
+  };
+
+  for (const entry of entries) {
+    summary.byConfidenceLevel[entry.confidenceLabel]++;
+    summary.byEngine[entry.engine] = (summary.byEngine[entry.engine] || 0) + 1;
+  }
+
+  return summary;
+}

--- a/packages/core/evidence-ledger/types.ts
+++ b/packages/core/evidence-ledger/types.ts
@@ -1,0 +1,61 @@
+/**
+ * Evidence Ledger Types
+ *
+ * Every major engine output carries traceable evidence metadata:
+ * - What was claimed
+ * - Why we believe it (reasoning)
+ * - How confident we are (and why)
+ * - What data fed it (inputs)
+ * - What we didn't account for (limitations)
+ * - Verification status of the inputs
+ */
+
+export type EngineType =
+  | 'astrology'
+  | 'numerology'
+  | 'human-design'
+  | 'behavior'
+  | 'dominance'
+  | 'synergy'
+  | 'timeline'
+  | 'pattern'
+  | 'predictive'
+  | 'interpretation';
+
+export type EvidenceConfidenceLevel = 'verified' | 'high' | 'moderate' | 'partial' | 'low' | 'unverified';
+
+export interface EvidenceEntry {
+  id: string;
+  engine: EngineType;
+  claim: string;
+  value: string | number | boolean | Record<string, unknown>;
+  confidence: number; // 0-100
+  confidenceLabel: EvidenceConfidenceLevel;
+  inputsUsed: string[]; // e.g., ["birth_date_verified", "birth_time_estimated"]
+  limitations: string[]; // e.g., ["No birth time provided", "Limited sample size"]
+  reasoning: string[]; // e.g., ["Personal Year is 5 + current month 7 = 3", "Pattern matches historical data"]
+  generatedAt: string; // ISO 8601 timestamp
+  version: string; // e.g., "1.0"
+}
+
+export interface EvidenceLedger {
+  readingId: string;
+  entries: EvidenceEntry[];
+  generatedAt: string;
+  version: string;
+}
+
+export type EvidenceGroupedByEngine = Partial<Record<EngineType, EvidenceEntry[]>>;
+
+export interface EvidenceSummary {
+  totalClaims: number;
+  averageConfidence: number;
+  byConfidenceLevel: Record<EvidenceConfidenceLevel, number>;
+  byEngine: Record<EngineType, number>;
+  lowConfidenceClaims: EvidenceEntry[];
+  conflictingClaims: Array<{
+    engines: EngineType[];
+    claim: string;
+    conflicts: EvidenceEntry[];
+  }>;
+}

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -15,3 +15,4 @@ export * from './soulcodex-v1/index.js';
 export * from './pattern-engine/index.js';
 export * from './timeline-intelligence/index.js';
 export * from './soul-guide/index.js';
+export * from './evidence-ledger/index.js';


### PR DESCRIPTION
Adds Evidence Ledger V1, a traceability layer for Soul Codex engine outputs.

This creates the foundation for confidence-aware readings, future cross-engine validation, and transparent user-facing evidence displays.

## Changes
- Adds core evidence-ledger package modules:
  - types
  - confidence
  - ledger helpers
  - formatting
  - exports
- Adds confidence label calculation:
  - verified
  - high
  - moderate
  - partial
  - low
  - unverified
- Adds evidence helpers:
  - createEvidenceEntry
  - groupEvidenceByEngine
  - summarizeEvidenceLedger
  - findLowConfidenceClaims
  - findConflictingClaims
- Adds evidence-enabled numerology wrappers:
  - calcPersonalDayWithEvidence
  - calcPersonalYearWithEvidence
  - calcPersonalMonthWithEvidence
- Adds EvidenceViewer component for user-facing evidence inspection
- Adds 18 deterministic unit tests

## Validation
- Tests passed: 112 passing
- Full build passed
- No dependencies added

## Scope
- Evidence/observability infrastructure only
- No astrology calculation changes
- No numerology calculation changes
- No Human Design changes
- No backend APIs
- No AI
- No dependency upgrades

## Design
Evidence is additive and does not alter existing engine outputs.
Confidence is driven by input quality and traceable reasoning.
Limitations are surfaced instead of hidden.

## Pre-merge checklist
- [ ] @soulcodex/core exports evidence-ledger cleanly
- [ ] Existing numerology APIs still work unchanged
- [ ] Evidence wrappers are additive, not replacing old calls yet
- [ ] EvidenceViewer does not break mobile layout
- [ ] No package-lock or package.json churn
- [ ] Build/test output confirms all passing

---
_Generated by [Claude Code](https://claude.ai/code/session_01TkFdwtn8XD6RTbf1a2GXUT)_