### PR TITLE
feat(codex): add evidence-backed depth synthesis

### DIFF
--- a/packages/core/depth-interpretation/SYNTHESIS.md
+++ b/packages/core/depth-interpretation/SYNTHESIS.md
@@ -1,0 +1,37 @@
+# Evidence-Backed Depth Synthesis
+
+PR 2 maps normalized source signals into `DepthInterpretationV1` without replacing the existing `synthesizeCodex()` API.
+
+## Flow
+
+1. `normalizeSoulProfileForDepth()` converts the application `SoulProfile` into stable evidence seeds.
+2. Each seed records its source system, field, value, confidence, provenance, time sensitivity, supported facets, and possible tension axes.
+3. `synthesizeDepthInterpretationV1()` selects the strongest supported seeds for each layer.
+4. Defined contradiction rules may identify coexistence between two supported signals.
+5. `validateDepthInterpretationV1()` remains the final contract gate.
+
+## Evidence Priority
+
+User-supplied Mirror answers and stated values receive higher selection priority than generalized symbolic mappings. This does not make them universal certainty. It means lived input should override a conflicting generalized interpretation.
+
+## Unknown Birth Time
+
+When birth time is unknown, the synthesizer removes evidence marked `birth-time-required` before layer construction. Rising sign and time-sensitive Human Design evidence therefore cannot support an available claim. Sun sign, date-derived numerology, and supplied Mirror answers remain usable.
+
+Approximate birth time retains time-sensitive evidence at low confidence and adds an explicit limitation.
+
+## Contradictions
+
+The deterministic rules currently recognize these supported tensions:
+
+- independence with consistency, partnership, or recognition
+- speed with analysis
+- structure with sensitivity
+- harmony with directness
+- freedom with stability
+
+A detected contradiction means both signals are present. It does not establish why the tension developed, diagnose a cause, or invent biography.
+
+## Compatibility
+
+The adapter calls the existing `synthesizeCodex(profile)` function for established deterministic text where useful. It does not mutate the profile, replace the current synthesis return type, or alter existing callers.

--- a/packages/core/depth-interpretation/SYNTHESIS.md
+++ b/packages/core/depth-interpretation/SYNTHESIS.md
@@ -35,3 +35,7 @@ A detected contradiction means both signals are present. It does not establish w
 ## Compatibility
 
 The adapter calls the existing `synthesizeCodex(profile)` function for established deterministic text where useful. It does not mutate the profile, replace the current synthesis return type, or alter existing callers.
+
+## Validation Boundary
+
+The synthesis implementation is validated through the repository's permanent workspace build, type-check, test, and production-build workflows. The documentation records behavior and guardrails; passing examples remain enforced by executable tests rather than prose alone.

--- a/packages/core/depth-interpretation/__tests__/synthesize.test.ts
+++ b/packages/core/depth-interpretation/__tests__/synthesize.test.ts
@@ -1,0 +1,210 @@
+import { test } from "node:test";
+import assert from "node:assert";
+import {
+  DEPTH_INTERPRETATION_LAYER_KEYS,
+  synthesizeDepthInterpretationV1,
+  validateDepthInterpretationV1,
+  type DepthSynthesisInputV1,
+  type DepthSynthesisSeed,
+  type InterpretationEvidenceRef,
+} from "../index.js";
+
+function evidence(
+  id: string,
+  overrides: Partial<InterpretationEvidenceRef> = {},
+): InterpretationEvidenceRef {
+  return {
+    id,
+    system: "mirror",
+    field: id,
+    value: id,
+    confidence: "high",
+    provenanceStatus: "partially-verified",
+    timeSensitivity: "none",
+    ...overrides,
+  };
+}
+
+function completeSeed(): DepthSynthesisSeed {
+  return {
+    evidence: evidence("mirror.independence"),
+    label: "reported independence",
+    priority: 100,
+    facets: {
+      claritySummary: "Independence is the strongest supplied pattern.",
+      visiblePattern: "Other people may notice self-directed movement first.",
+      innerExperience: "Private processing may continue after visible action begins.",
+      hiddenNeed: "Reliable room for self-direction may matter beneath the pattern.",
+      protectiveFunction: "Self-direction may reduce exposure to uncertain dependence.",
+      gift: "The pattern can support initiative and ownership.",
+      shadow: "Overuse can reduce collaboration and corrective feedback.",
+      commonMisreading: "Self-direction may be mistaken for a lack of care.",
+      relationshipImpact: "Trust may grow through consistency without forced closeness.",
+      decisionImpact: "Choices may favor control over waiting for group agreement.",
+      boundaryOrRepair: "State the need for autonomy before withdrawing.",
+      action: "Name one decision that can move without more permission.",
+    },
+    tensionAxes: ["independence", "speed"],
+    limitations: [
+      "The supplied signal does not establish how the pattern developed.",
+    ],
+  };
+}
+
+function input(seeds: DepthSynthesisSeed[]): DepthSynthesisInputV1 {
+  return {
+    version: 1,
+    generatedAt: "2026-07-24T16:00:00.000Z",
+    birthTimeStatus: "known",
+    seeds,
+    missingData: [],
+  };
+}
+
+test("Depth synthesis", async (suite) => {
+  await suite.test("produces a valid complete interpretation", () => {
+    const result = synthesizeDepthInterpretationV1(
+      input([
+        completeSeed(),
+        {
+          evidence: evidence("values.consistency", {
+            system: "moral-compass",
+          }),
+          label: "stated consistency needs",
+          priority: 90,
+          facets: {
+            hiddenNeed: "Consistency remains important inside independent movement.",
+          },
+          tensionAxes: ["consistency", "stability"],
+          limitations: [
+            "A stated value does not prove identical behavior in every context.",
+          ],
+        },
+      ]),
+    );
+
+    const validation = validateDepthInterpretationV1(result, {
+      birthTimeStatus: "known",
+    });
+
+    assert.equal(validation.valid, true);
+    assert.deepEqual(validation.findings, []);
+    assert.equal(result.coreContradiction.claimKind, "inferred");
+    assert.deepEqual(result.coreContradiction.evidenceIds, [
+      "mirror.independence",
+      "values.consistency",
+    ]);
+  });
+
+  await suite.test("links every available layer to existing evidence", () => {
+    const result = synthesizeDepthInterpretationV1(input([completeSeed()]));
+    const evidenceIds = new Set(result.evidence.map((item) => item.id));
+
+    for (const key of DEPTH_INTERPRETATION_LAYER_KEYS) {
+      const layer = result[key];
+      if (layer.claimKind === "unavailable") continue;
+
+      assert.ok(layer.evidenceIds.length > 0, `${key} must cite evidence`);
+      layer.evidenceIds.forEach((id) => {
+        assert.ok(evidenceIds.has(id), `${key} cites missing evidence ${id}`);
+      });
+    }
+  });
+
+  await suite.test("leaves unsupported contradiction unavailable", () => {
+    const result = synthesizeDepthInterpretationV1(input([completeSeed()]));
+
+    assert.equal(result.coreContradiction.claimKind, "unavailable");
+    assert.match(result.coreContradiction.summary, /^Unavailable:/);
+  });
+
+  await suite.test("removes time-sensitive support when birth time is unknown", () => {
+    const risingSeed: DepthSynthesisSeed = {
+      evidence: evidence("astrology.rising.sign", {
+        system: "astrology",
+        field: "chart.rising.sign",
+        value: "Scorpio",
+        timeSensitivity: "birth-time-required",
+      }),
+      label: "Scorpio Rising",
+      priority: 200,
+      facets: {
+        visiblePattern: "A time-sensitive first-impression pattern is present.",
+      },
+      tensionAxes: ["structure"],
+      limitations: ["Rising sign requires an accurate birth time."],
+    };
+    const normalizedInput = input([completeSeed(), risingSeed]);
+    normalizedInput.birthTimeStatus = "unknown";
+
+    const result = synthesizeDepthInterpretationV1(normalizedInput);
+
+    assert.equal(
+      result.evidence.some((item) => item.id === "astrology.rising.sign"),
+      false,
+    );
+    assert.equal(
+      result.visiblePattern.evidenceIds.includes("astrology.rising.sign"),
+      false,
+    );
+    assert.ok(
+      result.missingData.some((item) =>
+        item.includes("chart.rising.sign"),
+      ),
+    );
+    assert.equal(
+      validateDepthInterpretationV1(result, {
+        birthTimeStatus: "unknown",
+      }).valid,
+      true,
+    );
+  });
+
+  await suite.test("degrades approximate-time evidence", () => {
+    const authoritySeed: DepthSynthesisSeed = {
+      evidence: evidence("human-design.authority", {
+        system: "human-design",
+        timeSensitivity: "birth-time-required",
+      }),
+      label: "time-sensitive authority",
+      facets: {
+        decisionImpact: "A time-sensitive authority may affect decision pacing.",
+      },
+      limitations: [],
+    };
+    const normalizedInput = input([completeSeed(), authoritySeed]);
+    normalizedInput.birthTimeStatus = "approximate";
+
+    const result = synthesizeDepthInterpretationV1(normalizedInput);
+    const authority = result.evidence.find(
+      (item) => item.id === "human-design.authority",
+    );
+
+    assert.equal(authority?.confidence, "low");
+    assert.ok(
+      authority?.notes?.some((note) => note.includes("approximate")),
+    );
+  });
+
+  await suite.test("serializes deterministically for identical input", () => {
+    const normalizedInput = input([
+      completeSeed(),
+      {
+        evidence: evidence("values.consistency", {
+          system: "moral-compass",
+        }),
+        label: "stated consistency needs",
+        facets: {
+          hiddenNeed: "Consistency supports sustainable independence.",
+        },
+        tensionAxes: ["consistency"],
+        limitations: ["The value may be situational."],
+      },
+    ]);
+
+    assert.equal(
+      JSON.stringify(synthesizeDepthInterpretationV1(normalizedInput)),
+      JSON.stringify(synthesizeDepthInterpretationV1(normalizedInput)),
+    );
+  });
+});

