### PR TITLE
feat(soul-guide): generate layered clarity responses

### DIFF
--- a/packages/core/soul-guide/DEPTH_SOUL_GUIDE.md
+++ b/packages/core/soul-guide/DEPTH_SOUL_GUIDE.md
@@ -1,0 +1,47 @@
+# Layered Soul Guide
+
+The layered Soul Guide consumes a deterministic `DepthInterpretationV1` and may improve only its user-facing prose.
+
+## Locked Metadata
+
+The provider cannot change:
+
+- evidence or evidence IDs
+- claim kind
+- confidence
+- limitations
+- provenance
+- missing data
+- generated time
+- contract version
+- overall confidence
+
+The prompt requests only `title`, `summary`, and `explanation` for every layer. The parser rejects additional fields and merges accepted prose back onto the original deterministic interpretation.
+
+## Safety Boundary
+
+The parser rejects prose that introduces:
+
+- diagnoses or clinical labels
+- invented childhood or parental causes
+- trauma or attachment labels
+- unsupported hidden motives
+- fixed identity or guaranteed future claims
+
+The merged interpretation must still pass `validateDepthInterpretationV1`.
+
+## Fallback
+
+`createDepthSoulGuideFallback()` renders the same contract without an AI provider.
+
+The primary order is:
+
+1. Core Pattern
+2. Main Contradiction
+3. Next Move
+
+Deeper cards retain claim kind, confidence, evidence IDs, limitations, and unavailable status. Unknown birth time therefore remains visibly degraded in both live and fallback responses.
+
+## Compatibility
+
+The existing `SoulGuideInterpretation` v1 prompt, parser, cache key, and storage behavior remain unchanged. The layered API is additive.

--- a/packages/core/soul-guide/DEPTH_SOUL_GUIDE.md
+++ b/packages/core/soul-guide/DEPTH_SOUL_GUIDE.md
@@ -45,3 +45,7 @@ Deeper cards retain claim kind, confidence, evidence IDs, limitations, and unava
 ## Compatibility
 
 The existing `SoulGuideInterpretation` v1 prompt, parser, cache key, and storage behavior remain unchanged. The layered API is additive.
+
+## Validation Boundary
+
+The layered prompt, metadata-preserving parser, deterministic fallback, service adapter, workspace packages, and production build are verified by the repository's permanent CI workflows. Safety and evidence-lock rules remain executable test requirements rather than documentation promises.

