### PR TITLE
feat(ui): add clarity-first progressive disclosure

### DIFF
--- a/client/src/components/DEPTH_SOUL_GUIDE.md
+++ b/client/src/components/DEPTH_SOUL_GUIDE.md
@@ -1,0 +1,50 @@
+# DepthSoulGuide
+
+`DepthSoulGuide` is the progressive-disclosure renderer for `DepthInterpretationV1`.
+
+## Usage
+
+```tsx
+import DepthSoulGuide from "./components/DepthSoulGuide";
+
+<DepthSoulGuide interpretation={depthInterpretation} />;
+```
+
+Optional props:
+
+```tsx
+<DepthSoulGuide
+  interpretation={depthInterpretation}
+  defaultOpenGroupIds={["gift-and-shadow"]}
+  defaultEvidenceOpen={false}
+/>;
+```
+
+## First View
+
+The component always begins with:
+
+1. Your Core Pattern
+2. The Main Contradiction
+3. What To Do With It
+
+All other layers remain available through accessible disclosure buttons.
+
+## Evidence
+
+The layer-evidence toggle exposes claim kind, source support, evidence IDs, and limitations.
+
+The evidence drawer exposes:
+
+- source-system records
+- field values
+- provenance
+- birth-time sensitivity
+- evidence notes
+- missing data
+
+Interpretation confidence is labeled as source support. The component does not reuse the birth-data `ConfidenceBadge`, because verification of birth data and support for an interpretive claim are different concepts.
+
+## Compatibility
+
+This component is additive. It does not replace the existing Timeline-based `SoulGuide` component, issue provider requests, read profile storage, or generate interpretations. A caller must supply a validated `DepthInterpretationV1`.

--- a/client/src/components/DEPTH_SOUL_GUIDE.md
+++ b/client/src/components/DEPTH_SOUL_GUIDE.md
@@ -48,3 +48,7 @@ Interpretation confidence is labeled as source support. The component does not r
 ## Compatibility
 
 This component is additive. It does not replace the existing Timeline-based `SoulGuide` component, issue provider requests, read profile storage, or generate interpretations. A caller must supply a validated `DepthInterpretationV1`.
+
+## Validation Boundary
+
+The view-model ordering, unavailable-state visibility, evidence summaries, source immutability, disclosure accessibility contract, TSX compilation, workspace tests, and production build are enforced by the repository's permanent CI workflows.