--- a/packages/core/depth-interpretation/index.ts
+++ b/packages/core/depth-interpretation/index.ts
@@ -1,2 +1,4 @@
 export * from "./types.js";
+export * from "./synthesis-types.js";
+export * from "./synthesize.js";
 export * from "./validate.js";

--- a/packages/core/depth-interpretation/synthesis-types.ts
+++ b/packages/core/depth-interpretation/synthesis-types.ts
@@ -1,0 +1,51 @@
+import type {
+  BirthTimeStatus,
+  InterpretationClaimKind,
+  InterpretationEvidenceRef,
+} from "./types.js";
+
+export type DepthSynthesisFacet =
+  | "claritySummary"
+  | "visiblePattern"
+  | "innerExperience"
+  | "hiddenNeed"
+  | "protectiveFunction"
+  | "gift"
+  | "shadow"
+  | "commonMisreading"
+  | "relationshipImpact"
+  | "decisionImpact"
+  | "boundaryOrRepair"
+  | "action";
+
+export type DepthTensionAxis =
+  | "independence"
+  | "consistency"
+  | "partnership"
+  | "recognition"
+  | "speed"
+  | "analysis"
+  | "structure"
+  | "sensitivity"
+  | "harmony"
+  | "directness"
+  | "freedom"
+  | "stability";
+
+export interface DepthSynthesisSeed {
+  evidence: InterpretationEvidenceRef;
+  label: string;
+  priority?: number;
+  claimKind?: Exclude<InterpretationClaimKind, "unavailable">;
+  facets: Partial<Record<DepthSynthesisFacet, string>>;
+  tensionAxes?: DepthTensionAxis[];
+  limitations?: string[];
+}
+
+export interface DepthSynthesisInputV1 {
+  version: 1;
+  generatedAt: string;
+  birthTimeStatus: BirthTimeStatus;
+  seeds: DepthSynthesisSeed[];
+  missingData?: string[];
+}

