### PR TITLE
fix(deploy): repair Railway production image and SPA serving

### DIFF
--- a/.github/workflows/railway-container-smoke.yml
+++ b/.github/workflows/railway-container-smoke.yml
@@ -1,0 +1,89 @@
+name: Railway Container Smoke
+
+on:
+  pull_request:
+    branches: ["main", "master"]
+    paths:
+      - "Dockerfile"
+      - "railway.json"
+      - "server/**"
+      - "client/**"
+      - "public/**"
+      - "packages/**"
+      - "scripts/generate-pwa-service-worker.mjs"
+      - "scripts/validate-pwa-output.mjs"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/railway-container-smoke.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: railway-container-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  container-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build production image
+        run: docker build --tag soulcodex-railway-smoke .
+
+      - name: Start production container
+        run: |
+          docker run --detach \
+            --name soulcodex-railway-smoke \
+            --publish 3000:3000 \
+            --env PORT=3000 \
+            --env SESSION_SECRET=container-smoke-secret \
+            soulcodex-railway-smoke
+
+      - name: Verify health and web application
+        run: |
+          set -euo pipefail
+
+          for attempt in $(seq 1 30); do
+            if curl --fail --silent http://127.0.0.1:3000/health > /tmp/health.json; then
+              break
+            fi
+            if [ "$attempt" -eq 30 ]; then
+              echo "Container did not become healthy"
+              docker logs soulcodex-railway-smoke
+              exit 1
+            fi
+            sleep 2
+          done
+
+          grep --quiet '"status":"ok"' /tmp/health.json
+
+          curl --fail --silent http://127.0.0.1:3000/ > /tmp/index.html
+          grep --quiet '<div id="root"></div>' /tmp/index.html
+          grep --quiet 'manifest.webmanifest' /tmp/index.html
+
+          asset_path=$(sed -n 's/.*src="\(\/assets\/[^\"]*\.js\)".*/\1/p' /tmp/index.html | head -n 1)
+          test -n "$asset_path"
+          curl --fail --silent "http://127.0.0.1:3000${asset_path}" > /dev/null
+
+          curl --fail --silent http://127.0.0.1:3000/profile/local-container-smoke > /tmp/deep-route.html
+          grep --quiet '<div id="root"></div>' /tmp/deep-route.html
+
+          if curl --fail --silent http://127.0.0.1:3000/api/not-a-real-route > /tmp/api-404.json; then
+            echo "Unknown API route unexpectedly returned success"
+            exit 1
+          fi
+          grep --quiet 'Route not found' /tmp/api-404.json
+
+      - name: Show container logs on failure
+        if: failure()
+        run: docker logs soulcodex-railway-smoke || true
+
+      - name: Stop production container
+        if: always()
+        run: docker rm --force soulcodex-railway-smoke || true

--- a/.github/workflows/railway-container-smoke.yml
+++ b/.github/workflows/railway-container-smoke.yml
@@ -86,10 +86,8 @@ jobs:
           curl --fail --silent http://127.0.0.1:3000/profile/local-container-smoke > /tmp/deep-route.html
           grep --quiet '<div id="root"></div>' /tmp/deep-route.html
 
