### PR TITLE
Fix guest profiles across dashboard

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -69,10 +69,9 @@ export default function App() {
   // Background Prefetcher: Ensure compatibility and readings are ready before click
   useEffect(() => {
     if (hasProfile && hydrated) {
-      const saved = localStorage.getItem("soulProfile");
-      if (saved) {
+      const p = loadActiveProfile();
+      if (p) {
         try {
-          const p = JSON.parse(saved);
           const sunSign = p.sunSign || p.astrologyData?.sunSign;
           if (sunSign) {
             // Warm up the compatibility engine and daily readings in the background

--- a/client/src/components/Nav.tsx
+++ b/client/src/components/Nav.tsx
@@ -7,6 +7,7 @@ import {
   IconLogo, IconSettings
 } from "./Icons";
 import { triggerHapticFeedback } from "../lib/haptics";
+import { loadActiveProfile } from "../lib/profileStorage";
 
 function useMode() {
   const [mode, setMode] = useState<"beginner" | "advanced">(() => {
@@ -44,7 +45,7 @@ export default function Nav() {
   const { mode, toggle } = useMode();
 
   const hasProfileData = (() => {
-    try { return !!localStorage.getItem("soulProfile"); } catch { return false; }
+    return !!loadActiveProfile();
   })();
 
   const baseLinks = [

--- a/client/src/lib/profileStorage.ts
+++ b/client/src/lib/profileStorage.ts
@@ -1,6 +1,7 @@
 const STORAGE_KEY = "soulcodex.activeProfile.v1";
 
 export interface StoredProfile {
+  [key: string]: any;
   birthDate?: string;
   birthTime?: string;
   birthLocation?: string;

--- a/client/src/pages/BlueprintPage.tsx
+++ b/client/src/pages/BlueprintPage.tsx
@@ -8,6 +8,7 @@ import {
 } from "../components/Icons";
 import { cleanCodexLine } from "../lib/soul-codex/utils/cleanCodexLine";
 import { isNativeStoreApp } from "../lib/platform";
+import { loadActiveProfile } from "../lib/profileStorage";
 
 const CACHE_PREFIX = "soulBlueprintReading";
 
@@ -56,7 +57,7 @@ interface CachedReading {
 }
 
 function getProfile() {
-  try { return JSON.parse(localStorage.getItem("soulProfile") ?? "{}"); } catch { return {}; }
+  return loadActiveProfile() ?? {};
 }
 
 function cacheKey(profile: any): string {

--- a/client/src/pages/CodexReadingPage.tsx
+++ b/client/src/pages/CodexReadingPage.tsx
@@ -9,6 +9,7 @@ import {
   IconIdentity, IconCompass, IconZap, IconActivity, IconAlert
 } from "../components/Icons";
 import { cleanCodexLine } from "../lib/soul-codex/utils/cleanCodexLine";
+import { loadActiveProfile } from "../lib/profileStorage";
 
 interface CoreDriver {
   name: string;
@@ -41,10 +42,7 @@ interface CodexSynthesis {
 }
 
 function getProfile() {
-  try {
-    const raw = localStorage.getItem("soulProfile");
-    return raw ? JSON.parse(raw) : null;
-  } catch { return null; }
+  return loadActiveProfile();
 }
 
 function extractNarrativeSection(narrative: string, heading: string): string | null {
@@ -103,17 +101,12 @@ export default function CodexReadingPage() {
   }, [synthesis, error]);
 
   function buildAndGenerate() {
-    const rawProfile = localStorage.getItem("soulProfile");
-    if (!rawProfile) {
+    const activeProfile = loadActiveProfile();
+    if (!activeProfile) {
       setError("No profile found. Please complete your calibration first.");
       return;
     }
-    try {
-      const p = JSON.parse(rawProfile);
-      generateMutation.mutate({ profile: p });
-    } catch (e) {
-      setError("Profile data is corrupted. Please recalibrate.");
-    }
+    generateMutation.mutate({ profile: activeProfile });
   }
 
   if (generateMutation.isPending && !synthesis) return <CodexSkeleton />;

--- a/client/src/pages/DailyHoroscopePage.tsx
+++ b/client/src/pages/DailyHoroscopePage.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "wouter";
 import PlanetWheel from "../components/PlanetWheel";
+import { loadActiveProfile } from "../lib/profileStorage";
 import { 
   IconMoon, IconReading, IconIdentity, IconEarth, 
   IconChevronDown, IconArrowLeft 
@@ -211,8 +212,7 @@ const INTENSITY_ORDER: Record<string, number> = { high: 0, medium: 1, low: 2 };
 
 export default function DailyHoroscopePage() {
   const profileData = (() => {
-    try { const s = localStorage.getItem("soulProfile"); if (s) return JSON.parse(s); } catch {}
-    return null;
+    return loadActiveProfile();
   })();
   const profileId = profileData?.id || profileData?.profileId;
 

--- a/client/src/pages/PosterPage.tsx
+++ b/client/src/pages/PosterPage.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { useState, useMemo, useEffect } from "react";
 import { Link } from "wouter";
 import BirthChartPosterSVG, { type PosterData } from "../components/BirthChartPosterSVG";
+import { loadActiveProfile } from "../lib/profileStorage";
 
 const ZODIAC_SIGNS = [
   "Aries","Taurus","Gemini","Cancer","Leo","Virgo",
@@ -74,7 +75,7 @@ function planetHouse(lon: number, cusps: number[]): number {
 }
 
 function getProfile() {
-  try { return JSON.parse(localStorage.getItem("soulProfile") ?? "{}"); } catch { return {}; }
+  return loadActiveProfile() ?? {};
 }
 
 const DEMO: PosterData = {

--- a/client/src/pages/PricingPage.tsx
+++ b/client/src/pages/PricingPage.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { useState } from "react";
 import { apiFetch } from "../lib/queryClient";
 import { isNativeStoreApp } from "../lib/platform";
+import { loadActiveProfile } from "../lib/profileStorage";
 
 export default function PricingPage() {
   const isNative = isNativeStoreApp();
@@ -26,8 +27,7 @@ export default function PricingPage() {
   ];
 
   const getProfileId = (): string | undefined => {
-    try { return JSON.parse(localStorage.getItem("soulProfile") || "null")?.profileId; }
-    catch { return undefined; }
+    return loadActiveProfile()?.profileId;
   };
 
   // Real entitlement: redeem an access code against the backend. Premium is only

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -5,12 +5,10 @@ import {
 } from "../components/Icons";
 import ConfidenceBadge from "@/components/ConfidenceBadge";
 import { cleanCodexLine } from "../lib/soul-codex/utils/cleanCodexLine";
+import { loadActiveProfile } from "../lib/profileStorage";
 
 function getProfile() {
-  try {
-    const raw = localStorage.getItem("soulProfile");
-    return raw ? JSON.parse(raw) : null;
-  } catch { return null; }
+  return loadActiveProfile();
 }
 
 export default function ProfilePage() {

--- a/client/src/pages/SoulGuidePage.tsx
+++ b/client/src/pages/SoulGuidePage.tsx
@@ -1,5 +1,6 @@
 import { apiFetch, resolveApiUrl } from "../lib/queryClient";
 import { cleanCodexLine } from "../lib/soul-codex/utils/cleanCodexLine";
+import { loadActiveProfile } from "../lib/profileStorage";
 import { useState, useEffect, useRef } from "react";
 import { useLocation, Link } from "wouter";
 import { isNativeStoreApp } from "../lib/platform";
@@ -63,9 +64,8 @@ export default function SoulGuidePage() {
 
   const getProfileContext = () => {
     try {
-      const raw = localStorage.getItem("soulProfile");
-      if (!raw) return null;
-      const p = JSON.parse(raw);
+      const p = loadActiveProfile();
+      if (!p) return null;
       return {
         name:        p.name,
         archetype:   p.archetype?.name,

--- a/client/src/pages/TimelinePage.tsx
+++ b/client/src/pages/TimelinePage.tsx
@@ -19,6 +19,7 @@ import {
 } from "../components/Icons";
 import TimelineIntelligence from "../components/TimelineIntelligence";
 import SoulGuide from "../components/SoulGuide";
+import { loadActiveProfile } from "../lib/profileStorage";
 
 // ── Phase content ─────────────────────────────────────────────────────────────
 
@@ -255,22 +256,16 @@ export default function TimelinePage() {
   const [profile, setProfile]     = useState<any>(null);
 
   useEffect(() => {
-    const savedProfile = localStorage.getItem("soulProfile");
-    if (savedProfile) setProfile(JSON.parse(savedProfile));
+    const activeProfile = loadActiveProfile();
+    if (activeProfile) setProfile(activeProfile);
 
     const savedToday = localStorage.getItem("soulTodayCard");
     if (savedToday) setTodayCard(JSON.parse(savedToday));
 
-    const rawProfile = localStorage.getItem("soulProfile");
-    if (rawProfile) {
-      try {
-        const p = JSON.parse(rawProfile);
-        if (p.birthDate) {
-          const parts = p.birthDate.split("-");
-          setBirthData({ month: parseInt(parts[1], 10), day: parseInt(parts[2], 10) });
-          return; // Birth date found in profile, we're good
-        }
-      } catch {}
+    if (activeProfile?.birthDate) {
+      const parts = activeProfile.birthDate.split("-");
+      setBirthData({ month: parseInt(parts[1], 10), day: parseInt(parts[2], 10) });
+      return;
     }
 
     const rawInputs = localStorage.getItem("onboardingData") || localStorage.getItem("soulUserInputs");

--- a/client/src/pages/TodayPage.tsx
+++ b/client/src/pages/TodayPage.tsx
@@ -10,6 +10,7 @@ import {
 import { cleanCodexLine } from "../lib/soul-codex/utils/cleanCodexLine";
 import ConfidenceBadge from "@/components/ConfidenceBadge";
 import { getDailyPulseForDate, saveDailyPulseEntry, type MoodType } from "../lib/dailyPulseStorage";
+import { loadActiveProfile } from "../lib/profileStorage";
 
 interface TodayCard {
   codename: string;
@@ -36,10 +37,7 @@ function formatDate(iso: string): string {
 }
 
 function getProfile() {
-  try {
-    const raw = localStorage.getItem("soulProfile");
-    return raw ? JSON.parse(raw) : null;
-  } catch { return null; }
+  return loadActiveProfile();
 }
 
 const MOOD_OPTIONS: { value: MoodType; label: string }[] = [


### PR DESCRIPTION
## Summary

- read guest and authenticated profiles through the canonical active-profile adapter
- keep Today, Profile, Soul Guide, Timeline, Blueprint, Poster, and related dashboard surfaces usable after guest onboarding
- preserve legacy `soulProfile` compatibility inside the shared storage adapter

## Why

Guest onboarding saved the completed profile as `soulGuestProfile` and `soulcodex.activeProfile.v1`, while several dashboard pages still read only `soulProfile`. The route guard admitted the user, but those pages behaved as if onboarding were incomplete.

## Validation

- `npm run check`
- `npm run build`
- `git diff --check`