--- a/packages/core/depth-interpretation/synthesize.ts
+++ b/packages/core/depth-interpretation/synthesize.ts
@@ -1,0 +1,337 @@
+import type {
+  DepthInterpretationV1,
+  EvidenceProvenanceStatus,
+  InterpretationClaimKind,
+  InterpretationConfidence,
+  InterpretationEvidenceRef,
+  InterpretationLayer,
+} from "./types.js";
+import type {
+  DepthSynthesisFacet,
+  DepthSynthesisInputV1,
+  DepthSynthesisSeed,
+  DepthTensionAxis,
+} from "./synthesis-types.js";
+
+const FACET_TITLES: Record<DepthSynthesisFacet, string> = {
+  claritySummary: "Clarity summary",
+  visiblePattern: "What people may notice first",
+  innerExperience: "What may be less visible",
+  hiddenNeed: "Possible need beneath the pattern",
+  protectiveFunction: "Possible protective function",
+  gift: "Constructive expression",
+  shadow: "Cost when overused",
+  commonMisreading: "Common misreading",
+  relationshipImpact: "Relationship impact",
+  decisionImpact: "Decision impact",
+  boundaryOrRepair: "Boundary or repair",
+  action: "Grounded action",
+};
+
+const DEFAULT_INFERENCE_LIMITATIONS = [
+  "This interpretation is limited to the supplied signals.",
+  "Lived experience may describe or weight the pattern differently.",
+];
+
+interface ContradictionRule {
+  title: string;
+  left: readonly DepthTensionAxis[];
+  right: readonly DepthTensionAxis[];
+}
+
+const CONTRADICTION_RULES: readonly ContradictionRule[] = [
+  {
+    title: "Independence and connection",
+    left: ["independence"],
+    right: ["consistency", "partnership", "recognition"],
+  },
+  {
+    title: "Speed and analysis",
+    left: ["speed"],
+    right: ["analysis"],
+  },
+  {
+    title: "Structure and sensitivity",
+    left: ["structure"],
+    right: ["sensitivity"],
+  },
+  {
+    title: "Harmony and directness",
+    left: ["harmony"],
+    right: ["directness"],
+  },
+  {
+    title: "Freedom and stability",
+    left: ["freedom"],
+    right: ["stability"],
+  },
+];
+
+function unique(values: readonly string[]): string[] {
+  return Array.from(new Set(values.filter((value) => value.trim().length > 0)));
+}
+
+function isVerified(status?: EvidenceProvenanceStatus): boolean {
+  return status === "externally-verified" || status === "partially-verified";
+}
+
+function confidenceRank(confidence: InterpretationConfidence): number {
+  if (confidence === "high") return 3;
+  if (confidence === "moderate") return 2;
+  return 1;
+}
+
+function confidenceFromRank(rank: number): InterpretationConfidence {
+  if (rank >= 3) return "high";
+  if (rank >= 2) return "moderate";
+  return "low";
+}
+
+function conservativeConfidence(
+  evidence: readonly InterpretationEvidenceRef[],
+): InterpretationConfidence {
+  if (evidence.length === 0) return "low";
+
+  const lowestRank = Math.min(
+    ...evidence.map((item) => confidenceRank(item.confidence)),
+  );
+  const confidence = confidenceFromRank(lowestRank);
+
+  if (
+    confidence === "high" &&
+    !evidence.some((item) => isVerified(item.provenanceStatus))
+  ) {
+    return "moderate";
+  }
+
+  return confidence;
+}
+
+function unavailableLayer(title: string, reason: string): InterpretationLayer {
+  return {
+    title,
+    summary: `Unavailable: ${reason}`,
+    explanation: `Insufficient data: ${reason}`,
+    claimKind: "unavailable",
+    evidenceIds: [],
+    confidence: "low",
+    limitations: [reason],
+  };
+}
+
+function claimKindForSeeds(
+  seeds: readonly DepthSynthesisSeed[],
+): Exclude<InterpretationClaimKind, "unavailable"> {
+  const kinds = seeds.map((seed) => seed.claimKind ?? "inferred");
+
+  if (kinds.every((kind) => kind === "observed")) return "observed";
+  if (kinds.every((kind) => kind === "derived")) return "derived";
+  return "inferred";
+}
+
+function layerFromFacet(
+  facet: DepthSynthesisFacet,
+  seeds: readonly DepthSynthesisSeed[],
+): InterpretationLayer {
+  const selected = seeds
+    .filter((seed) => Boolean(seed.facets[facet]?.trim()))
+    .slice(0, 2);
+
+  if (selected.length === 0) {
+    return unavailableLayer(
+      FACET_TITLES[facet],
+      `no supported signal was supplied for ${FACET_TITLES[facet].toLowerCase()}.`,
+    );
+  }
+
+  const evidence = selected.map((seed) => seed.evidence);
+  const claimKind = claimKindForSeeds(selected);
+  const limitations = unique([
+    ...selected.flatMap((seed) => seed.limitations ?? []),
+    ...(claimKind === "inferred" ? DEFAULT_INFERENCE_LIMITATIONS : []),
+  ]);
+  const summary = selected[0].facets[facet]!.trim();
+  const labels = selected.map((seed) => seed.label);
+  const explanation =
+    selected.length === 1
+      ? `This layer is supported by ${labels[0]}. It describes the supplied pattern without treating it as fixed identity.`
+      : `This layer combines ${labels[0]} with ${labels[1]}. Their overlap is supporting context, not independent proof.`;
+
+  return {
+    title: FACET_TITLES[facet],
+    summary,
+    explanation,
+    claimKind,
+    evidenceIds: unique(evidence.map((item) => item.id)),
+    confidence: conservativeConfidence(evidence),
+    limitations,
+  };
+}
+
+function hasAxis(
+  seed: DepthSynthesisSeed,
+  axes: readonly DepthTensionAxis[],
+): boolean {
+  return (seed.tensionAxes ?? []).some((axis) => axes.includes(axis));
+}
+
+function contradictionLayer(
+  seeds: readonly DepthSynthesisSeed[],
+): InterpretationLayer {
+  for (const rule of CONTRADICTION_RULES) {
+    const left = seeds.find((seed) => hasAxis(seed, rule.left));
+    if (!left) continue;
+
+    const right = seeds.find(
+      (seed) =>
+        seed.evidence.id !== left.evidence.id && hasAxis(seed, rule.right),
+    );
+    if (!right) continue;
+
+    const evidence = [left.evidence, right.evidence];
+
+    return {
+      title: rule.title,
+      summary: `The supplied profile supports both ${left.label} and ${right.label}.`,
+      explanation:
+        "These signals can coexist even when they appear to pull in different directions. The rule identifies a supported tension, not a hidden cause or biography.",
+      claimKind: "inferred",
+      evidenceIds: unique(evidence.map((item) => item.id)),
+      confidence: conservativeConfidence(evidence),
+      limitations: [
+        "This rule detects coexistence between supplied signals; it does not establish why the tension developed.",
+        "Lived experience may show that one side is stronger, situational, or no longer active.",
+      ],
+    };
+  }
+
+  return unavailableLayer(
+    "Core contradiction",
+    "the supplied signals do not support one of the defined contradiction pairs.",
+  );
+}
+
+function prepareSeeds(input: DepthSynthesisInputV1): {
+  seeds: DepthSynthesisSeed[];
+  missingData: string[];
+} {
+  const missingData = [...(input.missingData ?? [])];
+  const seeds: DepthSynthesisSeed[] = [];
+
+  for (const seed of input.seeds) {
+    const requiresBirthTime =
+      seed.evidence.timeSensitivity === "birth-time-required";
+
+    if (input.birthTimeStatus === "unknown" && requiresBirthTime) {
+      missingData.push(
+        `Exact birth time is required for ${seed.evidence.field}.`,
+      );
+      continue;
+    }
+
+    if (input.birthTimeStatus === "approximate" && requiresBirthTime) {
+      seeds.push({
+        ...seed,
+        evidence: {
+          ...seed.evidence,
+          confidence: "low",
+          notes: unique([
+            ...(seed.evidence.notes ?? []),
+            "Birth time is approximate; this time-sensitive signal is degraded.",
+          ]),
+        },
+        limitations: unique([
+          ...(seed.limitations ?? []),
+          "Birth time is approximate, so this signal may change after verification.",
+        ]),
+      });
+      continue;
+    }
+
+    seeds.push(seed);
+  }
+
+  seeds.sort(
+    (a, b) =>
+      (b.priority ?? 0) - (a.priority ?? 0) ||
+      a.evidence.id.localeCompare(b.evidence.id) ||
+      a.label.localeCompare(b.label),
+  );
+
+  return { seeds, missingData: unique(missingData) };
+}
+
+function evidenceFromSeeds(
+  seeds: readonly DepthSynthesisSeed[],
+): InterpretationEvidenceRef[] {
+  const byId = new Map<string, InterpretationEvidenceRef>();
+
+  for (const seed of seeds) {
+    if (!byId.has(seed.evidence.id)) {
+      byId.set(seed.evidence.id, seed.evidence);
+    }
+  }
+
+  return Array.from(byId.values()).sort((a, b) => a.id.localeCompare(b.id));
+}
+
+function overallConfidence(
+  evidence: readonly InterpretationEvidenceRef[],
+  missingData: readonly string[],
+): InterpretationConfidence {
+  if (evidence.length === 0) return "low";
+
+  const allHigh = evidence.every((item) => item.confidence === "high");
+  const hasVerifiedSupport = evidence.some((item) =>
+    isVerified(item.provenanceStatus),
+  );
+
+  if (
+    evidence.length >= 3 &&
+    allHigh &&
+    hasVerifiedSupport &&
+    missingData.length === 0
+  ) {
+    return "high";
+  }
+
+  if (evidence.some((item) => item.confidence !== "low")) {
+    return "moderate";
+  }
+
+  return "low";
+}
+
+export function synthesizeDepthInterpretationV1(
+  input: DepthSynthesisInputV1,
+): DepthInterpretationV1 {
+  const prepared = prepareSeeds(input);
+  const evidence = evidenceFromSeeds(prepared.seeds);
+
+  return {
+    version: 1,
+    generatedAt: input.generatedAt,
+    claritySummary: layerFromFacet("claritySummary", prepared.seeds),
+    visiblePattern: layerFromFacet("visiblePattern", prepared.seeds),
+    innerExperience: layerFromFacet("innerExperience", prepared.seeds),
+    hiddenNeed: layerFromFacet("hiddenNeed", prepared.seeds),
+    protectiveFunction: layerFromFacet(
+      "protectiveFunction",
+      prepared.seeds,
+    ),
+    coreContradiction: contradictionLayer(prepared.seeds),
+    gift: layerFromFacet("gift", prepared.seeds),
+    shadow: layerFromFacet("shadow", prepared.seeds),
+    commonMisreading: layerFromFacet("commonMisreading", prepared.seeds),
+    relationshipImpact: layerFromFacet(
+      "relationshipImpact",
+      prepared.seeds,
+    ),
+    decisionImpact: layerFromFacet("decisionImpact", prepared.seeds),
+    boundaryOrRepair: layerFromFacet("boundaryOrRepair", prepared.seeds),
+    action: layerFromFacet("action", prepared.seeds),
+    evidence,
+    missingData: prepared.missingData,
+    overallConfidence: overallConfidence(evidence, prepared.missingData),
+  };
+}

