### PR TITLE
fix(ios): align SwiftPM lock with Capacitor

### DIFF
--- a/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ionic-team/capacitor-swift-pm.git",
       "state" : {
-        "revision" : "f1a8fadf1437c23b825c818fb6509c9dbbae2f61",
-        "version" : "8.3.1"
+        "revision" : "9b9fb0af76b2b653f6e9b999f658adc132b9ab4c",
+        "version" : "8.4.2"
       }
     }
   ],

--- a/scripts/validate-mobile-release.mjs
+++ b/scripts/validate-mobile-release.mjs
@@ -39,6 +39,8 @@ requireFile("client/src/pages/SupportPage.tsx");
 if (platform === "ios") {
   requireFile("ios/App/App/PrivacyInfo.xcprivacy");
   requireFile("ios/App/App.xcodeproj/xcshareddata/xcschemes/Soul Codex.xcscheme");
+  requireMatch("ios/App/CapApp-SPM/Package.swift", /capacitor-swift-pm\.git", exact: "8\.4\.2"/, "The iOS Capacitor Swift package must remain pinned to 8.4.2.");
+  requireMatch("ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved", /"version"\s*:\s*"8\.4\.2"/, "The resolved iOS Capacitor Swift package is stale; resolve it to 8.4.2.");
   requireMatch("scripts/ExportOptions.plist", /<string>86NUJ8M3B8<\/string>/, "The iOS export Team ID is missing or incorrect.");
   requireMatch("ios/App/App.xcodeproj/project.pbxproj", /PRODUCT_BUNDLE_IDENTIFIER = app\.soulcodex\.ios;/, "The iOS bundle identifier must remain app.soulcodex.ios.");
 }


### PR DESCRIPTION
## Summary

The iOS project declares `capacitor-swift-pm` 8.4.2, but Xcode was locked to 8.3.1. That stale resolution caused Capacitor StatusBar to compile against incompatible Swift APIs.

- update the Xcode SwiftPM lock to the official Capacitor 8.4.2 tag
- validate both the declared and resolved Capacitor Swift package versions before mobile builds

## Evidence

- Android debug build 29518547542 now succeeds and uploads its APK
- iOS run 29518552546 reaches native compilation, then fails in StatusBarPlugin against the stale 8.3.1 Swift package

## Validation

- iOS mobile release validator passes with the Railway production origin
- workspace checks pass
- `Package.resolved` parses as valid JSON
- `git diff --check` passes