### PR TITLE
fix(mobile): run Capacitor workflows on Node 22

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Setup Java

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

Capacitor 8.4.2 requires Node.js 22 or newer. The Android and iOS manual build workflows were still using Node 20, causing both to fail at `npx cap sync` after all release validation and web-build steps passed.

## Change

- use Node.js 22 in the Android workflow
- use Node.js 22 in the iOS workflow

## Evidence

- Android run 29517769690 failed at Capacitor sync with `The Capacitor CLI requires NodeJS >=22.0.0`
- iOS run 29517774789 failed at the same step
- `VITE_API_URL=https://soulcodex.up.railway.app` validation passed in both runs

After merge, rerun Android `debug` and iOS `development` from `main`.