--- a/packages/core/depth-interpretation/types.ts
+++ b/packages/core/depth-interpretation/types.ts
@@ -11,6 +11,8 @@ export type EvidenceSystem =
   | "numerology"
   | "human-design"
   | "mirror"
+  | "elements"
+  | "moral-compass"
   | "timeline"
   | "tracker"
   | "user-stated"

--- a/src/codex/__tests__/depth-adapter.test.ts
+++ b/src/codex/__tests__/depth-adapter.test.ts
@@ -1,0 +1,205 @@
+import { test } from "node:test";
+import assert from "node:assert";
+import type { SoulProfile } from "../../types/soulcodex.js";
+import {
+  validateDepthInterpretationV1,
+} from "../../../packages/core/depth-interpretation/index.js";
+import {
+  normalizeSoulProfileForDepth,
+  synthesizeDepthCodex,
+} from "../depth-adapter.js";
+import { synthesizeCodex } from "../synthesize.js";
+
+function completeProfile(): SoulProfile {
+  return {
+    birth: {
+      name: "Test Profile",
+      birthDate: "1990-09-17",
+      birthTime: "11:11",
+      birthPlace: "Bronx, New York",
+      lat: 40.8448,
+      lon: -73.8648,
+      timezone: "America/New_York",
+      timeKnown: true,
+    },
+    confidence: {
+      badge: "partial",
+      label: "Partially verified",
+      reason: "Birth time is supplied but not externally documented.",
+    },
+    mirror: {
+      driver: "Independence",
+      shadowTrigger: "Loss of control",
+      decisionStyle: "Analytical logic",
+      energyStyle: "Fast and independent",
+      conflictStyle: "Direct confrontation",
+      nuance: ["Consistency matters more than people first assume."],
+    },
+    numerology: {
+      lifePath: 4,
+      expression: 1,
+      soulUrge: 9,
+    },
+    chart: {
+      sun: { planet: "Sun", sign: "Virgo", degree: 24 },
+      moon: { planet: "Moon", sign: "Cancer", degree: 12 },
+      rising: { planet: "Ascendant", sign: "Scorpio", degree: 8 },
+      venus: { planet: "Venus", sign: "Libra", degree: 3 },
+    },
+    humanDesign: {
+      type: "Manifestor",
+      strategy: "Inform before acting",
+      authority: "Emotional",
+      profile: "2/5",
+    },
+    elements: {
+      earth: 4,
+      air: 2,
+      fire: 3,
+      water: 3,
+    },
+    morals: {
+      values: ["Consistency", "Honesty"],
+      intolerances: ["Dishonesty", "Control"],
+      crisisResponse: "Take control and solve the immediate problem",
+    },
+    timeline: {
+      currentPhase: "Construction",
+      reasons: ["Long-term systems are becoming the main focus"],
+    },
+  };
+}
+
+test("SoulProfile depth adapter", async (suite) => {
+  await suite.test("creates a valid evidence-backed interpretation", () => {
+    const profile = completeProfile();
+    const interpretation = synthesizeDepthCodex(profile, {
+      generatedAt: "2026-07-24T16:30:00.000Z",
+    });
+    const validation = validateDepthInterpretationV1(interpretation, {
+      birthTimeStatus: "known",
+    });
+
+    assert.equal(validation.valid, true);
+    assert.deepEqual(validation.findings, []);
+    assert.ok(
+      interpretation.evidence.some((item) => item.id === "mirror.driver"),
+    );
+    assert.ok(
+      interpretation.evidence.some(
+        (item) => item.id === "astrology.rising.sign",
+      ),
+    );
+    assert.ok(
+      interpretation.evidence.some(
+        (item) => item.id === "moral-compass.values",
+      ),
+    );
+    assert.deepEqual(interpretation.coreContradiction.evidenceIds, [
+      "mirror.driver",
+      "moral-compass.values",
+    ]);
+  });
+
+  await suite.test("removes time-sensitive astrology and Human Design evidence when time is unknown", () => {
+    const profile = completeProfile();
+    profile.birth.timeKnown = false;
+    delete profile.birth.birthTime;
+
+    const interpretation = synthesizeDepthCodex(profile, {
+      generatedAt: "2026-07-24T16:30:00.000Z",
+    });
+    const ids = new Set(interpretation.evidence.map((item) => item.id));
+
+    assert.equal(ids.has("astrology.rising.sign"), false);
+    assert.equal(ids.has("human-design.type"), false);
+    assert.equal(ids.has("human-design.authority"), false);
+    assert.equal(ids.has("human-design.strategy"), false);
+    assert.equal(ids.has("astrology.sun.sign"), true);
+    assert.equal(ids.has("numerology.life-path"), true);
+    assert.equal(ids.has("mirror.driver"), true);
+    assert.ok(
+      interpretation.missingData.some((item) =>
+        item.includes("Exact birth time is unknown"),
+      ),
+    );
+    assert.equal(
+      validateDepthInterpretationV1(interpretation, {
+        birthTimeStatus: "unknown",
+      }).valid,
+      true,
+    );
+  });
+
+  await suite.test("uses unavailable layers instead of invented filler", () => {
+    const profile: SoulProfile = {
+      birth: {
+        birthDate: "1990-09-17",
+        birthPlace: "Bronx, New York",
+        timeKnown: false,
+      },
+      numerology: { lifePath: 4 },
+      chart: {
+        sun: { planet: "Sun", sign: "Virgo" },
+        moon: { planet: "Moon", sign: "Cancer" },
+      },
+    };
+
+    const interpretation = synthesizeDepthCodex(profile, {
+      generatedAt: "2026-07-24T16:30:00.000Z",
+    });
+
+    assert.equal(interpretation.protectiveFunction.claimKind, "unavailable");
+    assert.equal(interpretation.boundaryOrRepair.claimKind, "unavailable");
+    assert.equal(interpretation.action.claimKind, "unavailable");
+    assert.match(interpretation.action.summary, /^Unavailable:/);
+    assert.ok(
+      interpretation.missingData.includes("Mirror behavioral driver is missing."),
+    );
+  });
+
+  await suite.test("keeps user-stated evidence authoritative without making it universal certainty", () => {
+    const interpretation = synthesizeDepthCodex(completeProfile(), {
+      generatedAt: "2026-07-24T16:30:00.000Z",
+    });
+
+    const driver = interpretation.evidence.find(
+      (item) => item.id === "mirror.driver",
+    );
+
+    assert.equal(driver?.confidence, "high");
+    assert.equal(driver?.provenanceStatus, "partially-verified");
+    assert.equal(interpretation.hiddenNeed.claimKind, "inferred");
+    assert.ok(interpretation.hiddenNeed.limitations.length > 0);
+  });
+
+  await suite.test("does not mutate or replace the existing synthesis API", () => {
+    const profile = completeProfile();
+    const profileSnapshot = JSON.stringify(profile);
+    const before = synthesizeCodex(profile);
+
+    normalizeSoulProfileForDepth(profile, {
+      generatedAt: "2026-07-24T16:30:00.000Z",
+    });
+    synthesizeDepthCodex(profile, {
+      generatedAt: "2026-07-24T16:30:00.000Z",
+    });
+
+    assert.deepEqual(synthesizeCodex(profile), before);
+    assert.equal(JSON.stringify(profile), profileSnapshot);
+  });
+
+  await suite.test("normalization is deterministic when generatedAt is fixed", () => {
+    const profile = completeProfile();
+    const options = { generatedAt: "2026-07-24T16:30:00.000Z" };
+
+    assert.equal(
+      JSON.stringify(normalizeSoulProfileForDepth(profile, options)),
+      JSON.stringify(normalizeSoulProfileForDepth(profile, options)),
+    );
+    assert.equal(
+      JSON.stringify(synthesizeDepthCodex(profile, options)),
+      JSON.stringify(synthesizeDepthCodex(profile, options)),
+    );
+  });
+});

