### PR TITLE
fix(ios): avoid gated Capacitor Swift APIs

### DIFF
--- a/scripts/patch-apple-sign-in-swiftpm.mjs
+++ b/scripts/patch-apple-sign-in-swiftpm.mjs
@@ -1,39 +1,60 @@
 import { readFileSync, writeFileSync } from "node:fs";
 
-const pluginPath =
-  "node_modules/@capawesome/capacitor-apple-sign-in/ios/Plugin/AppleSignInPlugin.swift";
+const pluginRoot =
+  "node_modules/@capawesome/capacitor-apple-sign-in/ios/Plugin";
 
-const replacements = [
-  [
-    "import AuthenticationServices\n",
-    "import AuthenticationServices\nimport UIKit\n",
-  ],
-  [
-    "        call.reject(error.localizedDescription, code)",
-    "        call.errorHandler(CAPPluginCallError(message: error.localizedDescription, code: code, error: error, data: nil))",
-  ],
-  [
-    "        return self.bridge?.webView?.window ?? ASPresentationAnchor()",
-    `        return UIApplication.shared.connectedScenes
+const patches = [
+  {
+    path: `${pluginRoot}/AppleSignInPlugin.swift`,
+    replacements: [
+      [
+        "import AuthenticationServices\n",
+        "import AuthenticationServices\nimport UIKit\n",
+      ],
+      [
+        "        call.reject(error.localizedDescription, code)",
+        '        call.unavailable(code.map { "\\($0): \\(error.localizedDescription)" } ?? error.localizedDescription)',
+      ],
+      [
+        "        return self.bridge?.webView?.window ?? ASPresentationAnchor()",
+        `        return UIApplication.shared.connectedScenes
             .compactMap { $0 as? UIWindowScene }
             .flatMap(\\.windows)
             .first { $0.isKeyWindow } ?? ASPresentationAnchor()`,
-  ],
+      ],
+    ],
+  },
+  {
+    path: `${pluginRoot}/Classes/Options/SignInOptions.swift`,
+    replacements: [
+      [
+        '        self.nonce = call.getString("nonce")',
+        `        let nonce = call.getString("nonce", "")
+        self.nonce = nonce.isEmpty ? nil : nonce`,
+      ],
+      [
+        '        guard let scopeStrings = call.getArray("scopes") as? [String] else {',
+        '        guard let scopeStrings = call.getArray("scopes", []) as? [String] else {',
+      ],
+    ],
+  },
 ];
 
-let source = readFileSync(pluginPath, "utf8");
+for (const patch of patches) {
+  let source = readFileSync(patch.path, "utf8");
 
-for (const [original, replacement] of replacements) {
-  if (source.includes(replacement)) {
-    continue;
+  for (const [original, replacement] of patch.replacements) {
+    if (source.includes(replacement)) {
+      continue;
+    }
+    if (!source.includes(original)) {
+      throw new Error(
+        `Apple Sign-In compatibility patch could not find expected source in ${patch.path}: ${original.trim()}`,
+      );
+    }
+    source = source.replace(original, replacement);
   }
-  if (!source.includes(original)) {
-    throw new Error(
-      `Apple Sign-In compatibility patch could not find expected source: ${original.trim()}`,
-    );
-  }
-  source = source.replace(original, replacement);
+
+  writeFileSync(patch.path, source);
 }
-
-writeFileSync(pluginPath, source);
 console.log("Applied Apple Sign-In SwiftPM compatibility patch.");


### PR DESCRIPTION
## Summary
- avoid Capacitor binary APIs hidden behind the NonescapableTypes compiler feature
- use public non-optional call accessors for Apple Sign-In options
- reject native sign-in failures through the public unavailable helper while preserving the native error code in the message
- patch both affected plugin source files with guarded, idempotent replacements

## Validation
- clean npm ci --ignore-scripts
- compatibility patch applied twice successfully
- iOS mobile release validator with production Railway URL
- git diff --check
- prior main build confirms all earlier Apple Sign-In bridge errors are resolved