### PR TITLE
fix(ios): pin plugin-compatible Capacitor release

### DIFF
--- a/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ionic-team/capacitor-swift-pm.git",
       "state" : {
-        "revision" : "9b9fb0af76b2b653f6e9b999f658adc132b9ab4c",
-        "version" : "8.4.2"
+        "revision" : "596259033e94829dffc552a40e7129262122995e",
+        "version" : "8.0.0"
       }
     }
   ],

--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
             targets: ["CapApp-SPM"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.4.2"),
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.0.0"),
         .package(name: "CapawesomeCapacitorAppleSignIn", path: "../../../node_modules/@capawesome/capacitor-apple-sign-in")
     ],
     targets: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,11 +11,11 @@
         "packages/*"
       ],
       "dependencies": {
-        "@capacitor/android": "^8.4.2",
-        "@capacitor/cli": "^8.4.2",
-        "@capacitor/core": "^8.4.2",
-        "@capacitor/ios": "^8.4.2",
-        "@capawesome/capacitor-apple-sign-in": "^0.1.0",
+        "@capacitor/android": "8.0.0",
+        "@capacitor/cli": "8.0.0",
+        "@capacitor/core": "8.0.0",
+        "@capacitor/ios": "8.0.0",
+        "@capawesome/capacitor-apple-sign-in": "0.1.2",
         "@google/genai": "^1.48.0",
         "@google/generative-ai": "^0.24.1",
         "@hookform/resolvers": "^3.10.0",
@@ -527,18 +527,18 @@
       }
     },
     "node_modules/@capacitor/android": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-8.4.2.tgz",
-      "integrity": "sha512-bzf8XZ9C+ePgOQ+e+T0fnhHGH4aCNY494vvSQIF5w4AY07RwEmkFqZs1678DDSMH0hLSQpxEwXGFNUVcXO6bBA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-8.0.0.tgz",
+      "integrity": "sha512-FrBSvVAC5JuLaYHNyDnwQny0/SYnP+xDQbc/KA4wInmRkMXLDv22fkx9aBJIDrxjuUVd+jsRih4SAt8FgMEzCw==",
       "license": "MIT",
       "peerDependencies": {
-        "@capacitor/core": "^8.4.0"
+        "@capacitor/core": "^8.0.0"
       }
     },
     "node_modules/@capacitor/cli": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-8.4.2.tgz",
-      "integrity": "sha512-hE4HmpMdr5T8eQ++kGa1BKkdG2JLEvo1y1cj1kmFK78VB9dBp538oe1EZvzwupNGOl0ZueALotzL5wcXRD9w1Q==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-8.0.0.tgz",
+      "integrity": "sha512-v9hEBi69xGxuuZhg55N031bMEenKaPSv71Il8C22VOOH6surDyv/MPeImN0oVfFc7eiklaW3rDFYVz6cmXfJWQ==",
       "license": "MIT",
       "dependencies": {
         "@ionic/cli-framework-output": "^2.2.8",
@@ -549,13 +549,13 @@
         "env-paths": "^2.2.0",
         "fs-extra": "^11.2.0",
         "kleur": "^4.1.5",
-        "native-run": "^2.0.3",
+        "native-run": "^2.0.1",
         "open": "^8.4.0",
         "plist": "^3.1.0",
         "prompts": "^2.4.2",
         "rimraf": "^6.0.1",
         "semver": "^7.6.3",
-        "tar": "^7.5.3",
+        "tar": "^6.1.11",
         "tslib": "^2.8.1",
         "xml2js": "^0.6.2"
       },
@@ -568,27 +568,27 @@
       }
     },
     "node_modules/@capacitor/core": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-8.4.2.tgz",
-      "integrity": "sha512-fQPRb3JXRaU2pnufDUvqOjhsrYxDQeFRZyaj/sHydIUxD2NxOGHKMpmKUdI+U4OOmKuGZyvRpi7TSJU+7Bjbmg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-8.0.0.tgz",
+      "integrity": "sha512-250HTVd/W/KdMygoqaedisvNbHbpbQTN2Hy/8ZYGm1nAqE0Fx7sGss4l0nDg33STxEdDhtVRoL2fIaaiukKseA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@capacitor/ios": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-8.4.2.tgz",
-      "integrity": "sha512-ClVzIjK++yRjsRPOpdEzhsZfbHfoEc0f4M6vD0v7sWh0qcoF6NkxNAeHpWTn4OPJpJfpGGoYsq+IfEHrYyBiWA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-8.0.0.tgz",
+      "integrity": "sha512-gwSn6X4uHYNHlM8zZmVmM1zjEhexxbHpPSSnH1DZkp8o3zdK/RmH8tmDma+3zPZrhhTSrMC7sT24dKTOvV8www==",
       "license": "MIT",
       "peerDependencies": {
-        "@capacitor/core": "^8.4.0"
+        "@capacitor/core": "^8.0.0"
       }
     },
     "node_modules/@capawesome/capacitor-apple-sign-in": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@capawesome/capacitor-apple-sign-in/-/capacitor-apple-sign-in-0.1.0.tgz",