--- a/packages/core/soul-guide/__tests__/depth-soul-guide.test.ts
+++ b/packages/core/soul-guide/__tests__/depth-soul-guide.test.ts
@@ -1,0 +1,302 @@
+import { test } from "node:test";
+import assert from "node:assert";
+import {
+  DEPTH_INTERPRETATION_LAYER_KEYS,
+  type DepthInterpretationV1,
+  type InterpretationLayer,
+} from "../../depth-interpretation/index.js";
+import {
+  createDepthSoulGuideFallback,
+  generateDepthSoulGuidePrompt,
+  generateSoulGuidePromptText,
+  parseDepthSoulGuideResponse,
+  parseSoulGuideResponse,
+  type SoulGuideDepthProseResponse,
+} from "../index.js";
+import type { TimelineIntelligenceSummary } from "../../timeline-intelligence/types.js";
+
+function layer(title: string): InterpretationLayer {
+  return {
+    title,
+    summary: `${title} is supported by the supplied pattern.`,
+    explanation: `${title} describes one possible expression of the supplied evidence without treating it as fixed identity.`,
+    claimKind: "inferred",
+    evidenceIds: ["mirror.driver"],
+    confidence: "high",
+    limitations: [
+      "This interpretation is limited to the supplied signals.",
+      "Lived experience may describe the pattern differently.",
+    ],
+  };
+}
+
+function sourceInterpretation(): DepthInterpretationV1 {
+  return {
+    version: 1,
+    generatedAt: "2026-07-24T17:00:00.000Z",
+    claritySummary: layer("Core pattern"),
+    visiblePattern: layer("Visible pattern"),
+    innerExperience: layer("Inner experience"),
+    hiddenNeed: layer("Hidden need"),
+    protectiveFunction: layer("Protective function"),
+    coreContradiction: layer("Core contradiction"),
+    gift: layer("Gift"),
+    shadow: layer("Shadow"),
+    commonMisreading: layer("Common misreading"),
+    relationshipImpact: layer("Relationship impact"),
+    decisionImpact: layer("Decision impact"),
+    boundaryOrRepair: layer("Boundary or repair"),
+    action: layer("Action"),
+    evidence: [
+      {
+        id: "mirror.driver",
+        system: "mirror",
+        field: "mirror.driver",
+        value: "Independence",
+        confidence: "high",
+        provenanceStatus: "partially-verified",
+        timeSensitivity: "none",
+        notes: ["User-supplied behavioral driver."],
+      },
+    ],
+    missingData: [],
+    overallConfidence: "high",
+  };
+}
+
+function proseResponse(
+  source: DepthInterpretationV1,
+): SoulGuideDepthProseResponse {
+  return Object.fromEntries(
+    DEPTH_INTERPRETATION_LAYER_KEYS.map((key) => [
+      key,
+      {
+        title: source[key].title,
+        summary: `Clear rewrite for ${key}.`,
+        explanation: `The supplied signals may support this ${key} pattern, while lived experience remains authoritative.`,
+      },
+    ]),
+  ) as unknown as SoulGuideDepthProseResponse;
+}
+
+function timelineSummary(): TimelineIntelligenceSummary {
+  return {
+    version: 1,
+    generatedAt: "2026-07-24T17:00:00.000Z",
+    sampleSize: 10,
+    confidence: "Moderate",
+    dateRange: { start: "2026-07-01", end: "2026-07-10" },
+    systemSignals: [],
+    livedSignals: [],
+    matches: [],
+    divergences: [],
+    alignmentScore: 0.5,
+    observations: [],
+    nextTrackingSuggestion: null,
+  };
+}
+
+test("Layered Soul Guide", async (suite) => {
+  await suite.test("prompt contains every layer and the evidence boundary", () => {
+    const source = sourceInterpretation();
+    const prompt = generateDepthSoulGuidePrompt(source);
+
+    for (const key of DEPTH_INTERPRETATION_LAYER_KEYS) {
+      assert.ok(prompt.includes(key), `prompt must include ${key}`);
+    }
+
+    assert.ok(prompt.includes("You may rewrite prose. You may not rewrite epistemology."));
+    assert.ok(prompt.includes("mirror.driver"));
+    assert.ok(prompt.includes("Lived experience overrides"));
+    assert.ok(prompt.includes("Do not return evidenceIds"));
+  });
+
+  await suite.test("prompt forbids biography, trauma, diagnosis, and certainty invention", () => {
+    const prompt = generateDepthSoulGuidePrompt(sourceInterpretation());
+
+    assert.ok(prompt.includes("childhood causes"));
+    assert.ok(prompt.includes("trauma"));
+    assert.ok(prompt.includes("attachment styles"));
+    assert.ok(prompt.includes("diagnoses"));
+    assert.ok(prompt.includes("Do not predict the future"));
+  });
+
+  await suite.test("parser accepts safe prose and preserves locked metadata", () => {
+    const source = sourceInterpretation();
+    const result = parseDepthSoulGuideResponse(
+      JSON.stringify(proseResponse(source)),
+      source,
+      { birthTimeStatus: "known" },
+    );
+
+    assert.ok(result.interpretation);
+    assert.deepEqual(result.findings, []);
+    assert.deepEqual(result.interpretation?.evidence, source.evidence);
+    assert.deepEqual(result.interpretation?.missingData, source.missingData);
+    assert.equal(
+      result.interpretation?.overallConfidence,
+      source.overallConfidence,
+    );
+    assert.equal(result.interpretation?.generatedAt, source.generatedAt);
+    assert.equal(result.interpretation?.version, source.version);
+
+    for (const key of DEPTH_INTERPRETATION_LAYER_KEYS) {
+      assert.deepEqual(
+        result.interpretation?.[key].evidenceIds,
+        source[key].evidenceIds,
+      );
+      assert.deepEqual(
+        result.interpretation?.[key].limitations,
+        source[key].limitations,
+      );
+      assert.equal(
+        result.interpretation?.[key].claimKind,
+        source[key].claimKind,
+      );
+      assert.equal(
+        result.interpretation?.[key].confidence,
+        source[key].confidence,
+      );
+    }
+  });
+
+  await suite.test("parser rejects missing layers", () => {
+    const source = sourceInterpretation();
+    const prose = proseResponse(source) as unknown as Record<string, unknown>;
+    delete prose.hiddenNeed;
+
+    const result = parseDepthSoulGuideResponse(JSON.stringify(prose), source);
+
+    assert.equal(result.interpretation, null);
+    assert.ok(result.findings.some((finding) => finding.code === "missing-layer"));
+  });
+
+  await suite.test("parser rejects attempts to change locked layer metadata", () => {
+    const source = sourceInterpretation();
+    const prose = proseResponse(source) as unknown as Record<
+      string,
+      Record<string, unknown>
+    >;
+    prose.claritySummary.evidenceIds = ["invented.evidence"];
+    prose.claritySummary.confidence = "high";
+
+    const result = parseDepthSoulGuideResponse(JSON.stringify(prose), source);
+
+    assert.equal(result.interpretation, null);
+    assert.ok(
+      result.findings.some(
+        (finding) => finding.code === "attempted-metadata-rewrite",
+      ),
+    );
+  });
+
+  await suite.test("parser rejects attempts to change top-level metadata", () => {
+    const source = sourceInterpretation();
+    const prose = proseResponse(source) as unknown as Record<string, unknown>;
+    prose.evidence = [{ id: "invented.evidence" }];
+    prose.overallConfidence = "high";
+
+    const result = parseDepthSoulGuideResponse(JSON.stringify(prose), source);
+
+    assert.equal(result.interpretation, null);
+    assert.ok(
+      result.findings.some(
+        (finding) =>
+          finding.code === "attempted-top-level-metadata-rewrite",
+      ),
+    );
+  });
+
+  await suite.test("parser rejects unsafe biography and diagnostic wording", () => {
+    const unsafePhrases = [
+      "Your childhood taught you never to depend on anyone.",
+      "This is a trauma response.",
+      "You have an avoidant attachment style.",
+      "This diagnosis proves that the pattern is permanent.",
+      "You will always repeat this behavior.",
+    ];
+
+    for (const unsafe of unsafePhrases) {
+      const source = sourceInterpretation();
+      const prose = proseResponse(source);
+      prose.hiddenNeed.explanation = unsafe;
+
+      const result = parseDepthSoulGuideResponse(
+        JSON.stringify(prose),
+        source,
+      );
+
+      assert.equal(result.interpretation, null, unsafe);
+      assert.ok(result.findings.length > 0, unsafe);
+    }
+  });
+
+  await suite.test("fallback follows clarity-first card order", () => {
+    const fallback = createDepthSoulGuideFallback(sourceInterpretation());
+
+    assert.deepEqual(
+      fallback.primaryCards.map((card) => card.key),
+      ["claritySummary", "coreContradiction", "action"],
+    );
+    assert.equal(fallback.cards[0].key, "claritySummary");
+    assert.equal(fallback.cards[1].key, "coreContradiction");
+    assert.equal(fallback.cards[2].key, "action");
+  });
+
+  await suite.test("fallback detail cards retain evidence and limitations", () => {
+    const fallback = createDepthSoulGuideFallback(sourceInterpretation());
+
+    for (const card of fallback.cards) {
+      assert.deepEqual(card.evidenceIds, ["mirror.driver"]);
+      assert.ok(card.limitations.length > 0);
+      assert.equal(card.confidence, "high");
+      assert.equal(card.claimKind, "inferred");
+    }
+
+    assert.ok(fallback.markdown.includes("**Evidence:** mirror.driver"));
+    assert.ok(fallback.markdown.includes("Lived experience remains"));
+  });
+
+  await suite.test("unknown-time degradation survives safe prose rewriting", () => {
+    const source = sourceInterpretation();
+    source.missingData = [
+      "Exact birth time is unknown; Rising sign and time-sensitive Human Design claims are unavailable.",
+    ];
+    source.overallConfidence = "moderate";
+
+    const result = parseDepthSoulGuideResponse(
+      JSON.stringify(proseResponse(source)),
+      source,
+      { birthTimeStatus: "unknown" },
+    );
+
+    assert.ok(result.interpretation);
+    assert.deepEqual(result.interpretation?.missingData, source.missingData);
+    assert.equal(result.interpretation?.overallConfidence, "moderate");
+    assert.equal(
+      result.interpretation?.evidence.some(
+        (item) => item.timeSensitivity === "birth-time-required",
+      ),
+      false,
+    );
+  });
+
+  await suite.test("existing Soul Guide v1 prompt and parser remain compatible", () => {
+    const prompt = generateSoulGuidePromptText(timelineSummary());
+    assert.ok(prompt.includes('"theme"'));
+    assert.ok(prompt.includes('"narrative"'));
+
+    const parsed = parseSoulGuideResponse(
+      JSON.stringify({
+        theme: "A stable theme",
+        narrative: "A stable narrative",
+        reflectionPrompts: ["One"],
+        nextSteps: ["Two"],
+        keyInsights: ["Three"],
+      }),
+    );
+
+    assert.equal(parsed?.theme, "A stable theme");
+    assert.equal(parsed?.version, 1);
+  });
+});

