### PR TITLE
fix(ios): migrate to Capacitor system bars

### DIFF
--- a/PUBLISHING_GUIDE.md
+++ b/PUBLISHING_GUIDE.md
@@ -25,7 +25,7 @@ Do not submit a build when asset generation or validation fails. Store artifacts
 ## 3. App Store Metadata
 Use the pre-written metadata in `app_store_metadata.md`.
 - **Hardened Selling Points**: Highlight the "Personality Physics" and "Loop Mapping" features.
-- **Privacy Policy**: Use `https://soulcodex.app/privacy`.
+- **Privacy Policy**: Use `https://soulcodex.up.railway.app/privacy`.
 
 ## 4. Archive & Upload
 1. Set the build destination to **Any iOS Device (arm64)**.

--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -11,7 +11,6 @@ apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
     implementation project(':capacitor-keyboard')
     implementation project(':capacitor-splash-screen')
-    implementation project(':capacitor-status-bar')
     implementation project(':capawesome-capacitor-apple-sign-in')
 
 }

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -8,8 +8,5 @@ project(':capacitor-keyboard').projectDir = new File('../node_modules/@capacitor
 include ':capacitor-splash-screen'
 project(':capacitor-splash-screen').projectDir = new File('../node_modules/@capacitor/splash-screen/android')
 
-include ':capacitor-status-bar'
-project(':capacitor-status-bar').projectDir = new File('../node_modules/@capacitor/status-bar/android')
-
 include ':capawesome-capacitor-apple-sign-in'
 project(':capawesome-capacitor-apple-sign-in').projectDir = new File('../node_modules/@capawesome/capacitor-apple-sign-in/android')

--- a/app_store_metadata.md
+++ b/app_store_metadata.md
@@ -27,13 +27,13 @@ Discover your true soul architecture and see the patterns you repeat—and where
 astrology, human design, numerology, spiritual guidance, soul blueprint, behavioral analysis, daily horoscope, self-awareness, mysticism, archetypes
 
 ## Privacy Policy URL
-<https://soulcodex.app/privacy>
+<https://soulcodex.up.railway.app/privacy>
 
 ## Support URL
-<https://soulcodex.app/support>
+<https://soulcodex.up.railway.app/support>
 
 ## Marketing URL
 <https://soulcodex.app>
 
 ## Account Deletion URL
-<https://soulcodex.app/account-deletion>
+<https://soulcodex.up.railway.app/account-deletion>

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -30,9 +30,11 @@ const config: CapacitorConfig = {
       splashFullScreen: true,
       splashImmersive: true,
     },
-    StatusBar: {
-      style: "LIGHT",
-      backgroundColor: "#0B0720",
+    SystemBars: {
+      insetsHandling: "css",
+      style: "DARK",
+      hidden: false,
+      animation: "FADE",
     },
     Keyboard: {
       resize: "body",

--- a/docs/MOBILE_BUILD_GUIDE.md
+++ b/docs/MOBILE_BUILD_GUIDE.md
@@ -89,7 +89,7 @@ The workflows build signed artifacts; they intentionally do not submit or releas
 
 Code cannot complete these account-bound steps:
 
-- Verify `https://soulcodex.app/privacy`, `/support`, and `/account-deletion` are publicly reachable after deployment.
+- Verify `https://soulcodex.up.railway.app/privacy`, `/support`, and `/account-deletion` are publicly reachable after deployment.
 - Complete Apple App Privacy and Google Play Data Safety from the shipped app behavior and `PrivacyPage.tsx`.
 - Upload screenshots and the Google Play feature graphic.
 - Complete age/content-rating, target-audience, ads, and app-access questionnaires.

--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -14,7 +14,6 @@ let package = Package(
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.4.2"),
         .package(name: "CapacitorKeyboard", path: "../../../node_modules/@capacitor/keyboard"),
         .package(name: "CapacitorSplashScreen", path: "../../../node_modules/@capacitor/splash-screen"),
-        .package(name: "CapacitorStatusBar", path: "../../../node_modules/@capacitor/status-bar"),
         .package(name: "CapawesomeCapacitorAppleSignIn", path: "../../../node_modules/@capawesome/capacitor-apple-sign-in")
     ],
     targets: [
@@ -25,7 +24,6 @@ let package = Package(
                 .product(name: "Cordova", package: "capacitor-swift-pm"),
                 .product(name: "CapacitorKeyboard", package: "CapacitorKeyboard"),
                 .product(name: "CapacitorSplashScreen", package: "CapacitorSplashScreen"),
-                .product(name: "CapacitorStatusBar", package: "CapacitorStatusBar"),
                 .product(name: "CapawesomeCapacitorAppleSignIn", package: "CapawesomeCapacitorAppleSignIn")
             ]
         )

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@capacitor/ios": "^8.4.2",
         "@capacitor/keyboard": "^8.0.5",
         "@capacitor/splash-screen": "^8.0.2",
-        "@capacitor/status-bar": "^8.0.3",
         "@capawesome/capacitor-apple-sign-in": "^0.1.0",
         "@google/genai": "^1.48.0",
         "@google/generative-ai": "^0.24.1",
@@ -601,15 +600,6 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@capacitor/splash-screen/-/splash-screen-8.0.2.tgz",
       "integrity": "sha512-0C6rYScr13WfAE9nPl4ScOQynmjFv9NT3Th+RZkD4ezYHmER6mcl1/lDYsv7jg3Rj3FOvLrlTlmNkUrr83kZzQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@capacitor/core": ">=8.0.0"
-      }
-    },
-    "node_modules/@capacitor/status-bar": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@capacitor/status-bar/-/status-bar-8.0.3.tgz",
-      "integrity": "sha512-csSpfNeN49Hx9JaQBSJEIiEbOLtXg3kcc2IpScq2fu5L520h3AWEvsxoH8Srk1jxfRKepaJ4S4sqSC3foI4AgA==",
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@capacitor/ios": "^8.4.2",
     "@capacitor/keyboard": "^8.0.5",
     "@capacitor/splash-screen": "^8.0.2",
-    "@capacitor/status-bar": "^8.0.3",
     "@capawesome/capacitor-apple-sign-in": "^0.1.0",
     "@google/genai": "^1.48.0",
     "@google/generative-ai": "^0.24.1",

--- a/store-assets/STORE_LISTING.md
+++ b/store-assets/STORE_LISTING.md
@@ -63,13 +63,13 @@ Secondary: Entertainment
 Intended audience: ages 13 and older. Complete each store's rating questionnaire from the shipped app behavior; do not infer the final rating from this document.
 
 ## Privacy Policy URL
-https://soulcodex.app/privacy
+https://soulcodex.up.railway.app/privacy
 
 ## Support URL
-https://soulcodex.app/support
+https://soulcodex.up.railway.app/support
 
 ## Account Deletion URL
-https://soulcodex.app/account-deletion
+https://soulcodex.up.railway.app/account-deletion
 
 ---
 


### PR DESCRIPTION
## Summary

Capacitor 8.4 bundles `SystemBars` in core. The separate legacy `@capacitor/status-bar` package no longer compiles against the 8.4 bridge protocol and Soul Codex does not call it directly.

- migrate status-bar configuration to the built-in `SystemBars` API
- remove the obsolete native plugin from npm, iOS SwiftPM, and Android Gradle wiring
- update App Store and Play listing URLs to the confirmed Railway deployment

## Evidence

- Android debug run 29518547542 succeeds and uploads an APK
- iOS run 29518999560 resolves Capacitor 8.4.2 correctly, then fails only inside the legacy status-bar plugin
- production `/start`, `/health`, `/privacy`, `/support`, and `/account-deletion` routes return HTTP 200

## Validation

- `npm run build`
- `npm run check`
- both mobile release validators using `https://soulcodex.up.railway.app`
- Capacitor sync succeeds for iOS and Android
- dependency tree confirms the legacy status-bar plugin is absent
- `git diff --check`