### PR TITLE
fix(ios): remove unused legacy bridge plugins

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -9,8 +9,6 @@ android {
 
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
-    implementation project(':capacitor-keyboard')
-    implementation project(':capacitor-splash-screen')
     implementation project(':capawesome-capacitor-apple-sign-in')
 
 }

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -2,11 +2,5 @@
 include ':capacitor-android'
 project(':capacitor-android').projectDir = new File('../node_modules/@capacitor/android/capacitor')
 
-include ':capacitor-keyboard'
-project(':capacitor-keyboard').projectDir = new File('../node_modules/@capacitor/keyboard/android')
-
-include ':capacitor-splash-screen'
-project(':capacitor-splash-screen').projectDir = new File('../node_modules/@capacitor/splash-screen/android')
-
 include ':capawesome-capacitor-apple-sign-in'
 project(':capawesome-capacitor-apple-sign-in').projectDir = new File('../node_modules/@capawesome/capacitor-apple-sign-in/android')

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -21,24 +21,11 @@ const config: CapacitorConfig = {
   },
 
   plugins: {
-    SplashScreen: {
-      launchAutoHide: true,
-      launchShowDuration: 2000,
-      backgroundColor: "#0B0720",
-      showSpinner: false,
-      androidScaleType: "CENTER_CROP",
-      splashFullScreen: true,
-      splashImmersive: true,
-    },
     SystemBars: {
       insetsHandling: "css",
       style: "DARK",
       hidden: false,
       animation: "FADE",
-    },
-    Keyboard: {
-      resize: "body",
-      resizeOnFullScreen: true,
     },
   },
 };

--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -12,8 +12,6 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.4.2"),
-        .package(name: "CapacitorKeyboard", path: "../../../node_modules/@capacitor/keyboard"),
-        .package(name: "CapacitorSplashScreen", path: "../../../node_modules/@capacitor/splash-screen"),
         .package(name: "CapawesomeCapacitorAppleSignIn", path: "../../../node_modules/@capawesome/capacitor-apple-sign-in")
     ],
     targets: [
@@ -22,8 +20,6 @@ let package = Package(
             dependencies: [
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
                 .product(name: "Cordova", package: "capacitor-swift-pm"),
-                .product(name: "CapacitorKeyboard", package: "CapacitorKeyboard"),
-                .product(name: "CapacitorSplashScreen", package: "CapacitorSplashScreen"),
                 .product(name: "CapawesomeCapacitorAppleSignIn", package: "CapawesomeCapacitorAppleSignIn")
             ]
         )

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,6 @@
         "@capacitor/cli": "^8.4.2",
         "@capacitor/core": "^8.4.2",
         "@capacitor/ios": "^8.4.2",
-        "@capacitor/keyboard": "^8.0.5",
-        "@capacitor/splash-screen": "^8.0.2",
         "@capawesome/capacitor-apple-sign-in": "^0.1.0",
         "@google/genai": "^1.48.0",
         "@google/generative-ai": "^0.24.1",
@@ -585,24 +583,6 @@
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^8.4.0"
-      }
-    },
-    "node_modules/@capacitor/keyboard": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/@capacitor/keyboard/-/keyboard-8.0.5.tgz",
-      "integrity": "sha512-oFXygC4eKYA5l2MdpTR06L2M/4x6e2SLD5yS1T9+UBDKTkzyvhWKEhbYLUaTIBPpLKqlfGudJw1X73S1H9eUzQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@capacitor/core": ">=8.0.0"
-      }
-    },
-    "node_modules/@capacitor/splash-screen": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@capacitor/splash-screen/-/splash-screen-8.0.2.tgz",
-      "integrity": "sha512-0C6rYScr13WfAE9nPl4ScOQynmjFv9NT3Th+RZkD4ezYHmER6mcl1/lDYsv7jg3Rj3FOvLrlTlmNkUrr83kZzQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@capacitor/core": ">=8.0.0"
       }
     },
     "node_modules/@capawesome/capacitor-apple-sign-in": {

--- a/package.json
+++ b/package.json
@@ -41,8 +41,6 @@
     "@capacitor/cli": "^8.4.2",
     "@capacitor/core": "^8.4.2",
     "@capacitor/ios": "^8.4.2",
-    "@capacitor/keyboard": "^8.0.5",
-    "@capacitor/splash-screen": "^8.0.2",
     "@capawesome/capacitor-apple-sign-in": "^0.1.0",
     "@google/genai": "^1.48.0",
     "@google/generative-ai": "^0.24.1",


### PR DESCRIPTION
## Summary

Remove the unused Capacitor splash-screen and keyboard bridge plugins. Soul Codex does not call either plugin; it uses its own React splash screen, while native launch assets remain in the iOS and Android projects.

These plugin releases target the pre-8.4 bridge API and prevent the iOS target from compiling against Capacitor 8.4.2.

- remove splash-screen and keyboard npm dependencies
- remove their SwiftPM and Gradle wiring through Capacitor sync
- remove unused plugin configuration
- retain built-in core `SystemBars`
- retain the actively used Apple Sign In plugin

## Evidence

- iOS run 29519404871 compiles past the removed status-bar plugin and fails only in the legacy splash-screen bridge API
- source search confirms no app runtime calls to splash-screen or keyboard

## Validation

- `npm run build`
- `npm run check`
- both mobile release validators with the Railway origin
- Capacitor sync succeeds for iOS and Android
- dependency tree contains only Capacitor core plus the actively used Apple Sign In plugin
- `git diff --check`