### PR TITLE
fix(ios): install local Swift packages before Xcode Cloud resolution

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -18,9 +18,9 @@ permissions:
 jobs:
   build-ios:
     runs-on: macos-14
-    timeout-minutes: 30
+    timeout-minutes: 40
     env:
-      VITE_API_URL: ${{ vars.VITE_API_URL }}
+      VITE_API_URL: ${{ vars.VITE_API_URL || 'https://soulcodex.up.railway.app' }}
 
     steps:
       - name: Checkout
@@ -32,27 +32,25 @@ jobs:
           node-version: 22
           cache: npm
 
-      - name: Install dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build workspace packages
-        run: |
-          npm run build -w @soulcodex/db
-          npm run build -w @soulcodex/core
-
-      - name: Validate mobile release configuration
-        run: npm run mobile:validate:ios
-
-      - name: Build web app
-        run: npm run build
-
-      - name: Sync Capacitor
-        run: npx cap sync ios
-
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
+
+      - name: Bootstrap JavaScript and local Swift packages
+        env:
+          CI_PRIMARY_REPOSITORY_PATH: ${{ github.workspace }}
+        run: ci_scripts/ci_post_clone.sh
+
+      - name: Validate mobile release configuration
+        run: npm run mobile:validate:ios
+
+      - name: Resolve Xcode package dependencies
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -project ios/App/App.xcodeproj \
+            -scheme "Soul Codex" \
+            -clonedSourcePackagesDirPath "$RUNNER_TEMP/SourcePackages"
 
       - name: Build iOS (Development)
         if: inputs.build_type == 'development'

--- a/.github/workflows/xcode-cloud-dependency-smoke.yml
+++ b/.github/workflows/xcode-cloud-dependency-smoke.yml
@@ -1,0 +1,61 @@
+name: Xcode Cloud Dependency Smoke
+
+on:
+  pull_request:
+    branches: ["main", "master"]
+    paths:
+      - "ci_scripts/**"
+      - "ios/**"
+      - "scripts/patch-apple-sign-in-swiftpm.mjs"
+      - "scripts/validate-mobile-release.mjs"
+      - "capacitor.config.ts"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/build-ios.yml"
+      - ".github/workflows/xcode-cloud-dependency-smoke.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: xcode-cloud-dependencies-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  resolve-local-swift-packages:
+    runs-on: macos-14
+    timeout-minutes: 35
+    env:
+      VITE_API_URL: https://soulcodex.up.railway.app
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Verify Xcode Cloud hook is executable
+        run: test -x ci_scripts/ci_post_clone.sh
+
+      - name: Run Xcode Cloud post-clone hook
+        env:
+          CI_PRIMARY_REPOSITORY_PATH: ${{ github.workspace }}
+        run: ci_scripts/ci_post_clone.sh
+
+      - name: Verify Apple Sign-In local package exists
+        run: |
+          test -d node_modules/@capawesome/capacitor-apple-sign-in
+          test -f node_modules/@capawesome/capacitor-apple-sign-in/Package.swift
+          grep -q 'CapawesomeCapacitorAppleSignIn' ios/App/CapApp-SPM/Package.swift
+
+      - name: Resolve Xcode package dependencies
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -project ios/App/App.xcodeproj \
+            -scheme "Soul Codex" \
+            -clonedSourcePackagesDirPath "$RUNNER_TEMP/SourcePackages"

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+set -eu
+
+REPOSITORY_PATH="${CI_PRIMARY_REPOSITORY_PATH:-$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)}"
+cd "$REPOSITORY_PATH"
+
+export VITE_API_URL="${VITE_API_URL:-https://soulcodex.up.railway.app}"
+
+echo "Xcode Cloud post-clone bootstrap"
+echo "Repository: $REPOSITORY_PATH"
+echo "Node: $(node --version)"
+echo "npm: $(npm --version)"
+
+npm ci --include=dev --no-audit --no-fund
+npm run build:workspaces
+npm run build:capacitor
+npx cap sync ios
+npm run mobile:patch:ios
+
+APPLE_SIGN_IN_PACKAGE="node_modules/@capawesome/capacitor-apple-sign-in"
+for required_path in \
+  "$APPLE_SIGN_IN_PACKAGE" \
+  "$APPLE_SIGN_IN_PACKAGE/Package.swift" \
+  "node_modules/@capacitor/keyboard/Package.swift" \
+  "node_modules/@capacitor/splash-screen/Package.swift" \
+  "node_modules/@capacitor/status-bar/Package.swift" \
+  "ios/App/CapApp-SPM/Package.swift"; do
+  if [ ! -e "$required_path" ]; then
+    echo "Missing required Xcode Cloud dependency: $required_path" >&2
+    exit 1
+  fi
+done
+
+grep -q 'CapawesomeCapacitorAppleSignIn' ios/App/CapApp-SPM/Package.swift
+
+echo "Xcode Cloud JavaScript and local Swift package dependencies are ready."


### PR DESCRIPTION
## Problem

Xcode Cloud resolves `ios/App/CapApp-SPM/Package.swift` before the repository has a `node_modules` directory. Capacitor's generated Swift package references Apple Sign-In and other plugins through local paths under `node_modules`, causing package resolution to fail immediately.

## Fix

- adds executable `ci_scripts/ci_post_clone.sh`, which Xcode Cloud runs before dependency resolution
- installs deterministic npm dependencies with `npm ci`
- builds workspace packages and the Capacitor web bundle
- runs `npx cap sync ios`
- applies the existing Apple Sign-In Swift compatibility patch
- verifies all local Swift package paths exist before Xcode starts
- updates the manual iOS workflow to use the same bootstrap path
- adds a macOS dependency smoke workflow that checks executable mode and runs `xcodebuild -resolvePackageDependencies`

## Failure addressed

`node_modules/@capawesome/capacitor-apple-sign-in doesn't exist in file system`

## Classification target

Integrated and macOS/Xcode dependency-resolution validated before merge.