--- a/packages/core/soul-guide/depth-fallback.ts
+++ b/packages/core/soul-guide/depth-fallback.ts
@@ -1,0 +1,166 @@
+import type {
+  DepthInterpretationLayerKey,
+  DepthInterpretationV1,
+  InterpretationLayer,
+} from "../depth-interpretation/types.js";
+import type {
+  SoulGuideDepthCard,
+  SoulGuideDepthFallbackResult,
+} from "./depth-types.js";
+
+const PRIMARY_CARD_KEYS: readonly DepthInterpretationLayerKey[] = [
+  "claritySummary",
+  "coreContradiction",
+  "action",
+];
+
+const DETAIL_CARD_KEYS: readonly DepthInterpretationLayerKey[] = [
+  "visiblePattern",
+  "innerExperience",
+  "hiddenNeed",
+  "protectiveFunction",
+  "gift",
+  "shadow",
+  "commonMisreading",
+  "relationshipImpact",
+  "decisionImpact",
+  "boundaryOrRepair",
+];
+
+const PROMPT_TEMPLATES: Partial<
+  Record<DepthInterpretationLayerKey, string>
+> = {
+  coreContradiction:
+    "Where do both sides of the main contradiction show up in the same situation?",
+  hiddenNeed:
+    "Which possible need feels accurate, and which part does not match lived experience?",
+  protectiveFunction:
+    "What is this pattern trying to preserve, and what does that protection cost?",
+  commonMisreading:
+    "What do other people usually misunderstand about this pattern?",
+  relationshipImpact:
+    "How does this pattern affect trust, closeness, or conflict in one real relationship?",
+  decisionImpact:
+    "Which recent decision shows this pattern most clearly?",
+  boundaryOrRepair:
+    "What boundary or repair needs to be stated plainly rather than implied?",
+  action:
+    "What would make the next move small enough to test today?",
+};
+
+function toCard(
+  key: DepthInterpretationLayerKey,
+  layer: InterpretationLayer,
+): SoulGuideDepthCard {
+  return {
+    key,
+    title: layer.title,
+    body: [layer.summary, layer.explanation].filter(Boolean).join("\n\n"),
+    summary: layer.summary,
+    explanation: layer.explanation,
+    confidence: layer.confidence,
+    claimKind: layer.claimKind,
+    evidenceIds: [...layer.evidenceIds],
+    limitations: [...layer.limitations],
+    unavailable: layer.claimKind === "unavailable",
+  };
+}
+
+function reflectionPrompts(
+  interpretation: DepthInterpretationV1,
+): string[] {
+  const prompts: string[] = [];
+  const preferredKeys: readonly DepthInterpretationLayerKey[] = [
+    "coreContradiction",
+    "hiddenNeed",
+    "protectiveFunction",
+    "commonMisreading",
+    "relationshipImpact",
+    "decisionImpact",
+    "boundaryOrRepair",
+    "action",
+  ];
+
+  for (const key of preferredKeys) {
+    if (interpretation[key].claimKind === "unavailable") continue;
+    const prompt = PROMPT_TEMPLATES[key];
+    if (prompt && !prompts.includes(prompt)) prompts.push(prompt);
+    if (prompts.length === 3) break;
+  }
+
+  if (prompts.length < 3) {
+    const fallbacks = [
+      "Which part of this reading matches lived experience most clearly?",
+      "Which part needs correction, more context, or better evidence?",
+      "What one observable result would show whether the next action helped?",
+    ];
+
+    for (const prompt of fallbacks) {
+      if (!prompts.includes(prompt)) prompts.push(prompt);
+      if (prompts.length === 3) break;
+    }
+  }
+
+  return prompts;
+}
+
+function renderCardMarkdown(card: SoulGuideDepthCard): string {
+  const evidence =
+    card.evidenceIds.length > 0 ? card.evidenceIds.join(", ") : "none available";
+  const limitations =
+    card.limitations.length > 0
+      ? card.limitations.map((item) => `- ${item}`).join("\n")
+      : "- None recorded.";
+
+  return `## ${card.title}\n\n${card.body}\n\n**Claim:** ${card.claimKind}  \n**Confidence:** ${card.confidence}  \n**Evidence:** ${evidence}\n\n**Limitations**\n${limitations}`;
+}
+
+export function renderDepthSoulGuideMarkdown(
+  interpretation: DepthInterpretationV1,
+): string {
+  const primaryCards = PRIMARY_CARD_KEYS.map((key) =>
+    toCard(key, interpretation[key]),
+  );
+  const detailCards = DETAIL_CARD_KEYS.map((key) =>
+    toCard(key, interpretation[key]),
+  );
+  const prompts = reflectionPrompts(interpretation);
+  const missingData =
+    interpretation.missingData.length > 0
+      ? interpretation.missingData.map((item) => `- ${item}`).join("\n")
+      : "- No material missing data recorded.";
+
+  return [
+    "# Soul Guide: Clarity First",
+    ...primaryCards.map(renderCardMarkdown),
+    "# Deeper Layers",
+    ...detailCards.map(renderCardMarkdown),
+    `# Overall Confidence\n\n${interpretation.overallConfidence}`,
+    `# Missing Data\n\n${missingData}`,
+    `# Reflection Prompts\n\n${prompts.map((prompt) => `- ${prompt}`).join("\n")}`,
+    "Lived experience remains the final authority. Correct any layer that does not match it.",
+  ].join("\n\n");
+}
+
+export function createDepthSoulGuideFallback(
+  interpretation: DepthInterpretationV1,
+): SoulGuideDepthFallbackResult {
+  const primaryCards = PRIMARY_CARD_KEYS.map((key) =>
+    toCard(key, interpretation[key]),
+  );
+  const detailCards = DETAIL_CARD_KEYS.map((key) =>
+    toCard(key, interpretation[key]),
+  );
+
+  return {
+    status: "fallback",
+    message:
+      "Using deterministic, evidence-linked guidance from your Codex. Lived experience remains the final authority.",
+    primaryCards,
+    detailCards,
+    cards: [...primaryCards, ...detailCards],
+    prompts: reflectionPrompts(interpretation),
+    interpretation,
+    markdown: renderDepthSoulGuideMarkdown(interpretation),
+  };
+}

