### PR TITLE
fix(ios): forward universal links via delegate protocol

### DIFF
--- a/ios/App/App/AppDelegate.swift
+++ b/ios/App/App/AppDelegate.swift
@@ -43,7 +43,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Called when the app was launched with an activity, including Universal Links.
         // Feel free to add additional processing here, but if you want the App API to support
         // tracking app url opens, make sure to keep this call
-        return ApplicationDelegateProxy.shared.application(application, continue: userActivity, restorationHandler: restorationHandler)
+        let proxy: UIApplicationDelegate = ApplicationDelegateProxy.shared
+        return proxy.application?(application, continue: userActivity, restorationHandler: restorationHandler) ?? false
     }
 
 }


### PR DESCRIPTION
## Summary
- forward universal links through UIApplicationDelegate's public optional method
- preserve Capacitor's runtime handling without compiling against its gated concrete proxy overload

## Validation
- iOS mobile release validator with production Railway URL
- git diff --check
- previous native build compiled the Apple Sign-In package successfully and identified only this app-target error