### PR TITLE
fix(ios): patch Apple Sign-In for SwiftPM

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
+      - name: Patch Apple Sign-In for Swift Package Manager
+        run: npm run mobile:patch:ios
+
       - name: Build workspace packages
         run: |
           npm run build -w @soulcodex/db

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "cap:build": "npm run build && npx cap sync",
     "mobile:validate:ios": "node scripts/validate-mobile-release.mjs ios",
     "mobile:validate:android": "node scripts/validate-mobile-release.mjs android",
+    "mobile:patch:ios": "node scripts/patch-apple-sign-in-swiftpm.mjs",
     "cap:ios": "npx cap open ios",
     "cap:android": "npx cap open android"
   },

--- a/scripts/patch-apple-sign-in-swiftpm.mjs
+++ b/scripts/patch-apple-sign-in-swiftpm.mjs
@@ -1,0 +1,39 @@
+import { readFileSync, writeFileSync } from "node:fs";
+
+const pluginPath =
+  "node_modules/@capawesome/capacitor-apple-sign-in/ios/Plugin/AppleSignInPlugin.swift";
+
+const replacements = [
+  [
+    "import AuthenticationServices\n",
+    "import AuthenticationServices\nimport UIKit\n",
+  ],
+  [
+    "        call.reject(error.localizedDescription, code)",
+    "        call.errorHandler(CAPPluginCallError(message: error.localizedDescription, code: code, error: error, data: nil))",
+  ],
+  [
+    "        return self.bridge?.webView?.window ?? ASPresentationAnchor()",
+    `        return UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap(\\.windows)
+            .first { $0.isKeyWindow } ?? ASPresentationAnchor()`,
+  ],
+];
+
+let source = readFileSync(pluginPath, "utf8");
+
+for (const [original, replacement] of replacements) {
+  if (source.includes(replacement)) {
+    continue;
+  }
+  if (!source.includes(original)) {
+    throw new Error(
+      `Apple Sign-In compatibility patch could not find expected source: ${original.trim()}`,
+    );
+  }
+  source = source.replace(original, replacement);
+}
+
+writeFileSync(pluginPath, source);
+console.log("Applied Apple Sign-In SwiftPM compatibility patch.");


### PR DESCRIPTION
## Summary
- patch Apple Sign-In's SwiftPM-invisible Capacitor call rejection helper
- choose the active iOS key window without relying on the hidden bridge web view
- apply the guarded compatibility patch explicitly in the iOS workflow

## Validation
- clean npm ci --ignore-scripts
- npm run mobile:patch:ios (including idempotency check)
- npm run build
- npm run check
- iOS and Android mobile release validators with the Railway production URL
- git diff --check