-          if curl --fail --silent http://127.0.0.1:3000/api/not-a-real-route > /tmp/api-404.json; then
-            echo "Unknown API route unexpectedly returned success"
-            exit 1
-          fi
+          api_status=$(curl --silent --output /tmp/api-404.json --write-out '%{http_code}' http://127.0.0.1:3000/api/not-a-real-route)
+          test "$api_status" = "404"
           grep --quiet 'Route not found' /tmp/api-404.json
 
       - name: Show container logs on failure

--- a/.github/workflows/railway-container-smoke.yml
+++ b/.github/workflows/railway-container-smoke.yml
@@ -34,7 +34,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build production image
-        run: docker build --tag soulcodex-railway-smoke .
+        shell: bash
+        run: |
+          set -o pipefail
+          docker build --progress=plain --tag soulcodex-railway-smoke . 2>&1 | tee docker-build.log
+
+      - name: Upload Docker build transcript on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: railway-docker-build-${{ github.run_id }}
+          path: docker-build.log
+          if-no-files-found: error
+          retention-days: 14
 
       - name: Start production container
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,69 +1,34 @@
-# Soul Codex Production Dockerfile
-# This builds the Express server from server/index.ts with all root-level dependencies
+# SoulCodex production image for Railway.
+# Build the complete web application and API in one stage, then copy only
+# production runtime files into the final image.
 
 FROM node:20-alpine AS builder
 WORKDIR /app
 
-# Copy package files for dependency installation
-COPY package*.json ./
-COPY .nvmrc ./
-
-# Install all dependencies (including devDependencies for build)
-RUN npm ci
-
-# Copy all source files
+# Copy the full workspace before npm ci. The root package references local
+# workspaces, so installing with only the root package.json is not valid.
 COPY . .
 
-# Build workspace packages that are required
-RUN npm run build --workspace=packages/db --if-present
-RUN npm run build --workspace=packages/core --if-present
+RUN npm ci
+RUN npm run build:workspaces
+RUN npm run build
+RUN npm prune --omit=dev
 
-# Build the server bundle using esbuild
-# The server is at server/index.ts (not apps/api/server.ts)
-RUN npx esbuild server/index.ts \
-  --platform=node \
-  --packages=external \
-  --bundle \
-  --format=esm \
-  --outdir=dist \
-  --outExtension:.js=.js
-
-# Production stage
 FROM node:20-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production
 ENV PORT=3000
 
-# Copy package files and install production dependencies only
-COPY package*.json ./
-RUN npm ci --production --ignore-scripts
-
-# Copy built server from builder
-COPY --from=builder /app/dist ./dist
-
-# Copy workspace package dist folders (needed for runtime imports)
-COPY --from=builder /app/packages/db/dist ./packages/db/dist
-COPY --from=builder /app/packages/db/package.json ./packages/db/package.json
-COPY --from=builder /app/packages/core/dist ./packages/core/dist
-COPY --from=builder /app/packages/core/package.json ./packages/core/package.json
-
-# Copy TypeScript source packages that don't have build steps
-COPY --from=builder /app/packages/astrology ./packages/astrology
-COPY --from=builder /app/packages/ai ./packages/ai
-
-# Copy necessary root-level files that might be imported
-COPY --from=builder /app/db.ts ./db.ts
-COPY --from=builder /app/storage.ts ./storage.ts
-COPY --from=builder /app/demo-seed.ts ./demo-seed.ts
-
-# Health check endpoint
-HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
-  CMD node -e "require('http').get('http://localhost:3000/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})"
+COPY --from=builder --chown=node:node /app/package.json /app/package-lock.json ./
+COPY --from=builder --chown=node:node /app/node_modules ./node_modules
+COPY --from=builder --chown=node:node /app/packages ./packages
+COPY --from=builder --chown=node:node /app/dist ./dist
 
 EXPOSE 3000
 
-# Use node user for security
+# Railway already performs the /health check declared in railway.json. Avoid a
+# second Docker health check tied to a hard-coded port because Railway may
+# override PORT at runtime.
 USER node
-
 CMD ["node", "dist/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Build the complete web application and API in one stage, then copy only
 # production runtime files into the final image.
 
-FROM node:20-alpine AS builder
+FROM node:20-bookworm-slim AS builder
 WORKDIR /app
 
 # Copy the full workspace before npm ci. The root package references local
@@ -14,7 +14,7 @@ RUN npm run build:workspaces
 RUN npm run build
 RUN npm prune --omit=dev
 
-FROM node:20-alpine AS runner
+FROM node:20-bookworm-slim AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production
@@ -27,8 +27,8 @@ COPY --from=builder --chown=node:node /app/dist ./dist
 
 EXPOSE 3000
 
-# Railway already performs the /health check declared in railway.json. Avoid a
-# second Docker health check tied to a hard-coded port because Railway may
+# Railway performs the /health check declared in railway.json. Avoid a second
+# image-level health check tied to a hard-coded port because Railway may
 # override PORT at runtime.
 USER node
 CMD ["node", "dist/index.js"]

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,27 +1,40 @@
 // Soul Codex Express Server Entry Point
-// This is the production entry point for the Express server
+// This is the production entry point for the Express server and web client.
 import "dotenv/config";
 import express, { type Express } from "express";
 import cors from "cors";
 import session from "express-session";
-import { createServer } from "http";
+import path from "node:path";
+import { existsSync } from "node:fs";
 import { registerRoutes } from "./routes.js";
 
 const app: Express = express();
 
-// Enable CORS for mobile app connectivity
-app.use(cors({
-  origin: [
-    "soulcodex://localhost", 
-    "capacitor://localhost", 
-    "http://localhost:3000", 
-    "http://localhost:5000",
-    "https://ultimate-soulcodex.up.railway.app"
-  ],
-  methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
-  allowedHeaders: ["Content-Type", "Authorization"],
-  credentials: true
-}));
+// Railway terminates TLS before forwarding traffic to the container.
+app.set("trust proxy", 1);
+
+const allowedOrigins = [
+  "soulcodex://localhost",
+  "capacitor://localhost",
+  "http://localhost:3000",
+  "http://localhost:5000",
+  "https://soulcodex.up.railway.app",
+  "https://ultimate-soulcodex.up.railway.app",
+  process.env.PUBLIC_APP_URL,
+].filter((origin): origin is string => Boolean(origin));
+
+// Enable CORS for the browser deployment and native mobile shells.
+app.use(
+  cors({
+    origin: allowedOrigins,
+    methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allowedHeaders: ["Content-Type", "Authorization"],
+    credentials: true,
+  }),
+);
+
+app.use(express.json({ limit: "1mb" }));
+app.use(express.urlencoded({ extended: false }));
 
 // Session configuration
 app.use(
@@ -32,43 +45,75 @@ app.use(
     cookie: {
       secure: process.env.NODE_ENV === "production",
       httpOnly: true,
-      maxAge: 1000 * 60 * 60 * 24 * 7, // 7 days
+      sameSite: "lax",
+      maxAge: 1000 * 60 * 60 * 24 * 7,
     },
-  })
+  }),
 );
 