--- a/client/src/components/DepthSoulGuide.tsx
+++ b/client/src/components/DepthSoulGuide.tsx
@@ -1,0 +1,790 @@
+import { useMemo, useState } from "react";
+import {
+  buildDepthSoulGuideViewModel,
+  type DepthInterpretationV1,
+  type DepthSoulGuideLayerView,
+  type InterpretationClaimKind,
+  type InterpretationConfidence,
+} from "@soulcodex/core";
+import {
+  IconChevronDown,
+  IconChevronRight,
+  IconInfo,
+  IconSparkles,
+} from "./Icons";
+
+export interface DepthSoulGuideProps {
+  interpretation: DepthInterpretationV1;
+  defaultOpenGroupIds?: string[];
+  defaultEvidenceOpen?: boolean;
+}
+
+const PRIMARY_HEADINGS: Record<
+  "claritySummary" | "coreContradiction" | "action",
+  string
+> = {
+  claritySummary: "Your Core Pattern",
+  coreContradiction: "The Main Contradiction",
+  action: "What To Do With It",
+};
+
+const SUPPORT_CONFIG: Record<
+  InterpretationConfidence,
+  { label: string; color: string; background: string; border: string }
+> = {
+  high: {
+    label: "High source support",
+    color: "var(--sc-gold, #d4a85f)",
+    background: "rgba(212, 168, 95, 0.12)",
+    border: "rgba(212, 168, 95, 0.38)",
+  },
+  moderate: {
+    label: "Moderate source support",
+    color: "var(--cosmic-lavender, #c8beff)",
+    background: "rgba(168, 145, 255, 0.12)",
+    border: "rgba(168, 145, 255, 0.35)",
+  },
+  low: {
+    label: "Low source support",
+    color: "var(--muted-foreground, #9b96aa)",
+    background: "rgba(255, 255, 255, 0.04)",
+    border: "rgba(255, 255, 255, 0.14)",
+  },
+};
+
+const CLAIM_LABELS: Record<InterpretationClaimKind, string> = {
+  observed: "Observed",
+  derived: "Derived",
+  inferred: "Inferred",
+  unavailable: "Unavailable",
+};
+
+function SupportPill({ confidence }: { confidence: InterpretationConfidence }) {
+  const config = SUPPORT_CONFIG[confidence];
+
+  return (
+    <span
+      role="status"
+      aria-label={`${config.label}. Confidence reflects source quality and consistency, not scientific truth.`}
+      className="depth-guide-support-pill"
+      style={{
+        color: config.color,
+        background: config.background,
+        borderColor: config.border,
+      }}
+    >
+      {config.label}
+    </span>
+  );
+}
+
+function ClaimPill({ claimKind }: { claimKind: InterpretationClaimKind }) {
+  return (
+    <span
+      className={`depth-guide-claim-pill depth-guide-claim-${claimKind}`}
+      aria-label={`Claim type: ${CLAIM_LABELS[claimKind]}`}
+    >
+      {CLAIM_LABELS[claimKind]}
+    </span>
+  );
+}
+
+function TraceDetails({ layer }: { layer: DepthSoulGuideLayerView }) {
+  return (
+    <div className="depth-guide-trace" aria-label={`${layer.title} evidence details`}>
+      <div className="depth-guide-trace-row">
+        <ClaimPill claimKind={layer.claimKind} />
+        <SupportPill confidence={layer.confidence} />
+      </div>
+
+      <div className="depth-guide-trace-block">
+        <strong>Evidence references</strong>
+        {layer.evidenceIds.length > 0 ? (
+          <ul>
+            {layer.evidenceIds.map((id) => (
+              <li key={id}>{id}</li>
+            ))}
+          </ul>
+        ) : (
+          <p>No evidence reference is available for this layer.</p>
+        )}
+      </div>
+
+      <div className="depth-guide-trace-block">
+        <strong>Limitations</strong>
+        {layer.limitations.length > 0 ? (
+          <ul>
+            {layer.limitations.map((limitation, index) => (
+              <li key={`${layer.key}-limitation-${index}`}>{limitation}</li>
+            ))}
+          </ul>
+        ) : (
+          <p>No additional limitation was recorded.</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function LayerCard({
+  layer,
+  showTrace,
+  primaryHeading,
+}: {
+  layer: DepthSoulGuideLayerView;
+  showTrace: boolean;
+  primaryHeading?: string;
+}) {
+  return (
+    <article
+      className={`depth-guide-layer-card${layer.unavailable ? " depth-guide-layer-unavailable" : ""}`}
+      data-layer-key={layer.key}
+    >
+      <div className="depth-guide-layer-heading">
+        <div>
+          {primaryHeading && (
+            <p className="depth-guide-eyebrow">{primaryHeading}</p>
+          )}
+          <h3>{layer.title}</h3>
+        </div>
+        {!showTrace && <SupportPill confidence={layer.confidence} />}
+      </div>
+
+      <p className="depth-guide-layer-summary">{layer.summary}</p>
+      <p className="depth-guide-layer-explanation">{layer.explanation}</p>
+
+      {layer.unavailable && (
+        <div className="depth-guide-unavailable-note">
+          <IconInfo size={15} aria-hidden="true" />
+          <span>This layer remains visible so missing support is not mistaken for certainty.</span>
+        </div>
+      )}
+
+      {showTrace && <TraceDetails layer={layer} />}
+    </article>
+  );
+}
+
+function formatEvidenceValue(value: string | number | boolean | null): string {
+  if (value === null) return "Not available";
+  if (typeof value === "boolean") return value ? "Yes" : "No";
+  return String(value);
+}
+
+function provenanceLabel(value: string | undefined): string {
+  if (value === "externally-verified") return "Externally verified";
+  if (value === "partially-verified") return "Partially verified";
+  return "Unverified";
+}
+
+export default function DepthSoulGuide({
+  interpretation,
+  defaultOpenGroupIds = [],
+  defaultEvidenceOpen = false,
+}: DepthSoulGuideProps) {
+  const model = useMemo(
+    () => buildDepthSoulGuideViewModel(interpretation),
+    [interpretation],
+  );
+  const [openGroups, setOpenGroups] = useState<Set<string>>(
+    () => new Set(defaultOpenGroupIds),
+  );
+  const [showTrace, setShowTrace] = useState(false);
+  const [evidenceOpen, setEvidenceOpen] = useState(defaultEvidenceOpen);
+
+  const toggleGroup = (id: string) => {
+    setOpenGroups((current) => {
+      const next = new Set(current);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  return (
+    <section className="depth-guide" aria-labelledby="depth-guide-title">
+      <header className="depth-guide-header">
+        <div className="depth-guide-title-row">
+          <div className="depth-guide-title-icon" aria-hidden="true">
+            <IconSparkles size={20} />
+          </div>
+          <div>
+            <p className="depth-guide-kicker">Clarity First, Depth On Demand</p>
+            <h2 id="depth-guide-title">Soul Guide</h2>
+          </div>
+        </div>
+
+        <div className="depth-guide-header-actions">
+          <SupportPill confidence={model.overallConfidence} />
+          <button
+            type="button"
+            className="depth-guide-secondary-button"
+            aria-pressed={showTrace}
+            onClick={() => setShowTrace((value) => !value)}
+          >
+            <IconInfo size={15} aria-hidden="true" />
+            {showTrace ? "Hide layer evidence" : "Show layer evidence"}
+          </button>
+        </div>
+      </header>
+
+      <div className="depth-guide-principle">
+        <p>
+          Start with the strongest supported pattern, the tension inside it, and one grounded move.
+          Open deeper layers only when they are useful.
+        </p>
+      </div>
+
+      <div className="depth-guide-primary-grid" aria-label="Soul Guide clarity summary">
+        {model.primary.map((layer) => (
+          <LayerCard
+            key={layer.key}
+            layer={layer}
+            showTrace={showTrace}
+            primaryHeading={PRIMARY_HEADINGS[layer.key as keyof typeof PRIMARY_HEADINGS]}
+          />
+        ))}
+      </div>
+
+      <div className="depth-guide-disclosures" aria-label="Deeper interpretation layers">
+        {model.disclosures.map((group) => {
+          const open = openGroups.has(group.id);
+          const panelId = `depth-guide-panel-${group.id}`;
+          const buttonId = `depth-guide-button-${group.id}`;
+
+          return (
+            <div className="depth-guide-disclosure" key={group.id}>
+              <button
+                type="button"
+                id={buttonId}
+                className="depth-guide-disclosure-button"
+                aria-expanded={open}
+                aria-controls={panelId}
+                onClick={() => toggleGroup(group.id)}
+              >
+                <span className="depth-guide-disclosure-icon" aria-hidden="true">
+                  {open ? <IconChevronDown size={18} /> : <IconChevronRight size={18} />}
+                </span>
+                <span className="depth-guide-disclosure-copy">
+                  <strong>{group.title}</strong>
+                  <span>{group.description}</span>
+                </span>
+                <span className="depth-guide-disclosure-count">
+                  {group.availableCount} supported
+                  {group.unavailableCount > 0 ? `, ${group.unavailableCount} unavailable` : ""}
+                </span>
+              </button>
+
+              {open && (
+                <div
+                  id={panelId}
+                  role="region"
+                  aria-labelledby={buttonId}
+                  className="depth-guide-disclosure-panel"
+                >
+                  {group.layers.map((layer) => (
+                    <LayerCard
+                      key={layer.key}
+                      layer={layer}
+                      showTrace={showTrace}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="depth-guide-disclosure depth-guide-evidence-disclosure">
+        <button
+          type="button"
+          id="depth-guide-evidence-button"
+          className="depth-guide-disclosure-button"
+          aria-expanded={evidenceOpen}
+          aria-controls="depth-guide-evidence-panel"
+          onClick={() => setEvidenceOpen((value) => !value)}
+        >
+          <span className="depth-guide-disclosure-icon" aria-hidden="true">
+            {evidenceOpen ? <IconChevronDown size={18} /> : <IconChevronRight size={18} />}
+          </span>
+          <span className="depth-guide-disclosure-copy">
+            <strong>Evidence, confidence, and missing data</strong>
+            <span>See exactly what supports the reading and what remains unknown.</span>
+          </span>
+          <span className="depth-guide-disclosure-count">
+            {model.evidence.totalEvidence} evidence items
+          </span>
+        </button>
+
+        {evidenceOpen && (
+          <div
+            id="depth-guide-evidence-panel"
+            role="region"
+            aria-labelledby="depth-guide-evidence-button"
+            className="depth-guide-evidence-panel"
+          >
+            <div className="depth-guide-evidence-summary">
+              <div>
+                <span>Total evidence</span>
+                <strong>{model.evidence.totalEvidence}</strong>
+              </div>
+              <div>
+                <span>Externally verified</span>
+                <strong>{model.evidence.externallyVerified}</strong>
+              </div>
+              <div>
+                <span>Partially verified</span>
+                <strong>{model.evidence.partiallyVerified}</strong>
+              </div>
+              <div>
+                <span>Unverified</span>
+                <strong>{model.evidence.unverified}</strong>
+              </div>
+              <div>
+                <span>Recorded limitations</span>
+                <strong>{model.evidence.limitationCount}</strong>
+              </div>
+            </div>
+
+            <div className="depth-guide-evidence-list">
+              {interpretation.evidence.map((evidence) => (
+                <article className="depth-guide-evidence-item" key={evidence.id}>
+                  <div className="depth-guide-evidence-item-heading">
+                    <div>
+                      <p>{evidence.system}</p>
+                      <h3>{evidence.field}</h3>
+                    </div>
+                    <SupportPill confidence={evidence.confidence} />
+                  </div>
+                  <dl>
+                    <div>
+                      <dt>Reference</dt>
+                      <dd>{evidence.id}</dd>
+                    </div>
+                    <div>
+                      <dt>Value</dt>
+                      <dd>{formatEvidenceValue(evidence.value)}</dd>
+                    </div>
+                    <div>
+                      <dt>Provenance</dt>
+                      <dd>{provenanceLabel(evidence.provenanceStatus)}</dd>
+                    </div>
+                    <div>
+                      <dt>Time sensitivity</dt>
+                      <dd>
+                        {evidence.timeSensitivity === "birth-time-required"
+                          ? "Exact birth time required"
+                          : "Not birth-time sensitive"}
+                      </dd>
+                    </div>
+                  </dl>
+                  {evidence.notes && evidence.notes.length > 0 && (
+                    <ul className="depth-guide-evidence-notes">
+                      {evidence.notes.map((note, index) => (
+                        <li key={`${evidence.id}-note-${index}`}>{note}</li>
+                      ))}
+                    </ul>
+                  )}
+                </article>
+              ))}
+            </div>
+
+            <div className="depth-guide-missing-data">
+              <h3>Missing data</h3>
+              {model.missingData.length > 0 ? (
+                <ul>
+                  {model.missingData.map((item, index) => (
+                    <li key={`missing-data-${index}`}>{item}</li>
+                  ))}
+                </ul>
+              ) : (
+                <p>No material missing data was recorded.</p>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <footer className="depth-guide-footer">
+        <IconInfo size={15} aria-hidden="true" />
+        <p>
+          Confidence describes source quality and consistency, not scientific truth. Lived experience
+          remains the final authority and may correct any layer.
+        </p>
+      </footer>
+
+      <style>{`
+        .depth-guide {
+          display: flex;
+          flex-direction: column;
+          gap: 1.25rem;
+          width: 100%;
+          color: var(--foreground, #f4f1ff);
+        }
+        .depth-guide-header {
+          display: flex;
+          justify-content: space-between;
+          align-items: flex-start;
+          gap: 1rem;
+          padding: 1.25rem;
+          border: 1px solid rgba(212, 168, 95, 0.28);
+          border-radius: 16px;
+          background: linear-gradient(135deg, rgba(212, 168, 95, 0.1), rgba(122, 82, 190, 0.08));
+        }
+        .depth-guide-title-row,
+        .depth-guide-header-actions,
+        .depth-guide-layer-heading,
+        .depth-guide-evidence-item-heading {
+          display: flex;
+          align-items: center;
+          gap: 0.75rem;
+        }
+        .depth-guide-header-actions {
+          justify-content: flex-end;
+          flex-wrap: wrap;
+        }
+        .depth-guide-title-icon {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          width: 42px;
+          height: 42px;
+          border-radius: 12px;
+          color: var(--sc-gold, #d4a85f);
+          background: rgba(212, 168, 95, 0.12);
+          border: 1px solid rgba(212, 168, 95, 0.28);
+        }
+        .depth-guide-kicker,
+        .depth-guide-eyebrow,
+        .depth-guide-evidence-item-heading p {
+          margin: 0 0 0.2rem;
+          color: var(--sc-gold, #d4a85f);
+          font-size: 0.68rem;
+          font-weight: 700;
+          letter-spacing: 0.11em;
+          text-transform: uppercase;
+        }
+        .depth-guide-header h2,
+        .depth-guide-layer-card h3,
+        .depth-guide-evidence-item h3,
+        .depth-guide-missing-data h3 {
+          margin: 0;
+        }
+        .depth-guide-header h2 {
+          font-size: 1.35rem;
+        }
+        .depth-guide-support-pill,
+        .depth-guide-claim-pill {
+          display: inline-flex;
+          align-items: center;
+          border: 1px solid;
+          border-radius: 999px;
+          padding: 0.22rem 0.58rem;
+          font-size: 0.66rem;
+          font-weight: 700;
+          letter-spacing: 0.04em;
+          white-space: nowrap;
+        }
+        .depth-guide-claim-pill {
+          border-color: rgba(255, 255, 255, 0.14);
+          color: var(--muted-foreground, #aaa4b8);
+          background: rgba(255, 255, 255, 0.04);
+        }
+        .depth-guide-claim-observed { color: #72d6b7; border-color: rgba(114, 214, 183, 0.34); }
+        .depth-guide-claim-derived { color: #7fd6f2; border-color: rgba(127, 214, 242, 0.34); }
+        .depth-guide-claim-inferred { color: #c8beff; border-color: rgba(200, 190, 255, 0.34); }
+        .depth-guide-claim-unavailable { color: #aaa4b8; border-color: rgba(170, 164, 184, 0.24); }
+        .depth-guide-secondary-button,
+        .depth-guide-disclosure-button {
+          font: inherit;
+          color: inherit;
+          cursor: pointer;
+        }
+        .depth-guide-secondary-button {
+          display: inline-flex;
+          align-items: center;
+          gap: 0.4rem;
+          padding: 0.48rem 0.72rem;
+          border-radius: 9px;
+          border: 1px solid rgba(255, 255, 255, 0.14);
+          background: rgba(255, 255, 255, 0.04);
+          color: var(--muted-foreground, #aaa4b8);
+          font-size: 0.72rem;
+        }
+        .depth-guide-secondary-button:hover,
+        .depth-guide-disclosure-button:hover {
+          border-color: rgba(212, 168, 95, 0.38);
+          background: rgba(212, 168, 95, 0.07);
+        }
+        .depth-guide-secondary-button:focus-visible,
+        .depth-guide-disclosure-button:focus-visible {
+          outline: 2px solid var(--sc-gold, #d4a85f);
+          outline-offset: 3px;
+        }
+        .depth-guide-principle,
+        .depth-guide-footer {
+          display: flex;
+          align-items: flex-start;
+          gap: 0.55rem;
+          padding: 0.8rem 1rem;
+          border-radius: 10px;
+          color: var(--muted-foreground, #aaa4b8);
+          background: rgba(255, 255, 255, 0.025);
+          border: 1px dashed rgba(255, 255, 255, 0.11);
+        }
+        .depth-guide-principle p,
+        .depth-guide-footer p {
+          margin: 0;
+          font-size: 0.78rem;
+          line-height: 1.55;
+        }
+        .depth-guide-primary-grid {
+          display: grid;
+          grid-template-columns: repeat(3, minmax(0, 1fr));
+          gap: 0.9rem;
+        }
+        .depth-guide-layer-card {
+          padding: 1.1rem;
+          border-radius: 13px;
+          border: 1px solid rgba(212, 168, 95, 0.2);
+          background: rgba(255, 255, 255, 0.035);
+          min-width: 0;
+        }
+        .depth-guide-primary-grid .depth-guide-layer-card:first-child {
+          border-color: rgba(212, 168, 95, 0.4);
+          background: rgba(212, 168, 95, 0.08);
+        }
+        .depth-guide-primary-grid .depth-guide-layer-card:nth-child(2) {
+          border-color: rgba(168, 145, 255, 0.35);
+          background: rgba(168, 145, 255, 0.07);
+        }
+        .depth-guide-primary-grid .depth-guide-layer-card:nth-child(3) {
+          border-color: rgba(80, 205, 205, 0.35);
+          background: rgba(80, 205, 205, 0.07);
+        }
+        .depth-guide-layer-unavailable {
+          opacity: 0.78;
+          border-style: dashed;
+        }
+        .depth-guide-layer-heading,
+        .depth-guide-evidence-item-heading {
+          justify-content: space-between;
+          align-items: flex-start;
+        }
+        .depth-guide-layer-card h3,
+        .depth-guide-evidence-item h3 {
+          font-size: 0.92rem;
+          line-height: 1.35;
+        }
+        .depth-guide-layer-summary {
+          margin: 0.7rem 0 0;
+          color: var(--foreground, #f4f1ff);
+          font-size: 0.91rem;
+          font-weight: 650;
+          line-height: 1.5;
+        }
+        .depth-guide-layer-explanation {
+          margin: 0.55rem 0 0;
+          color: var(--muted-foreground, #aaa4b8);
+          font-size: 0.8rem;
+          line-height: 1.58;
+        }
+        .depth-guide-unavailable-note {
+          display: flex;
+          align-items: flex-start;
+          gap: 0.45rem;
+          margin-top: 0.75rem;
+          color: var(--muted-foreground, #aaa4b8);
+          font-size: 0.72rem;
+          line-height: 1.45;
+        }
+        .depth-guide-trace {
+          display: flex;
+          flex-direction: column;
+          gap: 0.7rem;
+          margin-top: 0.9rem;
+          padding-top: 0.85rem;
+          border-top: 1px solid rgba(255, 255, 255, 0.1);
+        }
+        .depth-guide-trace-row {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 0.4rem;
+        }
+        .depth-guide-trace-block strong {
+          display: block;
+          margin-bottom: 0.35rem;
+          color: var(--muted-foreground, #aaa4b8);
+          font-size: 0.68rem;
+          letter-spacing: 0.06em;
+          text-transform: uppercase;
+        }
+        .depth-guide-trace ul,
+        .depth-guide-trace p,
+        .depth-guide-missing-data ul,
+        .depth-guide-missing-data p,
+        .depth-guide-evidence-notes {
+          margin: 0;
+          padding-left: 1.1rem;
+          color: var(--muted-foreground, #aaa4b8);
+          font-size: 0.72rem;
+          line-height: 1.5;
+        }
+        .depth-guide-disclosures {
+          display: flex;
+          flex-direction: column;
+          gap: 0.65rem;
+        }
+        .depth-guide-disclosure {
+          overflow: hidden;
+          border: 1px solid rgba(255, 255, 255, 0.1);
+          border-radius: 12px;
+          background: rgba(255, 255, 255, 0.02);
+        }
+        .depth-guide-disclosure-button {
+          display: grid;
+          grid-template-columns: auto minmax(0, 1fr) auto;
+          align-items: center;
+          gap: 0.7rem;
+          width: 100%;
+          padding: 0.9rem 1rem;
+          border: 0;
+          border-radius: 0;
+          background: transparent;
+          text-align: left;
+        }
+        .depth-guide-disclosure-icon {
+          display: flex;
+          color: var(--sc-gold, #d4a85f);
+        }
+        .depth-guide-disclosure-copy {
+          display: flex;
+          flex-direction: column;
+          gap: 0.15rem;
+          min-width: 0;
+        }
+        .depth-guide-disclosure-copy strong {
+          font-size: 0.85rem;
+        }
+        .depth-guide-disclosure-copy span,
+        .depth-guide-disclosure-count {
+          color: var(--muted-foreground, #aaa4b8);
+          font-size: 0.7rem;
+          line-height: 1.4;
+        }
+        .depth-guide-disclosure-count {
+          text-align: right;
+          white-space: nowrap;
+        }
+        .depth-guide-disclosure-panel {
+          display: grid;
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+          gap: 0.75rem;
+          padding: 0 0.85rem 0.85rem;
+        }
+        .depth-guide-disclosure-panel .depth-guide-layer-card:only-child {
+          grid-column: 1 / -1;
+        }
+        .depth-guide-evidence-panel {
+          display: flex;
+          flex-direction: column;
+          gap: 1rem;
+          padding: 0 0.85rem 0.95rem;
+        }
+        .depth-guide-evidence-summary {
+          display: grid;
+          grid-template-columns: repeat(5, minmax(0, 1fr));
+          gap: 0.55rem;
+        }
+        .depth-guide-evidence-summary > div {
+          display: flex;
+          flex-direction: column;
+          gap: 0.25rem;
+          padding: 0.7rem;
+          border-radius: 9px;
+          background: rgba(255, 255, 255, 0.035);
+          border: 1px solid rgba(255, 255, 255, 0.08);
+        }
+        .depth-guide-evidence-summary span {
+          color: var(--muted-foreground, #aaa4b8);
+          font-size: 0.64rem;
+          line-height: 1.3;
+        }
+        .depth-guide-evidence-summary strong {
+          font-size: 1rem;
+        }
+        .depth-guide-evidence-list {
+          display: grid;
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+          gap: 0.7rem;
+        }
+        .depth-guide-evidence-item,
+        .depth-guide-missing-data {
+          padding: 0.9rem;
+          border-radius: 10px;
+          background: rgba(255, 255, 255, 0.025);
+          border: 1px solid rgba(255, 255, 255, 0.09);
+        }
+        .depth-guide-evidence-item dl {
+          display: grid;
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+          gap: 0.55rem;
+          margin: 0.75rem 0 0;
+        }
+        .depth-guide-evidence-item dl > div {
+          min-width: 0;
+        }
+        .depth-guide-evidence-item dt {
+          color: var(--muted-foreground, #aaa4b8);
+          font-size: 0.62rem;
+          text-transform: uppercase;
+          letter-spacing: 0.05em;
+        }
+        .depth-guide-evidence-item dd {
+          margin: 0.16rem 0 0;
+          overflow-wrap: anywhere;
+          font-size: 0.72rem;
+          line-height: 1.4;
+        }
+        .depth-guide-evidence-notes {
+          margin-top: 0.7rem;
+        }
+        .depth-guide-missing-data h3 {
+          margin-bottom: 0.55rem;
+          font-size: 0.82rem;
+        }
+        @media (max-width: 760px) {
+          .depth-guide-header {
+            flex-direction: column;
+          }
+          .depth-guide-header-actions {
+            justify-content: flex-start;
+          }
+          .depth-guide-primary-grid,
+          .depth-guide-disclosure-panel,
+          .depth-guide-evidence-list {
+            grid-template-columns: 1fr;
+          }
+          .depth-guide-evidence-summary {
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+          }
+        }
+        @media (max-width: 520px) {
+          .depth-guide-disclosure-button {
+            grid-template-columns: auto minmax(0, 1fr);
+          }
+          .depth-guide-disclosure-count {
+            grid-column: 2;
+            text-align: left;
+            white-space: normal;
+          }
+          .depth-guide-evidence-summary,
+          .depth-guide-evidence-item dl {
+            grid-template-columns: 1fr;
+          }
+        }
+      `}</style>
+    </section>
+  );
+}

--- a/packages/core/soul-guide/__tests__/depth-ui-source-contract.test.ts
+++ b/packages/core/soul-guide/__tests__/depth-ui-source-contract.test.ts
@@ -1,0 +1,68 @@
+import { test } from "node:test";
+import assert from "node:assert";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const COMPONENT_PATH = fileURLToPath(
+  new URL(
+    "../../../../client/src/components/DepthSoulGuide.tsx",
+    import.meta.url,
+  ),
+);
+
+function componentSource(): string {
+  return readFileSync(COMPONENT_PATH, "utf8");
+}
+
+test("DepthSoulGuide source contract", async (suite) => {
+  await suite.test("uses native disclosure accessibility semantics", () => {
+    const source = componentSource();
+
+    assert.ok(source.includes('type="button"'));
+    assert.ok(source.includes("aria-expanded={open}"));
+    assert.ok(source.includes("aria-controls={panelId}"));
+    assert.ok(source.includes('role="region"'));
+    assert.ok(source.includes("aria-labelledby={buttonId}"));
+    assert.ok(source.includes(":focus-visible"));
+  });
+
+  await suite.test("keeps evidence disclosure separately accessible", () => {
+    const source = componentSource();
+
+    assert.ok(source.includes('id="depth-guide-evidence-button"'));
+    assert.ok(source.includes('aria-controls="depth-guide-evidence-panel"'));
+    assert.ok(source.includes('id="depth-guide-evidence-panel"'));
+    assert.ok(source.includes('aria-labelledby="depth-guide-evidence-button"'));
+  });
+
+  await suite.test("does not reuse birth-data verification badges", () => {
+    const source = componentSource();
+
+    assert.equal(source.includes("ConfidenceBadge"), false);
+    assert.ok(source.includes("High source support"));
+    assert.ok(source.includes("Moderate source support"));
+    assert.ok(source.includes("Low source support"));
+    assert.ok(
+      source.includes(
+        "Confidence describes source quality and consistency, not scientific truth.",
+      ),
+    );
+  });
+
+  await suite.test("keeps the clarity-first headings visible", () => {
+    const source = componentSource();
+
+    assert.ok(source.includes("Your Core Pattern"));
+    assert.ok(source.includes("The Main Contradiction"));
+    assert.ok(source.includes("What To Do With It"));
+  });
+
+  await suite.test("preserves unavailable and missing-data visibility", () => {
+    const source = componentSource();
+
+    assert.ok(source.includes("depth-guide-layer-unavailable"));
+    assert.ok(source.includes("This layer remains visible"));
+    assert.ok(source.includes("Missing data"));
+    assert.ok(source.includes("model.missingData"));
+  });
+});

--- a/packages/core/soul-guide/__tests__/depth-view-model.test.ts
+++ b/packages/core/soul-guide/__tests__/depth-view-model.test.ts
@@ -1,0 +1,185 @@
+import { test } from "node:test";
+import assert from "node:assert";
+import {
+  DEPTH_INTERPRETATION_LAYER_KEYS,
+  type DepthInterpretationV1,
+  type InterpretationLayer,
+} from "../../depth-interpretation/index.js";
+import {
+  DEPTH_SOUL_GUIDE_DISCLOSURES,
+  buildDepthSoulGuideViewModel,
+} from "../depth-view-model.js";
+
+function layer(
+  title: string,
+  overrides: Partial<InterpretationLayer> = {},
+): InterpretationLayer {
+  return {
+    title,
+    summary: `${title} summary`,
+    explanation: `${title} explanation`,
+    claimKind: "derived",
+    evidenceIds: ["mirror.driver"],
+    confidence: "moderate",
+    limitations: [`${title} limitation`],
+    ...overrides,
+  };
+}
+
+function interpretation(): DepthInterpretationV1 {
+  return {
+    version: 1,
+    generatedAt: "2026-07-24T18:00:00.000Z",
+    claritySummary: layer("Core pattern"),
+    visiblePattern: layer("Visible pattern"),
+    innerExperience: layer("Inner experience"),
+    hiddenNeed: layer("Hidden need"),
+    protectiveFunction: layer("Protective function"),
+    coreContradiction: layer("Core contradiction"),
+    gift: layer("Gift"),
+    shadow: layer("Shadow"),
+    commonMisreading: layer("Common misreading"),
+    relationshipImpact: layer("Relationship impact"),
+    decisionImpact: layer("Decision impact"),
+    boundaryOrRepair: layer("Boundary or repair"),
+    action: layer("Action"),
+    evidence: [
+      {
+        id: "mirror.driver",
+        system: "mirror",
+        field: "mirror.driver",
+        value: "Independence",
+        confidence: "high",
+        provenanceStatus: "partially-verified",
+      },
+      {
+        id: "numerology.life-path",
+        system: "numerology",
+        field: "numerology.lifePath",
+        value: 4,
+        confidence: "moderate",
+        provenanceStatus: "unverified",
+      },
+      {
+        id: "tracker.energy",
+        system: "tracker",
+        field: "energy.average",
+        value: 4,
+        confidence: "high",
+        provenanceStatus: "externally-verified",
+      },
+    ],
+    missingData: [],
+    overallConfidence: "moderate",
+  };
+}
+
+test("Depth Soul Guide view model", async (suite) => {
+  await suite.test("keeps clarity, contradiction, and action first", () => {
+    const model = buildDepthSoulGuideViewModel(interpretation());
+
+    assert.deepEqual(
+      model.primary.map((item) => item.key),
+      ["claritySummary", "coreContradiction", "action"],
+    );
+  });
+
+  await suite.test("keeps disclosure group order stable", () => {
+    const model = buildDepthSoulGuideViewModel(interpretation());
+
+    assert.deepEqual(
+      model.disclosures.map((group) => group.id),
+      [
+        "what-people-see",
+        "what-they-miss",
+        "need-and-protection",
+        "gift-and-shadow",
+        "common-misreading",
+        "relationship-and-decision-effects",
+        "boundary-and-repair",
+      ],
+    );
+    assert.deepEqual(
+      model.disclosures.map((group) => group.id),
+      DEPTH_SOUL_GUIDE_DISCLOSURES.map((group) => group.id),
+    );
+  });
+
+  await suite.test("represents every non-primary layer exactly once", () => {
+    const model = buildDepthSoulGuideViewModel(interpretation());
+    const primary = new Set(model.primary.map((item) => item.key));
+    const detailKeys = model.disclosures.flatMap((group) =>
+      group.layers.map((layerItem) => layerItem.key),
+    );
+    const expected = DEPTH_INTERPRETATION_LAYER_KEYS.filter(
+      (key) => !primary.has(key),
+    );
+
+    assert.equal(new Set(detailKeys).size, detailKeys.length);
+    assert.deepEqual([...detailKeys].sort(), [...expected].sort());
+  });
+
+  await suite.test("keeps unavailable layers visible", () => {
+    const source = interpretation();
+    source.hiddenNeed = layer("Hidden need", {
+      summary: "Unavailable: hidden need lacks support.",
+      explanation: "Insufficient data: no supported need signal is available.",
+      claimKind: "unavailable",
+      evidenceIds: [],
+      confidence: "low",
+      limitations: ["Mirror driver is missing."],
+    });
+
+    const model = buildDepthSoulGuideViewModel(source);
+    const group = model.disclosures.find(
+      (item) => item.id === "need-and-protection",
+    );
+    const hiddenNeed = group?.layers.find(
+      (item) => item.key === "hiddenNeed",
+    );
+
+    assert.equal(hiddenNeed?.unavailable, true);
+    assert.equal(group?.unavailableCount, 1);
+    assert.equal(group?.availableCount, 1);
+  });
+
+  await suite.test("summarizes evidence, provenance, and limitations", () => {
+    const model = buildDepthSoulGuideViewModel(interpretation());
+
+    assert.equal(model.evidence.totalEvidence, 3);
+    assert.equal(model.evidence.externallyVerified, 1);
+    assert.equal(model.evidence.partiallyVerified, 1);
+    assert.equal(model.evidence.unverified, 1);
+    assert.deepEqual(model.evidence.systemCounts, [
+      { system: "mirror", count: 1 },
+      { system: "numerology", count: 1 },
+      { system: "tracker", count: 1 },
+    ]);
+    assert.equal(model.evidence.limitationCount, 13);
+    assert.deepEqual(model.evidence.referencedEvidenceIds, ["mirror.driver"]);
+  });
+
+  await suite.test("exposes unknown-time missing data", () => {
+    const source = interpretation();
+    source.missingData = [
+      "Exact birth time is unknown; Rising sign, houses, angles, Moon degree, and time-sensitive Human Design claims are unavailable.",
+    ];
+
+    const model = buildDepthSoulGuideViewModel(source);
+
+    assert.deepEqual(model.missingData, source.missingData);
+    assert.ok(model.missingData[0].includes("Exact birth time is unknown"));
+  });
+
+  await suite.test("does not mutate the source interpretation", () => {
+    const source = interpretation();
+    const snapshot = JSON.stringify(source);
+    const model = buildDepthSoulGuideViewModel(source);
+
+    model.primary[0].evidenceIds.push("mutated.id");
+    model.primary[0].limitations.push("mutated limitation");
+    model.missingData.push("mutated missing data");
+
+    assert.equal(JSON.stringify(source), snapshot);
+  });
+});

--- a/packages/core/soul-guide/depth-view-model.ts
+++ b/packages/core/soul-guide/depth-view-model.ts
@@ -1,0 +1,208 @@
+import type {
+  DepthInterpretationLayerKey,
+  DepthInterpretationV1,
+  EvidenceSystem,
+  InterpretationClaimKind,
+  InterpretationConfidence,
+} from "../depth-interpretation/types.js";
+
+export const DEPTH_SOUL_GUIDE_PRIMARY_KEYS = [
+  "claritySummary",
+  "coreContradiction",
+  "action",
+] as const satisfies readonly DepthInterpretationLayerKey[];
+
+export interface DepthSoulGuideDisclosureDefinition {
+  id: string;
+  title: string;
+  description: string;
+  layerKeys: readonly DepthInterpretationLayerKey[];
+}
+
+export const DEPTH_SOUL_GUIDE_DISCLOSURES: readonly DepthSoulGuideDisclosureDefinition[] = [
+  {
+    id: "what-people-see",
+    title: "What people see",
+    description: "The behavior or energy that may appear first.",
+    layerKeys: ["visiblePattern"],
+  },
+  {
+    id: "what-they-miss",
+    title: "What they miss",
+    description: "The internal experience that may not be obvious from the outside.",
+    layerKeys: ["innerExperience"],
+  },
+  {
+    id: "need-and-protection",
+    title: "The need and protection beneath it",
+    description: "What the pattern may be preserving, preventing, or asking for.",
+    layerKeys: ["hiddenNeed", "protectiveFunction"],
+  },
+  {
+    id: "gift-and-shadow",
+    title: "Gift and shadow",
+    description: "What the pattern does well and what happens when it is overused.",
+    layerKeys: ["gift", "shadow"],
+  },
+  {
+    id: "common-misreading",
+    title: "Common misreading",
+    description: "How other people may misunderstand the visible pattern.",
+    layerKeys: ["commonMisreading"],
+  },
+  {
+    id: "relationship-and-decision-effects",
+    title: "Relationship and decision effects",
+    description: "How the pattern may affect trust, conflict, judgment, and timing.",
+    layerKeys: ["relationshipImpact", "decisionImpact"],
+  },
+  {
+    id: "boundary-and-repair",
+    title: "Boundary and repair",
+    description: "What may need to be protected, clarified, said, or repaired.",
+    layerKeys: ["boundaryOrRepair"],
+  },
+] as const;
+
+export interface DepthSoulGuideLayerView {
+  key: DepthInterpretationLayerKey;
+  title: string;
+  summary: string;
+  explanation: string;
+  claimKind: InterpretationClaimKind;
+  confidence: InterpretationConfidence;
+  evidenceIds: string[];
+  limitations: string[];
+  unavailable: boolean;
+}
+
+export interface DepthSoulGuideDisclosureView {
+  id: string;
+  title: string;
+  description: string;
+  layers: DepthSoulGuideLayerView[];
+  availableCount: number;
+  unavailableCount: number;
+}
+
+export interface DepthSoulGuideEvidenceSystemCount {
+  system: EvidenceSystem;
+  count: number;
+}
+
+export interface DepthSoulGuideEvidenceView {
+  totalEvidence: number;
+  externallyVerified: number;
+  partiallyVerified: number;
+  unverified: number;
+  referencedEvidenceIds: string[];
+  systemCounts: DepthSoulGuideEvidenceSystemCount[];
+  limitationCount: number;
+}
+
+export interface DepthSoulGuideViewModel {
+  primary: DepthSoulGuideLayerView[];
+  disclosures: DepthSoulGuideDisclosureView[];
+  evidence: DepthSoulGuideEvidenceView;
+  missingData: string[];
+  overallConfidence: InterpretationConfidence;
+  generatedAt: string;
+}
+
+function layerView(
+  interpretation: DepthInterpretationV1,
+  key: DepthInterpretationLayerKey,
+): DepthSoulGuideLayerView {
+  const layer = interpretation[key];
+
+  return {
+    key,
+    title: layer.title,
+    summary: layer.summary,
+    explanation: layer.explanation,
+    claimKind: layer.claimKind,
+    confidence: layer.confidence,
+    evidenceIds: [...layer.evidenceIds],
+    limitations: [...layer.limitations],
+    unavailable: layer.claimKind === "unavailable",
+  };
+}
+
+function evidenceView(
+  interpretation: DepthInterpretationV1,
+  allLayers: readonly DepthSoulGuideLayerView[],
+): DepthSoulGuideEvidenceView {
+  const systemCounts = new Map<EvidenceSystem, number>();
+  let externallyVerified = 0;
+  let partiallyVerified = 0;
+  let unverified = 0;
+
+  for (const evidence of interpretation.evidence) {
+    systemCounts.set(
+      evidence.system,
+      (systemCounts.get(evidence.system) ?? 0) + 1,
+    );
+
+    if (evidence.provenanceStatus === "externally-verified") {
+      externallyVerified += 1;
+    } else if (evidence.provenanceStatus === "partially-verified") {
+      partiallyVerified += 1;
+    } else {
+      unverified += 1;
+    }
+  }
+
+  const referencedEvidenceIds = Array.from(
+    new Set(allLayers.flatMap((layer) => layer.evidenceIds)),
+  ).sort((a, b) => a.localeCompare(b));
+
+  return {
+    totalEvidence: interpretation.evidence.length,
+    externallyVerified,
+    partiallyVerified,
+    unverified,
+    referencedEvidenceIds,
+    systemCounts: Array.from(systemCounts.entries())
+      .map(([system, count]) => ({ system, count }))
+      .sort((a, b) => a.system.localeCompare(b.system)),
+    limitationCount: allLayers.reduce(
+      (total, layer) => total + layer.limitations.length,
+      0,
+    ),
+  };
+}
+
+export function buildDepthSoulGuideViewModel(
+  interpretation: DepthInterpretationV1,
+): DepthSoulGuideViewModel {
+  const primary = DEPTH_SOUL_GUIDE_PRIMARY_KEYS.map((key) =>
+    layerView(interpretation, key),
+  );
+  const disclosures = DEPTH_SOUL_GUIDE_DISCLOSURES.map((definition) => {
+    const layers = definition.layerKeys.map((key) =>
+      layerView(interpretation, key),
+    );
+
+    return {
+      id: definition.id,
+      title: definition.title,
+      description: definition.description,
+      layers,
+      availableCount: layers.filter((layer) => !layer.unavailable).length,
+      unavailableCount: layers.filter((layer) => layer.unavailable).length,
+    };
+  });
+  const allLayers = [
+    ...primary,
+    ...disclosures.flatMap((group) => group.layers),
+  ];
+
+  return {
+    primary,
+    disclosures,
+    evidence: evidenceView(interpretation, allLayers),
+    missingData: [...interpretation.missingData],
+    overallConfidence: interpretation.overallConfidence,
+    generatedAt: interpretation.generatedAt,
+  };
+}

--- a/packages/core/soul-guide/index.ts
+++ b/packages/core/soul-guide/index.ts
@@ -9,6 +9,7 @@ export * from "./depth-types.js";
 export * from "./depth-prompt.js";
 export * from "./depth-parser.js";
 export * from "./depth-fallback.js";
+export * from "./depth-view-model.js";
 
 /**
  * Generates a Soul Guide prompt for Claude to interpret Timeline Intelligence data.


### PR DESCRIPTION
## Summary

Implements Issue #110 as the fourth stacked delivery in the Codex Depth Initiative.

This PR adds an additive `DepthSoulGuide` renderer for `DepthInterpretationV1`. It presents the strongest supported pattern, the main contradiction, and one grounded next move before exposing deeper layers on demand.

## Stack

- base: `feat/soul-guide-layered-clarity-v1` / PR #109
- head: `feat/ui-depth-progressive-disclosure-v1`
- parent epic: #102
- implementation issue: #110

This PR should be retargeted after the preceding stacked PRs merge.

## First view

The component always begins with:

1. Your Core Pattern
2. The Main Contradiction
3. What To Do With It

No deeper section is forced open by default.

## Progressive disclosure

Added accessible disclosure groups for:

- What people see
- What they miss
- The need and protection beneath it
- Gift and shadow
- Common misreading
- Relationship and decision effects
- Boundary and repair
- Evidence, confidence, limitations, and missing data

Buttons use native semantics with `aria-expanded`, `aria-controls`, linked region labels, keyboard behavior, and visible focus styles.

## Evidence UX

- claim kind and interpretation confidence remain separate
- confidence is labeled as source support, not verification or scientific truth
- evidence IDs and limitations can be shown per layer
- evidence records expose system, field, value, provenance, time sensitivity, and notes
- unavailable layers remain visible
- unknown-time missing data remains visible
- lived experience is stated as the final authority

The existing birth-data `ConfidenceBadge` is intentionally not reused because it represents a different concept.

## Architecture

### Pure view model

Added `buildDepthSoulGuideViewModel()` with stable ordering for:

- three primary cards
- seven disclosure groups
- evidence provenance counts
- referenced evidence IDs
- total limitations
- missing data

The builder clones mutable arrays and does not mutate the source interpretation.

### React component

Added reusable `client/src/components/DepthSoulGuide.tsx`.

The component:

- accepts a validated `DepthInterpretationV1`
- issues no API requests
- reads no profile storage
- generates no interpretation
- remains responsive across desktop and narrow mobile layouts
- preserves unavailable and low-support states instead of hiding them

### Compatibility

The existing Timeline-based `SoulGuide` component remains unchanged. This avoids replacing its large legacy implementation and prevents accidental provider or cache changes. Future callers can import the new renderer directly once a validated depth interpretation is available.

## Tests

Added focused coverage for:

- clarity, contradiction, and action ordering
- stable disclosure group ordering
- every non-primary layer appearing exactly once
- unavailable-layer visibility
- provenance and limitation counting
- unknown-time missing-data exposure
- source immutability
- disclosure accessibility source contract
- evidence panel accessibility
- confidence-label separation

## Validation completed

The inherited repository workflows remain blocked at `npm install` by Issue #106, before client compilation begins.

Independent validation completed:

- strict TypeScript compilation for the pure view-model contract: passed
- view-model runtime ordering smoke: passed
- source immutability smoke: passed
- evidence and missing-data summary smoke: passed
- remote diff inspection: passed

Full application and TSX compilation remains a repository CI gate once Issue #106 restores clean dependency installation.

## Diff scope

Six files only:

- one reusable React component
- one integration document
- one pure view-model module
- two focused test files
- one additive core export

No route replacement, API change, provider change, profile-storage change, dependency addition, or lockfile churn.