--- a/packages/core/soul-guide/depth-parser.ts
+++ b/packages/core/soul-guide/depth-parser.ts
@@ -1,0 +1,270 @@
+import {
+  DEPTH_INTERPRETATION_LAYER_KEYS,
+  validateDepthInterpretationV1,
+  type DepthInterpretationLayerKey,
+  type DepthInterpretationV1,
+  type DepthValidationContext,
+} from "../depth-interpretation/index.js";
+import type {
+  SoulGuideDepthParseFinding,
+  SoulGuideDepthParseResult,
+  SoulGuideDepthProse,
+  SoulGuideDepthProseResponse,
+} from "./depth-types.js";
+
+const ALLOWED_PROSE_FIELDS = new Set(["title", "summary", "explanation"]);
+
+const PROSE_SAFETY_RULES: ReadonlyArray<{
+  code: string;
+  pattern: RegExp;
+  message: string;
+}> = [
+  {
+    code: "diagnostic-wording",
+    pattern:
+      /\b(?:diagnos(?:e|ed|is)|mental illness|personality disorder|psychopath|sociopath|narcissist(?:ic)? disorder)\b/i,
+    message: "Soul Guide prose must not diagnose or assign clinical labels.",
+  },
+  {
+    code: "invented-biography",
+    pattern:
+      /\b(?:your childhood|when you were a child|your parents?|your mother|your father|your caregiver|grew up|because you were raised|taught you never|learned as a child)\b/i,
+    message:
+      "Soul Guide prose must not invent childhood, parental, or biographical causes.",
+  },
+  {
+    code: "invented-trauma-or-attachment",
+    pattern:
+      /\b(?:trauma response|trauma wound|traumatized|attachment style|attachment wound|anxious attachment|avoidant attachment|abandonment wound)\b/i,
+    message:
+      "Soul Guide prose must not infer trauma or attachment labels from symbolic data.",
+  },
+  {
+    code: "deterministic-wording",
+    pattern:
+      /\b(?:you (?:will|always|never)|destined to|guaranteed to|cannot change|fixed identity|proves that|definitely means)\b/i,
+    message:
+      "Soul Guide prose must not present identity or future behavior as fixed.",
+  },
+  {
+    code: "invented-hidden-cause",
+    pattern:
+      /\b(?:the cause is|this happened because|the real reason is|deep down you know)\b/i,
+    message:
+      "Soul Guide prose must not declare an unsupported hidden cause or motive.",
+  },
+];
+
+function addFinding(
+  findings: SoulGuideDepthParseFinding[],
+  code: string,
+  path: string,
+  message: string,
+): void {
+  findings.push({ code, path, message });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function extractJsonObject(response: string): unknown {
+  const trimmed = response.trim();
+  const start = trimmed.indexOf("{");
+  const end = trimmed.lastIndexOf("}");
+
+  if (start < 0 || end < start) {
+    throw new Error("No JSON object was found in the response.");
+  }
+
+  return JSON.parse(trimmed.slice(start, end + 1));
+}
+
+function scanProseSafety(
+  findings: SoulGuideDepthParseFinding[],
+  path: string,
+  value: string,
+): void {
+  for (const rule of PROSE_SAFETY_RULES) {
+    if (rule.pattern.test(value)) {
+      addFinding(findings, rule.code, path, rule.message);
+    }
+  }
+}
+
+function parseLayerProse(
+  raw: unknown,
+  layerKey: DepthInterpretationLayerKey,
+  findings: SoulGuideDepthParseFinding[],
+): SoulGuideDepthProse | null {
+  if (!isRecord(raw)) {
+    addFinding(
+      findings,
+      "invalid-layer-object",
+      layerKey,
+      "Each layer must be an object containing title, summary, and explanation.",
+    );
+    return null;
+  }
+
+  for (const key of Object.keys(raw)) {
+    if (!ALLOWED_PROSE_FIELDS.has(key)) {
+      addFinding(
+        findings,
+        "attempted-metadata-rewrite",
+        `${layerKey}.${key}`,
+        `Field "${key}" is locked. The AI may return prose fields only.`,
+      );
+    }
+  }
+
+  const prose: Partial<SoulGuideDepthProse> = {};
+
+  for (const field of ["title", "summary", "explanation"] as const) {
+    const value = raw[field];
+
+    if (typeof value !== "string" || value.trim().length === 0) {
+      addFinding(
+        findings,
+        "missing-layer-prose",
+        `${layerKey}.${field}`,
+        `Layer "${layerKey}" requires a non-empty ${field}.`,
+      );
+      continue;
+    }
+
+    const cleanValue = value.trim();
+    prose[field] = cleanValue;
+    scanProseSafety(findings, `${layerKey}.${field}`, cleanValue);
+  }
+
+  if (!prose.title || !prose.summary || !prose.explanation) {
+    return null;
+  }
+
+  return prose as SoulGuideDepthProse;
+}
+
+function parseProseResponse(
+  parsed: unknown,
+  findings: SoulGuideDepthParseFinding[],
+): SoulGuideDepthProseResponse | null {
+  if (!isRecord(parsed)) {
+    addFinding(
+      findings,
+      "invalid-response-shape",
+      "$",
+      "The response must be one JSON object keyed by interpretation layer.",
+    );
+    return null;
+  }
+
+  const requiredKeys = new Set<string>(DEPTH_INTERPRETATION_LAYER_KEYS);
+
+  for (const key of Object.keys(parsed)) {
+    if (!requiredKeys.has(key)) {
+      addFinding(
+        findings,
+        "attempted-top-level-metadata-rewrite",
+        key,
+        `Top-level field "${key}" is not editable and must not be returned.`,
+      );
+    }
+  }
+
+  const prose = {} as SoulGuideDepthProseResponse;
+  let complete = true;
+
+  for (const layerKey of DEPTH_INTERPRETATION_LAYER_KEYS) {
+    if (!(layerKey in parsed)) {
+      addFinding(
+        findings,
+        "missing-layer",
+        layerKey,
+        `The response is missing required layer "${layerKey}".`,
+      );
+      complete = false;
+      continue;
+    }
+
+    const layerProse = parseLayerProse(parsed[layerKey], layerKey, findings);
+    if (!layerProse) {
+      complete = false;
+      continue;
+    }
+
+    prose[layerKey] = layerProse;
+  }
+
+  return complete ? prose : null;
+}
+
+function mergeLockedInterpretation(
+  source: DepthInterpretationV1,
+  prose: SoulGuideDepthProseResponse,
+): DepthInterpretationV1 {
+  const merged: DepthInterpretationV1 = {
+    ...source,
+    evidence: source.evidence.map((item) => ({
+      ...item,
+      notes: item.notes ? [...item.notes] : undefined,
+    })),
+    missingData: [...source.missingData],
+  };
+
+  for (const layerKey of DEPTH_INTERPRETATION_LAYER_KEYS) {
+    merged[layerKey] = {
+      ...source[layerKey],
+      title: prose[layerKey].title,
+      summary: prose[layerKey].summary,
+      explanation: prose[layerKey].explanation,
+      evidenceIds: [...source[layerKey].evidenceIds],
+      limitations: [...source[layerKey].limitations],
+    };
+  }
+
+  return merged;
+}
+
+export function parseDepthSoulGuideResponse(
+  response: string,
+  source: DepthInterpretationV1,
+  context: DepthValidationContext = {},
+): SoulGuideDepthParseResult {
+  const findings: SoulGuideDepthParseFinding[] = [];
+  let parsed: unknown;
+
+  try {
+    parsed = extractJsonObject(response);
+  } catch (error) {
+    addFinding(
+      findings,
+      "invalid-json",
+      "$",
+      error instanceof Error ? error.message : "The response is not valid JSON.",
+    );
+    return { interpretation: null, findings };
+  }
+
+  const prose = parseProseResponse(parsed, findings);
+  if (!prose || findings.length > 0) {
+    return { interpretation: null, findings };
+  }
+
+  const interpretation = mergeLockedInterpretation(source, prose);
+  const validation = validateDepthInterpretationV1(interpretation, context);
+
+  for (const finding of validation.findings) {
+    addFinding(
+      findings,
+      `contract-${finding.code}`,
+      finding.path,
+      finding.message,
+    );
+  }
+
+  return {
+    interpretation: validation.valid ? interpretation : null,
+    findings,
+  };
+}

--- a/packages/core/soul-guide/depth-prompt.ts
+++ b/packages/core/soul-guide/depth-prompt.ts
@@ -1,0 +1,87 @@
+import {
+  DEPTH_INTERPRETATION_LAYER_KEYS,
+  type DepthInterpretationV1,
+} from "../depth-interpretation/types.js";
+import type {
+  SoulGuideDepthPromptOptions,
+  SoulGuideDepthProseResponse,
+} from "./depth-types.js";
+
+const LAYER_ORDER_LABELS = [
+  "claritySummary",
+  "coreContradiction",
+  "action",
+  "visiblePattern",
+  "innerExperience",
+  "hiddenNeed",
+  "protectiveFunction",
+  "gift",
+  "shadow",
+  "commonMisreading",
+  "relationshipImpact",
+  "decisionImpact",
+  "boundaryOrRepair",
+] as const;
+
+function proseShape(): SoulGuideDepthProseResponse {
+  return Object.fromEntries(
+    DEPTH_INTERPRETATION_LAYER_KEYS.map((key) => [
+      key,
+      {
+        title: `<plain-language title for ${key}>`,
+        summary: `<concise summary for ${key}>`,
+        explanation: `<grounded explanation for ${key}>`,
+      },
+    ]),
+  ) as unknown as SoulGuideDepthProseResponse;
+}
+
+export function generateDepthSoulGuidePrompt(
+  source: DepthInterpretationV1,
+  options: SoulGuideDepthPromptOptions = {},
+): string {
+  const tone = options.tone ?? "plain";
+
+  return `You are the prose layer for an evidence-bound Soul Codex interpretation.
+
+Your job is to improve clarity. You may rewrite prose. You may not rewrite epistemology.
+
+## Authoritative Source Contract
+
+The JSON below is the complete evidence boundary. It already contains the only allowed evidence, claim kinds, confidence levels, limitations, missing data, and birth-time degradation.
+
+${JSON.stringify(source, null, 2)}
+
+## Non-Negotiable Rules
+
+1. Use only the source contract above. Do not add evidence, placements, events, motives, or history.
+2. Do not change, upgrade, reinterpret, or restate evidence IDs, claim kinds, confidence, limitations, provenance, missing data, or overall confidence.
+3. Do not invent childhood causes, parental causes, trauma, attachment styles, diagnoses, disorders, wounds, or hidden biography.
+4. Do not predict the future or describe identity as fixed. Avoid "always," "never," "destined," "guaranteed," and similar certainty.
+5. Inferred layers must remain calibrated. Use language such as "may," "can," "one possible function," or "the supplied signals suggest."
+6. Unavailable layers must remain unavailable. Do not fill missing data with generic personality prose.
+7. Lived experience overrides any conflicting interpretation.
+8. Explain visible behavior, contradiction, protection, cost, and next action only when the source layer supports them.
+9. Keep the tone ${tone}, clear, grounded, and readable. Do not use mystical filler or clinical authority.
+10. Return valid JSON only. Do not include Markdown fences or commentary.
+
+## Reading Order
+
+Write the strongest user-facing material first in this conceptual order:
+${LAYER_ORDER_LABELS.map((key, index) => `${index + 1}. ${key}`).join("\n")}
+
+## Editable Surface
+
+Return exactly one object containing every required layer key. Each layer may contain only:
+
+- title
+- summary
+- explanation
+
+Do not return evidenceIds, claimKind, confidence, limitations, evidence, missingData, generatedAt, version, or overallConfidence. Those fields are locked and will be restored from the deterministic source after parsing.
+
+## Required JSON Shape
+
+${JSON.stringify(proseShape(), null, 2)}
+`;
+}

--- a/packages/core/soul-guide/depth-types.ts
+++ b/packages/core/soul-guide/depth-types.ts
@@ -1,0 +1,56 @@
+import type {
+  DepthInterpretationLayerKey,
+  DepthInterpretationV1,
+  InterpretationClaimKind,
+  InterpretationConfidence,
+} from "../depth-interpretation/types.js";
+
+export interface SoulGuideDepthProse {
+  title: string;
+  summary: string;
+  explanation: string;
+}
+
+export type SoulGuideDepthProseResponse = Record<
+  DepthInterpretationLayerKey,
+  SoulGuideDepthProse
+>;
+
+export interface SoulGuideDepthParseFinding {
+  code: string;
+  path: string;
+  message: string;
+}
+
+export interface SoulGuideDepthParseResult {
+  interpretation: DepthInterpretationV1 | null;
+  findings: SoulGuideDepthParseFinding[];
+}
+
+export interface SoulGuideDepthPromptOptions {
+  tone?: "plain" | "reflective" | "analytical";
+}
+
+export interface SoulGuideDepthCard {
+  key: DepthInterpretationLayerKey;
+  title: string;
+  body: string;
+  summary: string;
+  explanation: string;
+  confidence: InterpretationConfidence;
+  claimKind: InterpretationClaimKind;
+  evidenceIds: string[];
+  limitations: string[];
+  unavailable: boolean;
+}
+
+export interface SoulGuideDepthFallbackResult {
+  status: "fallback";
+  message: string;
+  primaryCards: SoulGuideDepthCard[];
+  detailCards: SoulGuideDepthCard[];
+  cards: SoulGuideDepthCard[];
+  prompts: string[];
+  interpretation: DepthInterpretationV1;
+  markdown: string;
+}

--- a/packages/core/soul-guide/index.ts
+++ b/packages/core/soul-guide/index.ts
@@ -5,6 +5,10 @@ import type { TimelineIntelligenceSummary } from "../timeline-intelligence/types
 const STORAGE_KEY = "soulcodex.soulGuide.v1";
 
 export type { SoulGuideInterpretation, SoulGuideOptions };
+export * from "./depth-types.js";
+export * from "./depth-prompt.js";
+export * from "./depth-parser.js";
+export * from "./depth-fallback.js";
 
 /**
  * Generates a Soul Guide prompt for Claude to interpret Timeline Intelligence data.

--- a/services/__tests__/soul-guide-fallback.test.ts
+++ b/services/__tests__/soul-guide-fallback.test.ts
@@ -1,0 +1,121 @@
+import { test } from "node:test";
+import assert from "node:assert";
+import type { SoulProfile } from "../../src/types/soulcodex.js";
+import {
+  answerFromProfile,
+  soulGuideFallback,
+} from "../soul-guide-fallback.js";
+
+function completeProfile(): SoulProfile {
+  return {
+    birth: {
+      name: "Fallback Test",
+      birthDate: "1990-09-17",
+      birthTime: "11:11",
+      birthPlace: "Bronx, New York",
+      timeKnown: true,
+    },
+    confidence: {
+      badge: "partial",
+      label: "Partially verified",
+      reason: "Birth details are supplied but not externally documented.",
+    },
+    mirror: {
+      driver: "Independence",
+      shadowTrigger: "Loss of control",
+      decisionStyle: "Analytical logic",
+      energyStyle: "Fast and independent",
+      conflictStyle: "Direct confrontation",
+      nuance: ["Consistency matters more than people first assume."],
+    },
+    numerology: {
+      lifePath: 4,
+    },
+    chart: {
+      sun: { planet: "Sun", sign: "Virgo" },
+      moon: { planet: "Moon", sign: "Cancer" },
+      rising: { planet: "Ascendant", sign: "Scorpio" },
+      venus: { planet: "Venus", sign: "Libra" },
+    },
+    humanDesign: {
+      type: "Manifestor",
+      strategy: "Inform before acting",
+      authority: "Emotional",
+      profile: "2/5",
+    },
+    elements: {
+      earth: 4,
+      air: 2,
+      fire: 3,
+      water: 3,
+    },
+    morals: {
+      values: ["Consistency", "Honesty"],
+      intolerances: ["Dishonesty", "Control"],
+      crisisResponse: "Solve the immediate problem",
+    },
+    timeline: {
+      currentPhase: "Construction",
+      reasons: ["Long-term systems are becoming the main focus"],
+    },
+  };
+}
+
+test("Soul Guide service fallback", async (suite) => {
+  await suite.test("returns layered clarity cards for a complete profile", () => {
+    const result = soulGuideFallback(completeProfile());
+
+    assert.deepEqual(
+      result.primaryCards?.map((card) => card.key),
+      ["claritySummary", "coreContradiction", "action"],
+    );
+    assert.ok(result.interpretation);
+    assert.ok(result.markdown?.includes("# Soul Guide: Clarity First"));
+    assert.ok(
+      result.cards.some((card) => card.body.includes("mirror.driver")) ||
+        result.markdown?.includes("mirror.driver"),
+    );
+  });
+
+  await suite.test("keeps unknown-time evidence degraded", () => {
+    const profile = completeProfile();
+    profile.birth.timeKnown = false;
+    delete profile.birth.birthTime;
+
+    const result = soulGuideFallback(profile);
+    const evidenceIds = new Set(
+      result.interpretation?.evidence.map((item) => item.id) ?? [],
+    );
+
+    assert.equal(evidenceIds.has("astrology.rising.sign"), false);
+    assert.equal(evidenceIds.has("human-design.type"), false);
+    assert.ok(
+      result.interpretation?.missingData.some((item) =>
+        item.includes("Exact birth time is unknown"),
+      ),
+    );
+  });
+
+  await suite.test("returns an explicit unavailable state for incomplete input", () => {
+    const result = soulGuideFallback({});
+
+    assert.equal(result.interpretation, undefined);
+    assert.equal(result.cards.length, 3);
+    result.cards.forEach((card) => {
+      assert.match(card.body, /^Unavailable:/);
+    });
+  });
+
+  await suite.test("answers from the matching depth layer", () => {
+    const profile = completeProfile();
+
+    const strength = answerFromProfile("What am I good at?", profile);
+    const decision = answerFromProfile("How should I decide?", profile);
+    const boundary = answerFromProfile("What boundary matters?", profile);
+
+    assert.ok(strength.length > 20);
+    assert.ok(decision.length > 20);
+    assert.ok(boundary.length > 20);
+    assert.notEqual(strength, decision);
+  });
+});

--- a/services/soul-guide-fallback.ts
+++ b/services/soul-guide-fallback.ts
@@ -1,4 +1,16 @@
-import { synthesizeCodex, type CodexSynthesis } from "../src/codex/synthesize";
+import {
+  createDepthSoulGuideFallback,
+  type SoulGuideDepthCard,
+  type SoulGuideDepthFallbackResult,
+} from "../packages/core/soul-guide/index.js";
+import {
+  synthesizeDepthCodex,
+} from "../src/codex/depth-adapter.js";
+import {
+  synthesizeCodex,
+  type CodexSynthesis,
+} from "../src/codex/synthesize.js";
+import type { SoulProfile } from "../src/types/soulcodex.js";
 
 export interface FallbackCard {
   title: string;
@@ -10,135 +22,216 @@ export interface SoulGuideFallbackResult {
   message: string;
   cards: FallbackCard[];
   prompts: string[];
+  primaryCards?: SoulGuideDepthCard[];
+  detailCards?: SoulGuideDepthCard[];
+  interpretation?: SoulGuideDepthFallbackResult["interpretation"];
+  markdown?: string;
 }
 
-function tryGetSynthesis(profile: any): CodexSynthesis | null {
+function isSoulProfile(profile: unknown): profile is SoulProfile {
+  if (!profile || typeof profile !== "object") return false;
+  const candidate = profile as Partial<SoulProfile>;
+
+  return Boolean(
+    candidate.birth &&
+      typeof candidate.birth.birthDate === "string" &&
+      typeof candidate.birth.birthPlace === "string" &&
+      typeof candidate.birth.timeKnown === "boolean",
+  );
+}
+
+function withTimeline(profile: SoulProfile, timeline?: unknown): SoulProfile {
+  if (profile.timeline || !timeline || typeof timeline !== "object") {
+    return profile;
+  }
+
+  const candidate = timeline as {
+    currentPhase?: SoulProfile["timeline"] extends infer Timeline
+      ? Timeline extends { currentPhase: infer Phase }
+        ? Phase
+        : never
+      : never;
+    phase?: SoulProfile["timeline"] extends infer Timeline
+      ? Timeline extends { currentPhase: infer Phase }
+        ? Phase
+        : never
+      : never;
+    reasons?: string[];
+  };
+  const currentPhase = candidate.currentPhase ?? candidate.phase;
+
+  if (!currentPhase) return profile;
+
+  return {
+    ...profile,
+    timeline: {
+      currentPhase,
+      reasons: candidate.reasons,
+    },
+  };
+}
+
+function tryGetDepthFallback(
+  profile: unknown,
+  timeline?: unknown,
+): SoulGuideDepthFallbackResult | null {
+  if (!isSoulProfile(profile)) return null;
+
   try {
-    if (profile?.synthesis?.coreNature) return profile.synthesis;
+    const interpretation = synthesizeDepthCodex(
+      withTimeline(profile, timeline),
+    );
+    return createDepthSoulGuideFallback(interpretation);
+  } catch {
+    return null;
+  }
+}
+
+function tryGetSynthesis(profile: unknown): CodexSynthesis | null {
+  try {
+    const candidate = profile as { synthesis?: CodexSynthesis };
+    if (candidate?.synthesis?.coreNature) return candidate.synthesis;
+    if (!isSoulProfile(profile)) return null;
     return synthesizeCodex(profile);
   } catch {
     return null;
   }
 }
 
-export function soulGuideFallback(
-  profile: any,
-  timeline?: any,
-  dailyCard?: any,
-): SoulGuideFallbackResult {
-  const synth = tryGetSynthesis(profile);
-
-  if (synth) {
-    return {
-      status: "fallback",
-      message: "Using backup guidance from your Codex.",
-      cards: [
-        {
-          title: "Your strongest edge right now",
-          body: synth.coreNature,
-        },
-        {
-          title: "What may be throwing you off",
-          body: synth.stressPattern,
-        },
-        {
-          title: "What to focus on today",
-          body: synth.currentPhaseMeaning + " " + synth.practicalGuidance[0],
-        },
-      ],
-      prompts: [
-        "What pattern am I repeating right now?",
-        "What do I need to stop tolerating?",
-        "What is this phase trying to teach me?",
-      ],
-    };
-  }
-
-  const archData = profile?.archetypeData || profile?.archetype || {};
-  const archName = archData?.archetype || archData?.name || (typeof profile?.archetype === "string" ? profile.archetype : profile?.archetype?.name) || "";
-  const themes = archData?.themes || profile?.themes?.topThemes || [];
-  const topTheme = themes[0] || "clarity";
-  const strengths = archData?.strengths || [];
-  const shadows = archData?.shadows || [];
-  const oldSynthesis = profile?.synthesis || {};
-  const stressPattern = oldSynthesis?.stressPattern || "";
-  const shadowTrigger = profile?.mirror?.shadowTrigger || stressPattern || "mental overload";
-  const decisionStyle = profile?.mirror?.decisionStyle || oldSynthesis?.moralCode?.name || "analytical";
-  const phase = timeline?.phase || timeline?.currentPhase || profile?.timeline?.currentPhase || "your current phase";
-  const focus = dailyCard?.focus || "one grounded next step";
-
-  const strengthBody = strengths.length > 0
-    ? `Your profile emphasizes ${topTheme}. Your strongest edges are ${strengths.slice(0, 2).join(" and ")}. You operate best when you prioritize precision instead of trying to do everything at once.`
-    : `Your profile emphasizes ${topTheme}. This is the part of you that works best when life gets noisy. ${archName ? `As ${archName}, you're built to cut through confusion and act on what matters.` : "You cut through confusion and act on what matters."}`;
-
-  const blindSpotBody = shadows.length > 0
-    ? `Your blind spot tends to show up as ${shadows[0].toLowerCase()}. Under stress, ${shadowTrigger.toLowerCase()} takes over — your mind speeds up and tries to solve everything at once.`
-    : `Your stress pattern leans toward ${shadowTrigger.toLowerCase()}. When pressure rises, your default is to speed up instead of slow down. Watch for the moment when thinking replaces doing.`;
-
-  const focusBody = `You are in ${phase}. The best move today is ${focus}. Narrow your attention. One finished action will help more than ten partially solved thoughts.`;
+function unavailableFallback(): SoulGuideFallbackResult {
+  const reason =
+    "Unavailable: a complete Soul Profile is required for evidence-linked backup guidance.";
 
   return {
     status: "fallback",
-    message: "Using backup guidance from your Codex.",
+    message:
+      "Backup guidance is unavailable because the profile does not contain the required source data.",
     cards: [
-      { title: "Your strongest edge right now", body: strengthBody },
-      { title: "What may be throwing you off", body: blindSpotBody },
-      { title: "What to focus on today", body: focusBody },
+      { title: "Core Pattern", body: reason },
+      { title: "Main Contradiction", body: reason },
+      { title: "Next Move", body: reason },
     ],
     prompts: [
-      "What pattern am I repeating right now?",
-      "What do I need to stop tolerating?",
-      "What is this phase trying to teach me?",
+      "Which profile fields are still missing?",
+      "Which lived-experience detail should be added before interpretation?",
+      "Is the recorded birth time known, approximate, or unknown?",
     ],
   };
 }
 
+export function soulGuideFallback(
+  profile: unknown,
+  timeline?: unknown,
+  _dailyCard?: unknown,
+): SoulGuideFallbackResult {
+  const depth = tryGetDepthFallback(profile, timeline);
+
+  if (depth) {
+    return {
+      status: depth.status,
+      message: depth.message,
+      cards: depth.cards,
+      prompts: depth.prompts,
+      primaryCards: depth.primaryCards,
+      detailCards: depth.detailCards,
+      interpretation: depth.interpretation,
+      markdown: depth.markdown,
+    };
+  }
+
+  const synthesis = tryGetSynthesis(profile);
+  if (synthesis) {
+    return {
+      status: "fallback",
+      message:
+        "Using legacy deterministic guidance because a complete depth profile is not available.",
+      cards: [
+        { title: "Core Pattern", body: synthesis.coreNature },
+        {
+          title: "Main Contradiction",
+          body: `${synthesis.stressPattern} ${synthesis.blindSpot}`,
+        },
+        {
+          title: "Next Move",
+          body: `${synthesis.currentPhaseMeaning} ${synthesis.practicalGuidance[0] ?? ""}`.trim(),
+        },
+      ],
+      prompts: [
+        "Which part matches lived experience most clearly?",
+        "What evidence would change this interpretation?",
+        "What one grounded action can be tested next?",
+      ],
+    };
+  }
+
+  return unavailableFallback();
+}
+
+function layerText(
+  fallback: SoulGuideDepthFallbackResult,
+  ...keys: SoulGuideDepthCard["key"][]
+): string {
+  return keys
+    .map((key) => fallback.interpretation[key])
+    .map((layer) => `${layer.summary} ${layer.explanation}`.trim())
+    .join(" ")
+    .trim();
+}
+
 export function answerFromProfile(
   question: string,
-  profile: any,
-  timeline?: any,
-  dailyCard?: any,
+  profile: unknown,
+  timeline?: unknown,
+  _dailyCard?: unknown,
 ): string {
-  const synth = tryGetSynthesis(profile);
+  const depth = tryGetDepthFallback(profile, timeline);
 
-  if (synth) {
+  if (depth) {
     const q = question.toLowerCase();
 
     if (q.includes("strength") || q.includes("best") || q.includes("good at")) {
-      return synth.coreNature;
+      return layerText(depth, "gift");
     }
-    if (q.includes("pattern") || q.includes("repeat") || q.includes("sabotage") || q.includes("stuck")) {
-      return `${synth.stressPattern} ${synth.blindSpot}`;
+    if (
+      q.includes("pattern") ||
+      q.includes("repeat") ||
+      q.includes("sabotage") ||
+      q.includes("stuck")
+    ) {
+      return layerText(depth, "claritySummary", "shadow");
     }
     if (q.includes("tolerat") || q.includes("boundary") || q.includes("stop")) {
-      return synth.relationshipStyle;
+      return layerText(depth, "boundaryOrRepair");
     }
-    if (q.includes("phase") || q.includes("teach") || q.includes("learn") || q.includes("season")) {
-      return `${synth.currentPhaseMeaning} ${synth.growthEdge}`;
-    }
-    if (q.includes("focus") || q.includes("today") || q.includes("week") || q.includes("next")) {
-      return `${synth.currentPhaseMeaning} ${synth.practicalGuidance.join(" ")}`;
+    if (
+      q.includes("focus") ||
+      q.includes("today") ||
+      q.includes("week") ||
+      q.includes("next") ||
+      q.includes("phase")
+    ) {
+      return layerText(depth, "claritySummary", "action");
     }
     if (q.includes("decision") || q.includes("choose") || q.includes("decide")) {
-      return synth.decisionStyle;
+      return layerText(depth, "decisionImpact", "action");
     }
     if (q.includes("relationship") || q.includes("love") || q.includes("partner")) {
-      return `${synth.relationshipStyle} ${synth.blindSpot}`;
+      return layerText(depth, "relationshipImpact", "commonMisreading");
     }
     if (q.includes("blind") || q.includes("miss") || q.includes("shadow")) {
-      return `${synth.blindSpot} ${synth.growthEdge}`;
+      return layerText(depth, "shadow", "commonMisreading");
     }
     if (q.includes("grow") || q.includes("edge") || q.includes("improve")) {
-      return synth.growthEdge;
+      return layerText(depth, "boundaryOrRepair", "action");
     }
 
-    return `As ${synth.archetype}: ${synth.coreNature} ${synth.currentPhaseMeaning}`;
+    return layerText(depth, "claritySummary", "coreContradiction", "action");
   }
 
-  const archName = profile?.archetypeData?.archetype || profile?.archetype?.name || "your archetype";
-  const topTheme = profile?.themes?.topThemes?.[0] || "clarity";
-  const phase = timeline?.phase || profile?.timeline?.currentPhase || "your current phase";
-  const sunSign = profile?.astrologyData?.sunSign || profile?.chart?.sun?.sign || "";
+  const synthesis = tryGetSynthesis(profile);
+  if (synthesis) {
+    return `${synthesis.coreNature} ${synthesis.currentPhaseMeaning}`.trim();
+  }
 
-  return `Based on your ${archName} profile${sunSign ? ` (${sunSign})` : ""}: your core pattern revolves around ${topTheme}. You're currently in ${phase}. Focus on one clear action rather than spreading your attention.`;
+  return "Unavailable: a complete Soul Profile is required before the Codex can answer this responsibly.";
 }


### PR DESCRIPTION
## Summary

Implements Issue #108 as the third stacked delivery in the Codex Depth Initiative.

This PR makes Soul Guide consume the deterministic depth contract while allowing an AI provider to rewrite only user-facing prose. Evidence, confidence, claim kinds, limitations, provenance, missing data, and birth-time degradation remain locked.

## Stack

- base: `feat/codex-depth-synthesis-v1` / PR #107
- head: `feat/soul-guide-layered-clarity-v1`
- parent epic: #102
- implementation issue: #108

This PR should be retargeted after the preceding stacked PRs merge.

## What changed

### Contract-bound prompt

Added `generateDepthSoulGuidePrompt()`.

The prompt:

- includes the full deterministic interpretation as the only evidence boundary
- requests every depth layer
- presents Clarity Summary, Core Contradiction, and Action first
- permits only `title`, `summary`, and `explanation` rewrites
- forbids evidence or confidence changes
- forbids invented childhood, parental causes, trauma, attachment labels, diagnoses, motives, and future certainty
- states that lived experience overrides conflicting interpretation

The existing Soul Guide v1 prompt remains unchanged.

### Metadata-preserving parser

Added `parseDepthSoulGuideResponse()`.

The parser:

- extracts structured JSON
- requires every layer
- accepts prose fields only
- rejects top-level and layer-level metadata rewrites
- rejects invented biography, trauma, attachment, diagnosis, hidden-cause, and deterministic wording
- restores all locked metadata from the deterministic source
- reruns `validateDepthInterpretationV1` after merging prose
- returns structured findings instead of silently accepting malformed output

### Deterministic layered fallback

Added `createDepthSoulGuideFallback()` and Markdown rendering.

Primary card order:

1. Core Pattern
2. Main Contradiction
3. Next Move

Detail cards preserve confidence, claim kind, evidence IDs, limitations, and unavailable status.

### Service fallback

Updated `services/soul-guide-fallback.ts` to:

- use `synthesizeDepthCodex()` for complete `SoulProfile` inputs
- preserve structured depth cards and Markdown
- keep unknown-time evidence degraded
- answer common questions from the matching depth layer
- return an explicit unavailable state for incomplete input instead of inventing generic biography
- retain a legacy deterministic compatibility path when a prior synthesis object exists

## Tests

Added focused coverage for:

- all required prompt layers and evidence boundary
- biography, trauma, attachment, diagnosis, and certainty prohibitions
- safe prose parsing
- preservation of all locked metadata
- missing-layer rejection
- top-level and layer metadata rewrite rejection
- unsafe prose rejection
- clarity-first fallback ordering
- fallback evidence and limitation traceability
- unknown-time preservation after prose rewriting
- existing Soul Guide v1 compatibility
- complete, unknown-time, and incomplete service fallback behavior
- question routing to matching depth layers

## Validation completed

The inherited repository workflows remain blocked at `npm install` by Issue #106, before they reach this code. Independent validation completed:

- strict TypeScript compilation for prompt, parser, types, and fallback: passed
- strict TypeScript compilation for the service adapter boundary: passed
- safe prose runtime parse: passed
- locked evidence preservation smoke: passed
- invented-childhood rejection smoke: passed
- clarity-first fallback order smoke: passed
- evidence trace rendering smoke: passed

## Known routing boundary

This PR updates the dedicated `services/soul-guide-fallback.ts` adapter. The older monolithic `services/deterministic-fallback.ts` provider-router implementation remains unchanged because the connector exposes only full-file replacement, not patch writes, and replacing that unrelated 400-line module would make this stacked diff unnecessarily risky.

The new layered fallback is complete and callable. Consolidating the older router onto this adapter should be handled as a focused follow-up once the stack and dependency baseline are stable.

## Scope guardrails

No UI changes, provider replacement, formula changes, database changes, dependency additions, or lockfile churn.