-// Health check endpoint (for Railway/Docker health checks)
+// Health check endpoint used by Railway.
 app.get("/health", (_req, res) => {
   res.status(200).json({ status: "ok" });
 });
 
-// Register all API routes
 (async () => {
   try {
     const server = await registerRoutes(app);
 
-    // Error handling middleware
+    // Serve the Vite/PWA output from the same Railway service as the API.
+    // API and health routes are registered first so the SPA fallback cannot
+    // disguise missing server endpoints as HTML responses.
+    if (process.env.NODE_ENV === "production") {
+      const publicDirectory = path.resolve(process.cwd(), "dist/public");
+      const indexFile = path.join(publicDirectory, "index.html");
+
+      if (!existsSync(indexFile)) {
+        throw new Error(
+          `Production web bundle is missing at ${indexFile}. Run the complete npm build before starting the server.`,
+        );
+      }
+
+      app.use(
+        express.static(publicDirectory, {
+          index: false,
+          maxAge: "1h",
+          immutable: false,
+        }),
+      );
+
+      app.get("*", (req, res, next) => {
+        if (req.path === "/health" || req.path.startsWith("/api/")) {
+          next();
+          return;
+        }
+        res.sendFile(indexFile);
+      });
+    }
+
+    app.use((req, res) => {
+      res.status(404).json({ message: `Route not found: ${req.method} ${req.path}` });
+    });
+
     app.use(
       (
-        err: any,
+        err: unknown,
         _req: express.Request,
         res: express.Response,
-        _next: express.NextFunction
+        _next: express.NextFunction,
       ) => {
-        const status = err.status || err.statusCode || 500;
-        const message = err.message || "Internal Server Error";
+        const typedError = err as { status?: number; statusCode?: number; message?: string };
+        const status = typedError.status || typedError.statusCode || 500;
+        const message = typedError.message || "Internal Server Error";
         console.error(`[ERROR] ${status}: ${message}`, err);
         res.status(status).json({ message });
-      }
+      },
     );
 
-    // Start the server
-    const PORT = parseInt(process.env.PORT || "3000", 10);
-    server.listen(PORT, "0.0.0.0", () => {
-      console.log(`🚀 Soul Codex server running on port ${PORT}`);
-      console.log(`📡 Health check: http://localhost:${PORT}/health`);
-      console.log(`🔮 API endpoints: http://localhost:${PORT}/api/*`);
-      console.log(`🌍 Environment: ${process.env.NODE_ENV || "development"}`);
+    const port = Number.parseInt(process.env.PORT || "3000", 10);
+    server.listen(port, "0.0.0.0", () => {
+      console.log(`Soul Codex server running on port ${port}`);
+      console.log(`Health check: http://localhost:${port}/health`);
+      console.log(`Environment: ${process.env.NODE_ENV || "development"}`);
     });
   } catch (error) {
     console.error("Failed to start server:", error);


### PR DESCRIPTION
## Problem

Railway deployments were failing across multiple recent commits. The repository's Docker path had three structural problems:

- `npm ci` ran before workspace package manifests were copied
- the Docker build bundled only the Express server and never built the Vite/PWA client
- the runtime image never contained `dist/public`, while the Express server did not serve the production client
- the image health check was hard-coded to port 3000 even though Railway can override `PORT`

## Fix

- build the complete monorepo from the full workspace context
- run the existing production build, including PWA generation and validation
- prune development dependencies before constructing the runtime image
- copy the complete `dist` output and workspace runtime packages
- serve `dist/public` from Express in production
- preserve `/health` and `/api/*` routing ahead of the SPA fallback
- accept both known Railway domains in CORS
- add request-body parsing and Railway proxy trust
- add a Docker-level smoke workflow that verifies:
  - image build
  - process startup
  - `/health`
  - homepage HTML
  - built JavaScript asset delivery
  - deep SPA routes
  - unknown API routes remain JSON 404s

## Classification

Target: integrated and container-validated before merge.