--- a/src/codex/depth-adapter.ts
+++ b/src/codex/depth-adapter.ts
@@ -1,0 +1,759 @@
+import type {
+  ConfidenceBadge,
+  SoulProfile,
+} from "../types/soulcodex.js";
+import { synthesizeCodex } from "./synthesize.js";
+import {
+  synthesizeDepthInterpretationV1,
+  type BirthTimeStatus,
+  type DepthInterpretationV1,
+  type DepthSynthesisInputV1,
+  type DepthSynthesisSeed,
+  type DepthTensionAxis,
+  type EvidenceProvenanceStatus,
+  type EvidenceSystem,
+  type InterpretationConfidence,
+  type InterpretationEvidenceRef,
+} from "../../packages/core/depth-interpretation/index.js";
+
+const SIGN_TRAITS: Record<
+  string,
+  { drive: string; shadow: string }
+> = {
+  Aries: {
+    drive: "initiating action and leading from the front",
+    shadow: "impatience and burning out other people",
+  },
+  Taurus: {
+    drive: "building stability and protecting what matters",
+    shadow: "rigidity presented as loyalty",
+  },
+  Gemini: {
+    drive: "gathering information and connecting ideas",
+    shadow: "scattering attention across too many interests",
+  },
+  Cancer: {
+    drive: "protecting and nurturing chosen relationships",
+    shadow: "absorbing other people's emotions as personal responsibility",
+  },
+  Leo: {
+    drive: "creating something meaningful and being recognized for it",
+    shadow: "depending on approval to confirm legitimacy",
+  },
+  Virgo: {
+    drive: "precision, improvement, and practical service",
+    shadow: "analysis expanding until action stalls",
+  },
+  Libra: {
+    drive: "creating harmony and finding a fair answer",
+    shadow: "delaying confrontation until resentment accumulates",
+  },
+  Scorpio: {
+    drive: "going deep, testing truth, and maintaining control",
+    shadow: "holding pain or suspicion past its useful life",
+  },
+  Sagittarius: {
+    drive: "seeking meaning and expanding understanding",
+    shadow: "leaving depth behind for the next horizon",
+  },
+  Capricorn: {
+    drive: "building legacy through discipline and mastery",
+    shadow: "measuring worth primarily through output",
+  },
+  Aquarius: {
+    drive: "thinking differently and challenging defaults",
+    shadow: "using detachment when emotional stakes rise",
+  },
+  Pisces: {
+    drive: "feeling deeply and translating experience into meaning",
+    shadow: "weakening boundaries when another person needs support",
+  },
+};
+
+const LIFE_PATH_TRAITS: Record<
+  number,
+  { theme: string; drive: string }
+> = {
+  1: { theme: "Independence", drive: "self-reliance and pioneering" },
+  2: { theme: "Partnership", drive: "cooperation and sensitivity" },
+  3: { theme: "Expression", drive: "creativity and communication" },
+  4: { theme: "Structure", drive: "building systems that last" },
+  5: { theme: "Freedom", drive: "adaptability and experience" },
+  6: { theme: "Responsibility", drive: "service and stewardship" },
+  7: { theme: "Analysis", drive: "investigation and private understanding" },
+  8: { theme: "Power", drive: "material mastery and leadership" },
+  9: { theme: "Legacy", drive: "humanitarian purpose and completion" },
+  11: { theme: "Intuition", drive: "visionary insight and influence" },
+  22: { theme: "Master Building", drive: "turning vision into durable reality" },
+  33: { theme: "Master Teaching", drive: "uplifting others through example" },
+};
+
+const HD_TYPE_TRAITS: Record<
+  string,
+  { strength: string; risk: string }
+> = {
+  Manifestor: {
+    strength: "initiating without waiting for permission",
+    risk: "moving before other people understand what changed",
+  },
+  Generator: {
+    strength: "sustaining effort when the work is genuinely engaging",
+    risk: "continuing obligations that steadily drain energy",
+  },
+  "Manifesting Generator": {
+    strength: "moving quickly across several connected interests",
+    risk: "leaving work before repetition creates mastery",
+  },
+  Projector: {
+    strength: "seeing how people and systems can work more effectively",
+    risk: "offering direction before recognition or consent is present",
+  },
+  Reflector: {
+    strength: "registering the condition of an environment",
+    risk: "confusing absorbed group pressure with personal direction",
+  },
+};
+
+const ELEMENT_TRAITS: Record<
+  "earth" | "air" | "fire" | "water",
+  { gift: string; shadow: string }
+> = {
+  earth: {
+    gift: "stability, follow-through, and practical structure",
+    shadow: "holding position after conditions have changed",
+  },
+  air: {
+    gift: "mental speed, perspective, and verbal connection",
+    shadow: "processing through thought while feeling remains unattended",
+  },
+  fire: {
+    gift: "momentum, courage, and visible initiative",
+    shadow: "acting before context or consequence is fully read",
+  },
+  water: {
+    gift: "emotional depth, responsiveness, and environmental awareness",
+    shadow: "absorbing pressure before identifying its source",
+  },
+};
+
+export interface DepthCodexOptions {
+  generatedAt?: string;
+  birthTimeStatus?: BirthTimeStatus;
+}
+
+interface EvidenceQuality {
+  confidence: InterpretationConfidence;
+  provenanceStatus: EvidenceProvenanceStatus;
+}
+
+function evidenceQuality(
+  badge: ConfidenceBadge | undefined,
+  userSupplied = false,
+): EvidenceQuality {
+  if (userSupplied) {
+    return {
+      confidence: "high",
+      provenanceStatus: "partially-verified",
+    };
+  }
+
+  if (badge === "verified") {
+    return {
+      confidence: "high",
+      provenanceStatus: "partially-verified",
+    };
+  }
+
+  if (badge === "partial") {
+    return {
+      confidence: "moderate",
+      provenanceStatus: "partially-verified",
+    };
+  }
+
+  return {
+    confidence: "moderate",
+    provenanceStatus: "unverified",
+  };
+}
+
+function axesFromText(text: string): DepthTensionAxis[] {
+  const value = text.toLowerCase();
+  const axes: DepthTensionAxis[] = [];
+  const add = (axis: DepthTensionAxis, pattern: RegExp) => {
+    if (pattern.test(value) && !axes.includes(axis)) axes.push(axis);
+  };
+
+  add("independence", /independen|self-reli|pioneer|initiat|lead/);
+  add("consistency", /consisten|repetition|reliable|routine/);
+  add("partnership", /partner|cooperat|relationship|together/);
+  add("recognition", /recognition|recognized|approval|seen|invitation/);
+  add("speed", /speed|fast|quick|impulse|gut|react|momentum/);
+  add("analysis", /analy|logic|precision|investigat|understand|information/);
+  add("structure", /structure|control|discipline|system|order|mastery/);
+  add("sensitivity", /sensitiv|emotion|feel|absorb|nurtur|responsive/);
+  add("harmony", /harmony|fair|peace|cooperat/);
+  add("directness", /direct|conflict|confront|disrespect|intoleran/);
+  add("freedom", /freedom|adapt|movement|experience|pivot/);
+  add("stability", /stability|stable|lasting|durable|follow-through/);
+
+  return axes;
+}
+
+function makeEvidence(
+  profile: SoulProfile,
+  input: {
+    id: string;
+    system: EvidenceSystem;
+    field: string;
+    value: string | number | boolean | null;
+    userSupplied?: boolean;
+    timeSensitivity?: "none" | "birth-time-required";
+    notes?: string[];
+  },
+): InterpretationEvidenceRef {
+  const quality = evidenceQuality(
+    profile.confidence?.badge,
+    input.userSupplied,
+  );
+
+  return {
+    id: input.id,
+    system: input.system,
+    field: input.field,
+    value: input.value,
+    confidence: quality.confidence,
+    provenanceStatus: quality.provenanceStatus,
+    timeSensitivity: input.timeSensitivity ?? "none",
+    notes: [
+      "Confidence describes source completeness and consistency, not scientific truth.",
+      ...(input.notes ?? []),
+    ],
+  };
+}
+
+function addSeed(
+  seeds: DepthSynthesisSeed[],
+  seed: DepthSynthesisSeed | null,
+): void {
+  if (seed) seeds.push(seed);
+}
+
+function normalizedBirthTimeStatus(
+  profile: SoulProfile,
+  override?: BirthTimeStatus,
+): BirthTimeStatus {
+  if (override) return override;
+  return profile.birth.timeKnown ? "known" : "unknown";
+}
+
+export function normalizeSoulProfileForDepth(
+  profile: SoulProfile,
+  options: DepthCodexOptions = {},
+): DepthSynthesisInputV1 {
+  const synthesis = synthesizeCodex(profile);
+  const seeds: DepthSynthesisSeed[] = [];
+  const missingData: string[] = [];
+  const birthTimeStatus = normalizedBirthTimeStatus(
+    profile,
+    options.birthTimeStatus,
+  );
+
+  if (profile.mirror?.driver) {
+    const driver = profile.mirror.driver;
+    addSeed(seeds, {
+      evidence: makeEvidence(profile, {
+        id: "mirror.driver",
+        system: "mirror",
+        field: "mirror.driver",
+        value: driver,
+        userSupplied: true,
+      }),
+      label: `the reported driver ${driver}`,
+      priority: 130,
+      facets: {
+        claritySummary: `The strongest user-supplied behavioral driver is ${driver}.`,
+        hiddenNeed: `${driver} may be the condition the person most often tries to preserve.`,
+        gift: `${driver} can create a clear standard for attention and effort.`,
+        boundaryOrRepair: `Name the need for ${driver.toLowerCase()} directly instead of expecting other people to infer it.`,
+        action: `Before the next decision, state how ${driver.toLowerCase()} should shape the choice.`,
+      },
+      tensionAxes: axesFromText(driver),
+      limitations: [
+        "A reported driver describes a current self-assessment, not a permanent identity.",
+      ],
+    });
+  } else {
+    missingData.push("Mirror behavioral driver is missing.");
+  }
+
+  if (profile.mirror?.shadowTrigger) {
+    const trigger = profile.mirror.shadowTrigger;
+    addSeed(seeds, {
+      evidence: makeEvidence(profile, {
+        id: "mirror.shadow-trigger",
+        system: "mirror",
+        field: "mirror.shadowTrigger",
+        value: trigger,
+        userSupplied: true,
+      }),
+      label: `the reported stress trigger ${trigger}`,
+      priority: 125,
+      facets: {
+        innerExperience: `The clearest reported pressure point is ${trigger}.`,
+        protectiveFunction: `The stress response may be trying to reduce exposure to ${trigger.toLowerCase()}.`,
+        shadow: synthesis.stressPattern,
+        commonMisreading: `Other people may react to the defensive behavior without seeing the reported trigger underneath it.`,
+      },
+      tensionAxes: axesFromText(trigger),
+      limitations: [
+        "The trigger is user-supplied, but its protective function remains an interpretation.",
+      ],
+    });
+  } else {
+    missingData.push("Mirror stress trigger is missing.");
+  }
+
+  if (profile.mirror?.decisionStyle) {
+    const decisionStyle = profile.mirror.decisionStyle;
+    addSeed(seeds, {
+      evidence: makeEvidence(profile, {
+        id: "mirror.decision-style",
+        system: "mirror",
+        field: "mirror.decisionStyle",
+        value: decisionStyle,
+        userSupplied: true,
+      }),
+      label: `the reported decision style ${decisionStyle}`,
+      priority: 120,
+      facets: {
+        decisionImpact: synthesis.decisionStyle,
+        action:
+          synthesis.practicalGuidance.find((item) =>
+            /decision|analysis|thought|pause|move/i.test(item),
+          ) ?? "Set a decision point before gathering another round of information.",
+      },
+      tensionAxes: axesFromText(decisionStyle),
+      limitations: [
+        "Decision style can change by context, stakes, fatigue, and available information.",
+      ],
+    });
+  } else {
+    missingData.push("Mirror decision style is missing.");
+  }
+
+  if (profile.mirror?.energyStyle) {
+    const energyStyle = profile.mirror.energyStyle;
+    addSeed(seeds, {
+      evidence: makeEvidence(profile, {
+        id: "mirror.energy-style",
+        system: "mirror",
+        field: "mirror.energyStyle",
+        value: energyStyle,
+        userSupplied: true,
+      }),
+      label: `the reported energy style ${energyStyle}`,
+      priority: 115,
+      facets: {
+        visiblePattern: `The reported energy style is ${energyStyle}.`,
+        innerExperience: `The person's own account of energy is ${energyStyle}, which should override a conflicting symbolic interpretation.`,
+      },
+      tensionAxes: axesFromText(energyStyle),
+      limitations: [
+        "Energy style is a self-report and may vary across environments or health conditions.",
+      ],
+    });
+  }
+
+  if (profile.mirror?.conflictStyle) {
+    const conflictStyle = profile.mirror.conflictStyle;
+    addSeed(seeds, {
+      evidence: makeEvidence(profile, {
+        id: "mirror.conflict-style",
+        system: "mirror",
+        field: "mirror.conflictStyle",
+        value: conflictStyle,
+        userSupplied: true,
+      }),
+      label: `the reported conflict style ${conflictStyle}`,
+      priority: 110,
+      facets: {
+        relationshipImpact: `The reported conflict style is ${conflictStyle}.`,
+        commonMisreading: `A conflict response of ${conflictStyle.toLowerCase()} may be mistaken for the person's full intention.`,
+        boundaryOrRepair: `Clarify the goal of the conversation before using the usual ${conflictStyle.toLowerCase()} response.`,
+      },
+      tensionAxes: axesFromText(conflictStyle),
+      limitations: [
+        "A reported conflict style does not establish how every relationship operates.",
+      ],
+    });
+  }
+
+  profile.mirror?.nuance?.forEach((nuance, index) => {
+    if (!nuance.trim()) return;
+    addSeed(seeds, {
+      evidence: makeEvidence(profile, {
+        id: `mirror.nuance.${index + 1}`,
+        system: "user-stated",
+        field: `mirror.nuance[${index}]`,
+        value: nuance,
+        userSupplied: true,
+      }),
+      label: `user-supplied nuance ${index + 1}`,
+      priority: 140 - index,
+      facets: {
+        innerExperience:
+          "A user-supplied nuance is available and should override any conflicting generalized interpretation.",
+      },
+      limitations: [
+        "The nuance is authoritative for the user's lived experience but may be specific to one context.",
+      ],
+    });
+  });
+
+  const sunSign = profile.chart?.sun?.sign;
+  const sunTrait = sunSign ? SIGN_TRAITS[sunSign] : undefined;
+  if (sunSign && sunTrait) {
+    addSeed(seeds, {
+      evidence: makeEvidence(profile, {
+        id: "astrology.sun.sign",
+        system: "astrology",
+        field: "chart.sun.sign",
+        value: sunSign,
+      }),
+      label: `Sun in ${sunSign}`,
+      priority: 90,
+      facets: {
+        claritySummary: `The Sun-sign calculation emphasizes ${sunTrait.drive}.`,
+        gift: `At its constructive edge, this supports ${sunTrait.drive}.`,
+        shadow: `When overextended, the same pattern can become ${sunTrait.shadow}.`,
+      },
+      tensionAxes: axesFromText(`${sunTrait.drive} ${sunTrait.shadow}`),
+      limitations: [
+        "A Sun-sign interpretation is one symbolic input and must not override lived experience.",
+      ],
+    });
+  } else {
+    missingData.push("Sun-sign data is missing or unsupported.");
+  }
+
+  const moonSign = profile.chart?.moon?.sign;
+  const moonTrait = moonSign ? SIGN_TRAITS[moonSign] : undefined;
+  if (moonSign && moonTrait) {
+    addSeed(seeds, {
+      evidence: makeEvidence(profile, {
+        id: "astrology.moon.sign",
+        system: "astrology",
+        field: "chart.moon.sign",
+        value: moonSign,
+        notes:
+          birthTimeStatus === "unknown"
+            ? [
+                "Only the supplied Moon sign is used; Moon degree and house claims remain unavailable.",
+              ]
+            : undefined,
+      }),
+      label: `Moon in ${moonSign}`,
+      priority: 95,
+      facets: {
+        innerExperience: `The Moon-sign calculation points toward ${moonTrait.drive} as a possible internal organizing pattern.`,
+        hiddenNeed: `Consistency with ${moonTrait.drive} may matter internally even when it is not obvious externally.`,
+        relationshipImpact: `Emotional safety may be supported by ${moonTrait.drive}.`,
+      },
+      tensionAxes: axesFromText(`${moonTrait.drive} ${moonTrait.shadow}`),
+      limitations: [
+        "Moon-sign interpretation does not establish a private emotional fact.",
+      ],
+    });
+  } else {
+    missingData.push("Moon-sign data is missing or unsupported.");
+  }
+
+  const risingSign = profile.chart?.rising?.sign;
+  const risingTrait = risingSign ? SIGN_TRAITS[risingSign] : undefined;
+  if (risingSign && risingTrait) {
+    addSeed(seeds, {
+      evidence: makeEvidence(profile, {
+        id: "astrology.rising.sign",
+        system: "astrology",
+        field: "chart.rising.sign",
+        value: risingSign,
+        timeSensitivity: "birth-time-required",
+      }),
+      label: `Rising sign in ${risingSign}`,
+      priority: 100,
+      facets: {
+        visiblePattern: `A ${risingSign} Rising calculation may shape first impressions through ${risingTrait.drive}.`,
+        commonMisreading:
+          "Other people may treat the first-impression pattern as the whole person and miss less visible signals.",
+      },
+      tensionAxes: axesFromText(`${risingTrait.drive} ${risingTrait.shadow}`),
+      limitations: [
+        "Rising-sign interpretation depends on accurate birth time and location.",
+      ],
+    });
+  } else if (birthTimeStatus !== "unknown") {
+    missingData.push("Rising-sign data is missing.");
+  }
+
+  const venusSign = profile.chart?.venus?.sign;
+  const venusTrait = venusSign ? SIGN_TRAITS[venusSign] : undefined;
+  if (venusSign && venusTrait) {
+    addSeed(seeds, {
+      evidence: makeEvidence(profile, {
+        id: "astrology.venus.sign",
+        system: "astrology",
+        field: "chart.venus.sign",
+        value: venusSign,
+      }),
+      label: `Venus in ${venusSign}`,
+      priority: 70,
+      facets: {
+        relationshipImpact: `The Venus-sign calculation adds ${venusTrait.drive} as a possible relationship preference.`,
+      },
+      tensionAxes: axesFromText(venusTrait.drive),
+      limitations: [
+        "A Venus-sign interpretation cannot establish how a specific relationship functions.",
+      ],
+    });
+  }
+
+  const lifePath = profile.numerology?.lifePath;
+  const lifePathTrait = lifePath ? LIFE_PATH_TRAITS[lifePath] : undefined;
+  if (lifePath && lifePathTrait) {
+    addSeed(seeds, {
+      evidence: makeEvidence(profile, {
+        id: "numerology.life-path",
+        system: "numerology",
+        field: "numerology.lifePath",
+        value: lifePath,
+      }),
+      label: `Life Path ${lifePath} ${lifePathTrait.theme}`,
+      priority: 85,
+      facets: {
+        claritySummary: `Life Path ${lifePath} contributes ${lifePathTrait.drive} as a date-derived theme.`,
+        gift: `${lifePathTrait.theme} can be expressed through ${lifePathTrait.drive}.`,
+      },
+      tensionAxes: axesFromText(
+        `${lifePathTrait.theme} ${lifePathTrait.drive}`,
+      ),
+      limitations: [
+        "Numerology describes a symbolic theme, not a proven behavioral cause.",
+      ],
+    });
+  } else {
+    missingData.push("Life Path data is missing or unsupported.");
+  }
+
+  const hdType = profile.humanDesign?.type;
+  const hdTrait = hdType ? HD_TYPE_TRAITS[hdType] : undefined;
+  if (hdType && hdTrait) {
+    addSeed(seeds, {
+      evidence: makeEvidence(profile, {
+        id: "human-design.type",
+        system: "human-design",
+        field: "humanDesign.type",
+        value: hdType,
+        timeSensitivity: "birth-time-required",
+      }),
+      label: `Human Design type ${hdType}`,
+      priority: 80,
+      facets: {
+        visiblePattern: `The Human Design type calculation emphasizes ${hdTrait.strength}.`,
+        gift: `The constructive expression is ${hdTrait.strength}.`,
+        shadow: `Under pressure, the same type pattern may risk ${hdTrait.risk}.`,
+        commonMisreading:
+          "Other people may notice the type's visible strategy while missing the conditions it requires.",
+      },
+      tensionAxes: axesFromText(`${hdTrait.strength} ${hdTrait.risk}`),
+      limitations: [
+        "Human Design interpretation is time-sensitive and symbolic.",
+      ],
+    });
+  } else {
+    missingData.push("Human Design type is missing.");
+  }
+
+  if (profile.humanDesign?.authority) {
+    const authority = profile.humanDesign.authority;
+    addSeed(seeds, {
+      evidence: makeEvidence(profile, {
+        id: "human-design.authority",
+        system: "human-design",
+        field: "humanDesign.authority",
+        value: authority,
+        timeSensitivity: "birth-time-required",
+      }),
+      label: `Human Design authority ${authority}`,
+      priority: 82,
+      facets: {
+        decisionImpact: synthesis.decisionStyle,
+        action: `Test the stated ${authority} authority against lived decision outcomes rather than treating it as a command.`,
+      },
+      tensionAxes: axesFromText(authority),
+      limitations: [
+        "Authority interpretation requires accurate birth data and real-world validation.",
+      ],
+    });
+  }
+
+  if (profile.humanDesign?.strategy) {
+    const strategy = profile.humanDesign.strategy;
+    addSeed(seeds, {
+      evidence: makeEvidence(profile, {
+        id: "human-design.strategy",
+        system: "human-design",
+        field: "humanDesign.strategy",
+        value: strategy,
+        timeSensitivity: "birth-time-required",
+      }),
+      label: `Human Design strategy ${strategy}`,
+      priority: 78,
+      facets: {
+        decisionImpact: `The supplied Human Design strategy is ${strategy}.`,
+        action: `Use ${strategy.toLowerCase()} as an experiment and compare it with actual outcomes.`,
+      },
+      tensionAxes: axesFromText(strategy),
+      limitations: [
+        "A Human Design strategy is an experiment, not a universal decision rule.",
+      ],
+    });
+  }
+
+  if (profile.elements) {
+    const dominant = (
+      Object.entries(profile.elements) as Array<
+        ["earth" | "air" | "fire" | "water", number]
+      >
+    ).sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))[0];
+    const [element, score] = dominant;
+    const trait = ELEMENT_TRAITS[element];
+
+    addSeed(seeds, {
+      evidence: makeEvidence(profile, {
+        id: "elements.dominant",
+        system: "elements",
+        field: "elements.dominant",
+        value: `${element}:${score}`,
+      }),
+      label: `dominant ${element} element`,
+      priority: 75,
+      facets: {
+        visiblePattern: `The elemental balance emphasizes ${trait.gift}.`,
+        innerExperience: `The dominant ${element} pattern may organize experience through ${trait.gift}.`,
+        gift: `The elemental gift is ${trait.gift}.`,
+        shadow: `When overused, the elemental pattern may become ${trait.shadow}.`,
+      },
+      tensionAxes: axesFromText(`${trait.gift} ${trait.shadow}`),
+      limitations: [
+        "Elemental balance is a symbolic synthesis and should be compared with lived behavior.",
+      ],
+    });
+  } else {
+    missingData.push("Elemental balance is missing.");
+  }
+
+  if (profile.morals?.values?.length) {
+    const values = profile.morals.values.slice(0, 5).join(", ");
+    addSeed(seeds, {
+      evidence: makeEvidence(profile, {
+        id: "moral-compass.values",
+        system: "moral-compass",
+        field: "morals.values",
+        value: values,
+        userSupplied: true,
+      }),
+      label: `the stated values ${values}`,
+      priority: 105,
+      facets: {
+        hiddenNeed: `The stated values place ${values} near the center of trust and alignment.`,
+        relationshipImpact: synthesis.relationshipStyle,
+        boundaryOrRepair:
+          "Name which stated value is being protected before conflict becomes a judgment about character.",
+      },
+      tensionAxes: axesFromText(values),
+      limitations: [
+        "Stated values do not prove that every action will express them consistently.",
+      ],
+    });
+  } else {
+    missingData.push("Moral values are missing.");
+  }
+
+  if (profile.morals?.intolerances?.length) {
+    const intolerances = profile.morals.intolerances.slice(0, 5).join(", ");
+    addSeed(seeds, {
+      evidence: makeEvidence(profile, {
+        id: "moral-compass.intolerances",
+        system: "moral-compass",
+        field: "morals.intolerances",
+        value: intolerances,
+        userSupplied: true,
+      }),
+      label: `the stated intolerances ${intolerances}`,
+      priority: 100,
+      facets: {
+        protectiveFunction: `Strong reactions may be attempting to protect boundaries around ${intolerances}.`,
+        commonMisreading: `A strong reaction to ${intolerances} may be read as rigidity when it is protecting a stated boundary.`,
+        relationshipImpact: synthesis.relationshipStyle,
+        boundaryOrRepair:
+          "Separate the protected boundary from the intensity of the reaction used to defend it.",
+      },
+      tensionAxes: axesFromText(intolerances),
+      limitations: [
+        "An intolerance identifies a reported boundary; it does not establish another person's intent.",
+      ],
+    });
+  }
+
+  if (profile.timeline?.currentPhase) {
+    const phase = profile.timeline.currentPhase;
+    addSeed(seeds, {
+      evidence: makeEvidence(profile, {
+        id: "timeline.current-phase",
+        system: "timeline",
+        field: "timeline.currentPhase",
+        value: phase,
+      }),
+      label: `current timeline phase ${phase}`,
+      priority: 60,
+      facets: {
+        claritySummary: synthesis.currentPhaseMeaning,
+        action:
+          synthesis.practicalGuidance[0] ??
+          "Choose one grounded action that matches the current phase.",
+      },
+      tensionAxes: axesFromText(
+        `${phase} ${(profile.timeline.reasons ?? []).join(" ")}`,
+      ),
+      limitations: [
+        "Timeline phase meaning is contextual and does not predict a guaranteed event.",
+      ],
+    });
+  } else {
+    missingData.push("Current timeline phase is missing.");
+  }
+
+  if (birthTimeStatus === "unknown") {
+    missingData.push(
+      "Exact birth time is unknown; Rising sign, houses, angles, Moon degree, and time-sensitive Human Design claims are unavailable.",
+    );
+  }
+
+  return {
+    version: 1,
+    generatedAt: options.generatedAt ?? new Date().toISOString(),
+    birthTimeStatus,
+    seeds,
+    missingData,
+  };
+}
+
+export function synthesizeDepthCodex(
+  profile: SoulProfile,
+  options: DepthCodexOptions = {},
+): DepthInterpretationV1 {
+  return synthesizeDepthInterpretationV1(
+    normalizeSoulProfileForDepth(profile, options),
+  );
+}