-      "integrity": "sha512-/iSFHj2ZEJa1TYfEkgtAhwLIqMB/sr1ntr/HfXNz3fdssmh/j00mWgDK7sFXUSIj5G8ArpVBzaK2hJKFBWoDUQ==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@capawesome/capacitor-apple-sign-in/-/capacitor-apple-sign-in-0.1.2.tgz",
+      "integrity": "sha512-qux8WBnoDYe8axpVkXYSsPPfl0Wy+bXddmhJ5GLx4V7AR2LVP7YZnl/AN0xbQI1pGJv234hAgrFGdZnUwhVyxw==",
       "funding": [
         {
           "type": "github",
@@ -2173,18 +2173,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@isaacs/fs-minipass": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -5518,12 +5506,12 @@
       }
     },
     "node_modules/chownr": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "license": "BlueOak-1.0.0",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "license": "ISC",
       "engines": {
-        "node": ">=18"
+        "node": ">=10"
       }
     },
     "node_modules/class-variance-authority": {
@@ -7385,6 +7373,36 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -8741,22 +8759,53 @@
       }
     },
     "node_modules/minizlib": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
       "license": "MIT",
       "dependencies": {
-        "minipass": "^7.1.2"
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 8"
       }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/mitt": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
       "license": "MIT"
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/motion-dom": {
       "version": "11.18.1",
@@ -10810,29 +10859,37 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
-      "license": "BlueOak-1.0.0",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
       "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.1.0",
-        "yallist": "^5.0.0"
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/tar/node_modules/yallist": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/text-encoding": {
       "version": "0.6.4",

--- a/package.json
+++ b/package.json
@@ -37,11 +37,11 @@
     "cap:android": "npx cap open android"
   },
   "dependencies": {
-    "@capacitor/android": "^8.4.2",
-    "@capacitor/cli": "^8.4.2",
-    "@capacitor/core": "^8.4.2",
-    "@capacitor/ios": "^8.4.2",
-    "@capawesome/capacitor-apple-sign-in": "^0.1.0",
+    "@capacitor/android": "8.0.0",
+    "@capacitor/cli": "8.0.0",
+    "@capacitor/core": "8.0.0",
+    "@capacitor/ios": "8.0.0",
+    "@capawesome/capacitor-apple-sign-in": "0.1.2",
     "@google/genai": "^1.48.0",
     "@google/generative-ai": "^0.24.1",
     "@hookform/resolvers": "^3.10.0",

--- a/scripts/validate-mobile-release.mjs
+++ b/scripts/validate-mobile-release.mjs
@@ -39,8 +39,8 @@ requireFile("client/src/pages/SupportPage.tsx");
 if (platform === "ios") {
   requireFile("ios/App/App/PrivacyInfo.xcprivacy");
   requireFile("ios/App/App.xcodeproj/xcshareddata/xcschemes/Soul Codex.xcscheme");
-  requireMatch("ios/App/CapApp-SPM/Package.swift", /capacitor-swift-pm\.git", exact: "8\.4\.2"/, "The iOS Capacitor Swift package must remain pinned to 8.4.2.");
-  requireMatch("ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved", /"version"\s*:\s*"8\.4\.2"/, "The resolved iOS Capacitor Swift package is stale; resolve it to 8.4.2.");
+  requireMatch("ios/App/CapApp-SPM/Package.swift", /capacitor-swift-pm\.git", exact: "8\.0\.0"/, "The iOS Capacitor Swift package must remain pinned to the plugin-compatible 8.0.0 release.");
+  requireMatch("ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved", /"version"\s*:\s*"8\.0\.0"/, "The resolved iOS Capacitor Swift package is stale; resolve it to 8.0.0.");
   requireMatch("scripts/ExportOptions.plist", /<string>86NUJ8M3B8<\/string>/, "The iOS export Team ID is missing or incorrect.");
   requireMatch("ios/App/App.xcodeproj/project.pbxproj", /PRODUCT_BUNDLE_IDENTIFIER = app\.soulcodex\.ios;/, "The iOS bundle identifier must remain app.soulcodex.ios.");
 }


### PR DESCRIPTION
## Summary

Pin Capacitor to the 8.0.0 release targeted by the actively used Apple Sign In bridge, and update Apple Sign In to 0.1.2.

Capacitor 8.4.2 changed the iOS bridge protocol before the plugin ecosystem updated: the current Apple Sign In package still calls `CAPPluginCall.reject` and `CAPBridgeProtocol.webView`, both available in Capacitor 8.0.0 but removed in 8.4.2.

- exact-pin Capacitor core, CLI, iOS, and Android to 8.0.0
- update Apple Sign In to 0.1.2
- pin SwiftPM and its lockfile to the official Capacitor 8.0.0 tag
- update the mobile validator to prevent version drift

## Evidence

- iOS run 29519839759 fails only on the two Apple Sign In bridge calls
- local Capacitor 8.0.0 source exposes both required APIs
- Apple Sign In declares Capacitor >=8.0.0 compatibility

## Validation

- `npm run build`
- `npm run check`
- both mobile release validators with the Railway origin
- Capacitor sync succeeds for iOS and Android
- exact dependency tree verified
- `git diff --check`