### PR DESCRIPTION
## Summary

Implements Issue #105 as the second stacked delivery in the Codex Depth Initiative.

This PR adds deterministic, evidence-backed synthesis for `DepthInterpretationV1` while preserving the existing `synthesizeCodex(profile)` API and all current callers.

## Stack

- base: `feat/codex-depth-contract-v1` / PR #104
- head: `feat/codex-depth-synthesis-v1`
- parent epic: #102
- implementation issue: #105

This PR should be retargeted to `main` after PR #104 merges.

## What changed

### Normalized core synthesis

- added `DepthSynthesisInputV1`
- added evidence seeds with stable IDs, source fields, confidence, provenance, time sensitivity, facet support, priority, limitations, and tension axes
- added deterministic synthesis for every v1 interpretation layer
- added conservative layer and overall confidence handling
- added stable evidence ordering and deterministic serialization

### Contradiction detection

Added evidence-linked rules for:

- independence with consistency, partnership, or recognition
- speed with analysis
- structure with sensitivity
- harmony with directness
- freedom with stability

Detected contradictions are always labeled as inference and explicitly state that coexistence does not establish cause or biography.

### SoulProfile adapter

Added `normalizeSoulProfileForDepth()` and `synthesizeDepthCodex()`.

The adapter maps existing:

- Mirror driver, trigger, decision, energy, conflict, and nuance
- Sun, Moon, Rising, and Venus signs
- Life Path
- Human Design type, strategy, and authority
- elemental balance
- moral values and intolerances
- timeline phase
- established `synthesizeCodex()` output

User-supplied Mirror and values evidence receives higher selection priority than generalized symbolic mappings.

### Unknown-time degradation

- removes Rising-sign and time-sensitive Human Design evidence when birth time is unknown
- retains Sun sign, supplied Moon sign without degree or house claims, date-derived numerology, and user-supplied Mirror evidence
- degrades approximate-time evidence to low confidence with explicit limitations
- records missing time-sensitive fields instead of filling them with generic prose

### Compatibility

- existing `synthesizeCodex(profile)` remains unchanged
- no existing imports or callers were replaced
- the adapter does not mutate `SoulProfile`
- no UI, provider, prompt, formula, database, dependency, or lockfile changes

## Tests added

Focused coverage includes:

- valid complete synthesis
- evidence existence for every available layer
- supported and unsupported contradiction handling
- unknown-time evidence removal
- approximate-time confidence degradation
- deterministic serialization
- complete SoulProfile adapter output
- unavailable layers when profile data is missing
- user-stated evidence authority with inference limitations
- existing synthesis API and input immutability

## Validation completed

Because the inherited repository workflows currently fail at `npm install` before reaching code, validation was performed in an isolated strict TypeScript harness:

- core synthesis strict TypeScript compilation: passed
- application adapter strict TypeScript compilation: passed
- known-time runtime synthesis smoke: passed
- unknown-time filtering smoke: passed
- contradiction evidence linking smoke: passed
- known-time output through PR #104 validator: passed
- unknown-time output through PR #104 validator: passed

The repository dependency baseline failure is tracked separately in Issue #106.

## Diff scope

The stacked diff contains only:

- normalized synthesis types
- deterministic synthesis implementation
- SoulProfile adapter
- focused tests
- synthesis documentation
- additive exports and evidence-system identifiers

No dependency or lockfile churn is included.
