### PR TITLE
fix(ios): make Swift packages resolvable before Xcode Cloud scripts

### DIFF
--- a/.github/workflows/xcode-cloud-dependency-smoke.yml
+++ b/.github/workflows/xcode-cloud-dependency-smoke.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   resolve-clone-ready-swift-packages:
     runs-on: macos-14
-    timeout-minutes: 40
+    timeout-minutes: 50
     env:
       VITE_API_URL: https://soulcodex.up.railway.app
 
@@ -46,6 +46,7 @@ jobs:
             exit 1
           fi
           grep -q 'ionic-team/capacitor-keyboard.git' "$manifest"
+          grep -q 'package: "capacitor-keyboard"' "$manifest"
           grep -q '../Vendor/CapacitorSplashScreen' "$manifest"
           grep -q '../Vendor/CapacitorStatusBar' "$manifest"
           grep -q '../Vendor/CapawesomeCapacitorAppleSignIn' "$manifest"
@@ -81,6 +82,7 @@ jobs:
             echo "Capacitor sync restored a node_modules Swift package path"
             exit 1
           fi
+          grep -q 'package: "capacitor-keyboard"' "$manifest"
           test -f ios/App/Vendor/CapawesomeCapacitorAppleSignIn/Sources/AppleSignInPlugin/AppleSignInPlugin.swift
           grep -q '../Vendor/CapawesomeCapacitorAppleSignIn' "$manifest"
 
@@ -94,6 +96,20 @@ jobs:
             -clonedSourcePackagesDirPath "$RUNNER_TEMP/PostBootstrapSourcePackages" \
             2>&1 | tee post-bootstrap-resolve.log
 
+      - name: Build iOS app without code signing
+        shell: bash
+        run: |
+          set -o pipefail
+          xcodebuild \
+            -project ios/App/App.xcodeproj \
+            -scheme "Soul Codex" \
+            -configuration Debug \
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath "$RUNNER_TEMP/SoulCodexDerivedData" \
+            -clonedSourcePackagesDirPath "$RUNNER_TEMP/PostBootstrapSourcePackages" \
+            CODE_SIGNING_ALLOWED=NO \
+            build 2>&1 | tee ios-build.log
+
       - name: Upload Xcode resolver evidence
         if: always()
         uses: actions/upload-artifact@v4
@@ -102,6 +118,7 @@ jobs:
           path: |
             pre-bootstrap-resolve.log
             post-bootstrap-resolve.log
+            ios-build.log
             post-sync-Package.swift
             post-sync-manifest.diff
           if-no-files-found: warn

--- a/.github/workflows/xcode-cloud-dependency-smoke.yml
+++ b/.github/workflows/xcode-cloud-dependency-smoke.yml
@@ -51,11 +51,14 @@ jobs:
           grep -q '../Vendor/CapawesomeCapacitorAppleSignIn' "$manifest"
 
       - name: Resolve dependencies before JavaScript bootstrap
+        shell: bash
         run: |
+          set -o pipefail
           xcodebuild -resolvePackageDependencies \
             -project ios/App/App.xcodeproj \
             -scheme "Soul Codex" \
-            -clonedSourcePackagesDirPath "$RUNNER_TEMP/PreBootstrapSourcePackages"
+            -clonedSourcePackagesDirPath "$RUNNER_TEMP/PreBootstrapSourcePackages" \
+            2>&1 | tee pre-bootstrap-resolve.log
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -72,6 +75,8 @@ jobs:
         run: |
           set -euo pipefail
           manifest="ios/App/CapApp-SPM/Package.swift"
+          cp "$manifest" post-sync-Package.swift
+          git diff -- "$manifest" > post-sync-manifest.diff || true
           if grep -q 'node_modules/' "$manifest"; then
             echo "Capacitor sync restored a node_modules Swift package path"
             exit 1
@@ -80,8 +85,24 @@ jobs:
           grep -q '../Vendor/CapawesomeCapacitorAppleSignIn' "$manifest"
 
       - name: Resolve dependencies after Capacitor sync
+        shell: bash
         run: |
+          set -o pipefail
           xcodebuild -resolvePackageDependencies \
             -project ios/App/App.xcodeproj \
             -scheme "Soul Codex" \
-            -clonedSourcePackagesDirPath "$RUNNER_TEMP/PostBootstrapSourcePackages"
+            -clonedSourcePackagesDirPath "$RUNNER_TEMP/PostBootstrapSourcePackages" \
+            2>&1 | tee post-bootstrap-resolve.log
+
+      - name: Upload Xcode resolver evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: xcode-package-resolution-${{ github.run_id }}
+          path: |
+            pre-bootstrap-resolve.log
+            post-bootstrap-resolve.log
+            post-sync-Package.swift
+            post-sync-manifest.diff
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/xcode-cloud-dependency-smoke.yml
+++ b/.github/workflows/xcode-cloud-dependency-smoke.yml
@@ -4,9 +4,9 @@ on:
   pull_request:
     branches: ["main", "master"]
     paths:
-      - "ios/App/ci_scripts/**"
       - "ios/**"
       - "scripts/patch-apple-sign-in-swiftpm.mjs"
+      - "scripts/patch-capapp-spm-vendored-packages.mjs"
       - "scripts/validate-mobile-release.mjs"
       - "capacitor.config.ts"
       - "package.json"
@@ -23,9 +23,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  resolve-local-swift-packages:
+  resolve-clone-ready-swift-packages:
     runs-on: macos-14
-    timeout-minutes: 35
+    timeout-minutes: 40
     env:
       VITE_API_URL: https://soulcodex.up.railway.app
 
@@ -33,32 +33,55 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Verify clone-ready Swift package graph
+        run: |
+          set -euo pipefail
+          manifest="ios/App/CapApp-SPM/Package.swift"
+          test -f "$manifest"
+          test -f ios/App/Vendor/CapawesomeCapacitorAppleSignIn/Package.swift
+          test -f ios/App/Vendor/CapacitorSplashScreen/Package.swift
+          test -f ios/App/Vendor/CapacitorStatusBar/Package.swift
+          if grep -q 'node_modules/' "$manifest"; then
+            echo "CapApp-SPM must not depend on node_modules during Xcode Cloud dependency resolution"
+            exit 1
+          fi
+          grep -q 'ionic-team/capacitor-keyboard.git' "$manifest"
+          grep -q '../Vendor/CapacitorSplashScreen' "$manifest"
+          grep -q '../Vendor/CapacitorStatusBar' "$manifest"
+          grep -q '../Vendor/CapawesomeCapacitorAppleSignIn' "$manifest"
+
+      - name: Resolve dependencies before JavaScript bootstrap
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -project ios/App/App.xcodeproj \
+            -scheme "Soul Codex" \
+            -clonedSourcePackagesDirPath "$RUNNER_TEMP/PreBootstrapSourcePackages"
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm
 
-      - name: Verify hook is beside the Xcode project
-        run: |
-          test -f ios/App/App.xcodeproj/project.pbxproj
-          test -f ios/App/ci_scripts/ci_post_clone.sh
-          test ! -f ci_scripts/ci_pre_xcodebuild.sh
-
       - name: Run project-local Xcode Cloud post-clone hook
         env:
           CI_PRIMARY_REPOSITORY_PATH: ${{ github.workspace }}
         run: sh ios/App/ci_scripts/ci_post_clone.sh
 
-      - name: Verify Apple Sign-In local package exists
+      - name: Verify Capacitor sync preserved clone-ready packages
         run: |
-          test -d node_modules/@capawesome/capacitor-apple-sign-in
-          test -f node_modules/@capawesome/capacitor-apple-sign-in/Package.swift
-          grep -q 'CapawesomeCapacitorAppleSignIn' ios/App/CapApp-SPM/Package.swift
+          set -euo pipefail
+          manifest="ios/App/CapApp-SPM/Package.swift"
+          if grep -q 'node_modules/' "$manifest"; then
+            echo "Capacitor sync restored a node_modules Swift package path"
+            exit 1
+          fi
+          test -f ios/App/Vendor/CapawesomeCapacitorAppleSignIn/Sources/AppleSignInPlugin/AppleSignInPlugin.swift
+          grep -q '../Vendor/CapawesomeCapacitorAppleSignIn' "$manifest"
 
-      - name: Resolve Xcode package dependencies
+      - name: Resolve dependencies after Capacitor sync
         run: |
           xcodebuild -resolvePackageDependencies \
             -project ios/App/App.xcodeproj \
             -scheme "Soul Codex" \
-            -clonedSourcePackagesDirPath "$RUNNER_TEMP/SourcePackages"
+            -clonedSourcePackagesDirPath "$RUNNER_TEMP/PostBootstrapSourcePackages"

--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -1,7 +1,8 @@
 // swift-tools-version: 5.9
 import PackageDescription
 
-// DO NOT MODIFY THIS FILE - managed by Capacitor CLI commands
+// DO NOT MODIFY THIS FILE - managed by Capacitor CLI commands and
+// scripts/patch-capapp-spm-vendored-packages.mjs.
 let package = Package(
     name: "CapApp-SPM",
     platforms: [.iOS(.v15)],
@@ -15,7 +16,7 @@ let package = Package(
         .package(name: "CapacitorKeyboard", path: "../../../node_modules/@capacitor/keyboard"),
         .package(name: "CapacitorSplashScreen", path: "../../../node_modules/@capacitor/splash-screen"),
         .package(name: "CapacitorStatusBar", path: "../../../node_modules/@capacitor/status-bar"),
-        .package(name: "CapawesomeCapacitorAppleSignIn", path: "../../../node_modules/@capawesome/capacitor-apple-sign-in")
+        .package(name: "CapawesomeCapacitorAppleSignIn", path: "../Vendor/CapawesomeCapacitorAppleSignIn")
     ],
     targets: [
         .target(

--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -1,8 +1,9 @@
 // swift-tools-version: 5.9
 import PackageDescription
 
-// DO NOT MODIFY THIS FILE - managed by Capacitor CLI commands and
+// Managed by Capacitor CLI commands and
 // scripts/patch-capapp-spm-vendored-packages.mjs.
+// All native package references must be resolvable immediately after clone.
 let package = Package(
     name: "CapApp-SPM",
     platforms: [.iOS(.v15)],
@@ -13,9 +14,9 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.4.2"),
-        .package(name: "CapacitorKeyboard", path: "../../../node_modules/@capacitor/keyboard"),
-        .package(name: "CapacitorSplashScreen", path: "../../../node_modules/@capacitor/splash-screen"),
-        .package(name: "CapacitorStatusBar", path: "../../../node_modules/@capacitor/status-bar"),
+        .package(url: "https://github.com/ionic-team/capacitor-keyboard.git", exact: "8.0.3"),
+        .package(name: "CapacitorSplashScreen", path: "../Vendor/CapacitorSplashScreen"),
+        .package(name: "CapacitorStatusBar", path: "../Vendor/CapacitorStatusBar"),
         .package(name: "CapawesomeCapacitorAppleSignIn", path: "../Vendor/CapawesomeCapacitorAppleSignIn")
     ],
     targets: [

--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -25,6 +25,9 @@ let package = Package(
             dependencies: [
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
                 .product(name: "Cordova", package: "capacitor-swift-pm"),
+                .product(name: "CapacitorKeyboard", package: "capacitor-keyboard"),
+                .product(name: "CapacitorSplashScreen", package: "CapacitorSplashScreen"),
+                .product(name: "CapacitorStatusBar", package: "CapacitorStatusBar"),
                 .product(name: "CapawesomeCapacitorAppleSignIn", package: "CapawesomeCapacitorAppleSignIn")
             ]
         )

--- a/ios/App/Vendor/CapacitorSplashScreen/LICENSE
+++ b/ios/App/Vendor/CapacitorSplashScreen/LICENSE
@@ -1,0 +1,23 @@
+Copyright 2020-present Ionic
+https://ionic.io
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/ios/App/Vendor/CapacitorSplashScreen/Package.swift
+++ b/ios/App/Vendor/CapacitorSplashScreen/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+// Vendored from @capacitor/splash-screen 8.0.1 (MIT) so Xcode Cloud can
+// resolve this native plugin immediately after cloning the repository.
+let package = Package(
+    name: "CapacitorSplashScreen",
+    platforms: [.iOS(.v15)],
+    products: [
+        .library(
+            name: "CapacitorSplashScreen",
+            targets: ["SplashScreenPlugin"])
+    ],
+    dependencies: [
+        .package(
+            url: "https://github.com/ionic-team/capacitor-swift-pm.git",
+            exact: "8.4.2")
+    ],
+    targets: [
+        .target(
+            name: "SplashScreenPlugin",
+            dependencies: [
+                .product(name: "Capacitor", package: "capacitor-swift-pm"),
+                .product(name: "Cordova", package: "capacitor-swift-pm")
+            ],
+            path: "Sources/SplashScreenPlugin")
+    ]
+)

--- a/ios/App/Vendor/CapacitorSplashScreen/Sources/SplashScreenPlugin/SplashScreen.swift
+++ b/ios/App/Vendor/CapacitorSplashScreen/Sources/SplashScreenPlugin/SplashScreen.swift
@@ -1,0 +1,157 @@
+import Foundation
+import Capacitor
+
+@objc public class SplashScreen: NSObject {
+
+    var parentView: UIView
+    var viewController = UIViewController()
+    var spinner = UIActivityIndicatorView()
+    var config: SplashScreenConfig = SplashScreenConfig()
+    var hideTask: Any?
+    var isVisible: Bool = false
+
+    init(parentView: UIView, config: SplashScreenConfig) {
+        self.parentView = parentView
+        self.config = config
+    }
+
+    public func showOnLaunch() {
+        buildViews()
+        if self.config.launchShowDuration == 0 {
+            return
+        }
+        var settings = SplashScreenSettings()
+        settings.showDuration = config.launchShowDuration
+        settings.fadeInDuration = config.launchFadeInDuration
+        settings.autoHide = config.launchAutoHide
+        showSplash(settings: settings, completion: {}, isLaunchSplash: true)
+    }
+
+    public func show(settings: SplashScreenSettings, completion: @escaping () -> Void) {
+        self.showSplash(settings: settings, completion: completion, isLaunchSplash: false)
+    }
+
+    public func hide(settings: SplashScreenSettings) {
+        hideSplash(fadeOutDuration: settings.fadeOutDuration, isLaunchSplash: false)
+    }
+
+    private func showSplash(settings: SplashScreenSettings, completion: @escaping () -> Void, isLaunchSplash: Bool) {
+        DispatchQueue.main.async { [weak self] in
+            guard let strongSelf = self else {
+                return
+            }
+            if let backgroundColor = strongSelf.config.backgroundColor {
+                strongSelf.viewController.view.backgroundColor = backgroundColor
+            }
+
+            if strongSelf.config.showSpinner {
+                if let style = strongSelf.config.spinnerStyle {
+                    strongSelf.spinner.style = style
+                }
+
+                if let spinnerColor = strongSelf.config.spinnerColor {
+                    strongSelf.spinner.color = spinnerColor
+                }
+            }
+
+            strongSelf.parentView.addSubview(strongSelf.viewController.view)
+
+            if strongSelf.config.showSpinner {
+                strongSelf.parentView.addSubview(strongSelf.spinner)
+                strongSelf.spinner.centerXAnchor.constraint(equalTo: strongSelf.parentView.centerXAnchor).isActive = true
+                strongSelf.spinner.centerYAnchor.constraint(equalTo: strongSelf.parentView.centerYAnchor).isActive = true
+            }
+
+            strongSelf.parentView.isUserInteractionEnabled = false
+
+            UIView.transition(with: strongSelf.viewController.view, duration: TimeInterval(Double(settings.fadeInDuration) / 1000), options: .curveLinear, animations: {
+                strongSelf.viewController.view.alpha = 1
+
+                if strongSelf.config.showSpinner {
+                    strongSelf.spinner.alpha = 1
+                }
+            }) { (_: Bool) in
+                strongSelf.isVisible = true
+
+                if settings.autoHide {
+                    strongSelf.hideTask = DispatchQueue.main.asyncAfter(
+                        deadline: DispatchTime.now() + (Double(settings.showDuration) / 1000)
+                    ) {
+                        strongSelf.hideSplash(fadeOutDuration: settings.fadeOutDuration, isLaunchSplash: isLaunchSplash)
+                        completion()
+                    }
+                } else {
+                    completion()
+                }
+            }
+        }
+    }
+
+    private func buildViews() {
+        let storyboardName = Bundle.main.infoDictionary?["UILaunchStoryboardName"] as? String ?? "LaunchScreen"
+        if let vc = UIStoryboard(name: storyboardName.replacingOccurrences(of: ".storyboard", with: ""), bundle: nil).instantiateInitialViewController() {
+            viewController = vc
+        }
+
+        parentView.addObserver(self, forKeyPath: "frame", options: .new, context: nil)
+        parentView.addObserver(self, forKeyPath: "bounds", options: .new, context: nil)
+
+        updateSplashImageBounds()
+        if config.showSpinner {
+            spinner.translatesAutoresizingMaskIntoConstraints = false
+            spinner.startAnimating()
+        }
+    }
+
+    private func tearDown() {
+        isVisible = false
+        parentView.isUserInteractionEnabled = true
+        viewController.view.removeFromSuperview()
+
+        if config.showSpinner {
+            spinner.removeFromSuperview()
+        }
+    }
+
+    private func updateSplashImageBounds() {
+        var window: UIWindow? = UIApplication.shared.delegate?.window ?? nil
+
+        if window == nil {
+            let scene: UIWindowScene? = UIApplication.shared.connectedScenes.first as? UIWindowScene
+            window = scene?.windows.filter({$0.isKeyWindow}).first
+            if window == nil {
+                window = scene?.windows.first
+            }
+        }
+
+        if let unwrappedWindow = window {
+            viewController.view.frame = CGRect(origin: CGPoint(x: 0, y: 0), size: unwrappedWindow.bounds.size)
+        } else {
+            CAPLog.print("Unable to find root window object for SplashScreen bounds. Please file an issue")
+        }
+    }
+
+    override public func observeValue(forKeyPath keyPath: String?, of object: Any?, change _: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
+        updateSplashImageBounds()
+    }
+
+    private func hideSplash(fadeOutDuration: Int, isLaunchSplash: Bool) {
+        if isLaunchSplash, isVisible {
+            CAPLog.print("SplashScreen.hideSplash: SplashScreen was automatically hidden after default timeout. " +
+                            "You should call `SplashScreen.hide()` as soon as your web app is loaded (or increase the timeout). " +
+                            "Read more at https://capacitorjs.com/docs/apis/splash-screen#hiding-the-splash-screen")
+        }
+        if !isVisible { return }
+        DispatchQueue.main.async {
+            UIView.transition(with: self.viewController.view, duration: TimeInterval(Double(fadeOutDuration) / 1000), options: .curveLinear, animations: {
+                self.viewController.view.alpha = 0
+
+                if self.config.showSpinner {
+                    self.spinner.alpha = 0
+                }
+            }) { (_: Bool) in
+                self.tearDown()
+            }
+        }
+    }
+}

--- a/ios/App/Vendor/CapacitorSplashScreen/Sources/SplashScreenPlugin/SplashScreenConfig.swift
+++ b/ios/App/Vendor/CapacitorSplashScreen/Sources/SplashScreenPlugin/SplashScreenConfig.swift
@@ -1,0 +1,11 @@
+import UIKit
+
+public struct SplashScreenConfig {
+    var backgroundColor: UIColor?
+    var spinnerStyle: UIActivityIndicatorView.Style?
+    var spinnerColor: UIColor?
+    var showSpinner = false
+    var launchShowDuration = 500
+    var launchAutoHide = true
+    let launchFadeInDuration = 0
+}

--- a/ios/App/Vendor/CapacitorSplashScreen/Sources/SplashScreenPlugin/SplashScreenPlugin.swift
+++ b/ios/App/Vendor/CapacitorSplashScreen/Sources/SplashScreenPlugin/SplashScreenPlugin.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Capacitor
+
+@objc(SplashScreenPlugin)
+public class SplashScreenPlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "SplashScreenPlugin"
+    public let jsName = "SplashScreen"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "show", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "hide", returnType: CAPPluginReturnPromise)
+    ]
+    private var splashScreen: SplashScreen?
+
+    override public func load() {
+        if let view = bridge?.viewController?.view {
+            splashScreen = SplashScreen(parentView: view, config: splashScreenConfig())
+            splashScreen?.showOnLaunch()
+        }
+    }
+
+    // Show the splash screen
+    @objc public func show(_ call: CAPPluginCall) {
+        if let splash = splashScreen {
+            let settings = splashScreenSettings(from: call)
+            splash.show(settings: settings,
+                        completion: {
+                            call.resolve()
+                        })
+        } else {
+            call.reject("Unable to show Splash Screen")
+        }
+
+    }
+
+    // Hide the splash screen
+    @objc public func hide(_ call: CAPPluginCall) {
+        if let splash = splashScreen {
+            let settings = splashScreenSettings(from: call)
+            splash.hide(settings: settings)
+            call.resolve()
+        } else {
+            call.reject("Unable to hide Splash Screen")
+        }
+    }
+
+    private func splashScreenSettings(from call: CAPPluginCall) -> SplashScreenSettings {
+        var settings = SplashScreenSettings()
+
+        if let showDuration = call.getInt("showDuration") {
+            settings.showDuration = showDuration
+        }
+        if let fadeInDuration = call.getInt("fadeInDuration") {
+            settings.fadeInDuration = fadeInDuration
+        }
+        if let fadeOutDuration = call.getInt("fadeOutDuration") {
+            settings.fadeOutDuration = fadeOutDuration
+        }
+        if let autoHide = call.getBool("autoHide") {
+            settings.autoHide = autoHide
+        }
+        return settings
+    }
+
+    private func splashScreenConfig() -> SplashScreenConfig {
+        var config = SplashScreenConfig()
+
+        if let backgroundColor = getConfig().getString("backgroundColor") {
+            config.backgroundColor = UIColor.capacitor.color(fromHex: backgroundColor)
+        }
+        if let spinnerStyle = getConfig().getString("iosSpinnerStyle") {
+            switch spinnerStyle.lowercased() {
+            case "small":
+                config.spinnerStyle = .medium
+            default:
+                config.spinnerStyle = .large
+            }
+        }
+        if let spinnerColor = getConfig().getString("spinnerColor") {
+            config.spinnerColor = UIColor.capacitor.color(fromHex: spinnerColor)
+        }
+        config.showSpinner = getConfig().getBoolean("showSpinner", config.showSpinner)
+
+        config.launchShowDuration = getConfig().getInt("launchShowDuration", config.launchShowDuration)
+        config.launchAutoHide = getConfig().getBoolean("launchAutoHide", config.launchAutoHide)
+        return config
+    }
+
+}

--- a/ios/App/Vendor/CapacitorSplashScreen/Sources/SplashScreenPlugin/SplashScreenPlugin.swift
+++ b/ios/App/Vendor/CapacitorSplashScreen/Sources/SplashScreenPlugin/SplashScreenPlugin.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Capacitor
+import UIKit
 
 @objc(SplashScreenPlugin)
 public class SplashScreenPlugin: CAPPlugin, CAPBridgedPlugin {
@@ -18,21 +19,15 @@ public class SplashScreenPlugin: CAPPlugin, CAPBridgedPlugin {
         }
     }
 
-    // Show the splash screen
     @objc public func show(_ call: CAPPluginCall) {
         if let splash = splashScreen {
             let settings = splashScreenSettings(from: call)
-            splash.show(settings: settings,
-                        completion: {
-                            call.resolve()
-                        })
+            splash.show(settings: settings, completion: { call.resolve() })
         } else {
             call.reject("Unable to show Splash Screen")
         }
-
     }
 
-    // Hide the splash screen
     @objc public func hide(_ call: CAPPluginCall) {
         if let splash = splashScreen {
             let settings = splashScreenSettings(from: call)
@@ -45,7 +40,6 @@ public class SplashScreenPlugin: CAPPlugin, CAPBridgedPlugin {
 
     private func splashScreenSettings(from call: CAPPluginCall) -> SplashScreenSettings {
         var settings = SplashScreenSettings()
-
         if let showDuration = call.getInt("showDuration") {
             settings.showDuration = showDuration
         }
@@ -61,13 +55,47 @@ public class SplashScreenPlugin: CAPPlugin, CAPBridgedPlugin {
         return settings
     }
 
+    private func configString(_ key: String) -> String? {
+        return getConfig().getConfigJSON()[key] as? String
+    }
+
+    private static func color(fromHex value: String) -> UIColor? {
+        let hex = value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "#", with: "")
+
+        guard hex.count == 6 || hex.count == 8,
+              let raw = UInt64(hex, radix: 16) else {
+            return nil
+        }
+
+        let red: CGFloat
+        let green: CGFloat
+        let blue: CGFloat
+        let alpha: CGFloat
+
+        if hex.count == 6 {
+            red = CGFloat((raw >> 16) & 0xFF) / 255.0
+            green = CGFloat((raw >> 8) & 0xFF) / 255.0
+            blue = CGFloat(raw & 0xFF) / 255.0
+            alpha = 1.0
+        } else {
+            red = CGFloat((raw >> 24) & 0xFF) / 255.0
+            green = CGFloat((raw >> 16) & 0xFF) / 255.0
+            blue = CGFloat((raw >> 8) & 0xFF) / 255.0
+            alpha = CGFloat(raw & 0xFF) / 255.0
+        }
+
+        return UIColor(red: red, green: green, blue: blue, alpha: alpha)
+    }
+
     private func splashScreenConfig() -> SplashScreenConfig {
         var config = SplashScreenConfig()
 
-        if let backgroundColor = getConfig().getString("backgroundColor") {
-            config.backgroundColor = UIColor.capacitor.color(fromHex: backgroundColor)
+        if let backgroundColor = configString("backgroundColor") {
+            config.backgroundColor = Self.color(fromHex: backgroundColor)
         }
-        if let spinnerStyle = getConfig().getString("iosSpinnerStyle") {
+        if let spinnerStyle = configString("iosSpinnerStyle") {
             switch spinnerStyle.lowercased() {
             case "small":
                 config.spinnerStyle = .medium
@@ -75,14 +103,12 @@ public class SplashScreenPlugin: CAPPlugin, CAPBridgedPlugin {
                 config.spinnerStyle = .large
             }
         }
-        if let spinnerColor = getConfig().getString("spinnerColor") {
-            config.spinnerColor = UIColor.capacitor.color(fromHex: spinnerColor)
+        if let spinnerColor = configString("spinnerColor") {
+            config.spinnerColor = Self.color(fromHex: spinnerColor)
         }
         config.showSpinner = getConfig().getBoolean("showSpinner", config.showSpinner)
-
         config.launchShowDuration = getConfig().getInt("launchShowDuration", config.launchShowDuration)
         config.launchAutoHide = getConfig().getBoolean("launchAutoHide", config.launchAutoHide)
         return config
     }
-
 }

--- a/ios/App/Vendor/CapacitorSplashScreen/Sources/SplashScreenPlugin/SplashScreenSettings.swift
+++ b/ios/App/Vendor/CapacitorSplashScreen/Sources/SplashScreenPlugin/SplashScreenSettings.swift
@@ -1,0 +1,8 @@
+import UIKit
+
+public struct SplashScreenSettings {
+    var showDuration = 3000
+    var fadeInDuration = 200
+    var fadeOutDuration = 200
+    var autoHide = true
+}

--- a/ios/App/Vendor/CapacitorStatusBar/LICENSE
+++ b/ios/App/Vendor/CapacitorStatusBar/LICENSE
@@ -1,0 +1,23 @@
+Copyright 2020-present Ionic
+https://ionic.io
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/ios/App/Vendor/CapacitorStatusBar/Package.swift
+++ b/ios/App/Vendor/CapacitorStatusBar/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+// Vendored from @capacitor/status-bar 8.0.2 (MIT) so Xcode Cloud can
+// resolve this native plugin immediately after cloning the repository.
+let package = Package(
+    name: "CapacitorStatusBar",
+    platforms: [.iOS(.v15)],
+    products: [
+        .library(
+            name: "CapacitorStatusBar",
+            targets: ["StatusBarPlugin"])
+    ],
+    dependencies: [
+        .package(
+            url: "https://github.com/ionic-team/capacitor-swift-pm.git",
+            exact: "8.4.2")
+    ],
+    targets: [
+        .target(
+            name: "StatusBarPlugin",
+            dependencies: [
+                .product(name: "Capacitor", package: "capacitor-swift-pm"),
+                .product(name: "Cordova", package: "capacitor-swift-pm")
+            ],
+            path: "Sources/StatusBarPlugin")
+    ]
+)

--- a/ios/App/Vendor/CapacitorStatusBar/Sources/StatusBarPlugin/StatusBar.swift
+++ b/ios/App/Vendor/CapacitorStatusBar/Sources/StatusBarPlugin/StatusBar.swift
@@ -1,0 +1,168 @@
+import Foundation
+import Capacitor
+
+public class StatusBar {
+
+    private var bridge: CAPBridgeProtocol
+    private var isOverlayingWebview = true
+    private var backgroundColor = UIColor.black
+    private var backgroundView: UIView?
+    private var observers: [NSObjectProtocol] = []
+
+    init(bridge: CAPBridgeProtocol, config: StatusBarConfig) {
+        self.bridge = bridge
+        setupObservers(with: config)
+    }
+
+    deinit {
+        observers.forEach { NotificationCenter.default.removeObserver($0) }
+    }
+
+    private func setupObservers(with config: StatusBarConfig) {
+        observers.append(NotificationCenter.default.addObserver(forName: .capacitorViewDidAppear, object: .none, queue: .none) { [weak self] _ in
+            self?.handleViewDidAppear(config: config)
+        })
+        observers.append(NotificationCenter.default.addObserver(forName: .capacitorStatusBarTapped, object: .none, queue: .none) { [weak self] _ in
+            self?.bridge.triggerJSEvent(eventName: "statusTap", target: "window")
+        })
+        observers.append(NotificationCenter.default.addObserver(forName: .capacitorViewWillTransition, object: .none, queue: .none) { [weak self] _ in
+            self?.handleViewWillTransition()
+        })
+    }
+
+    private func handleViewDidAppear(config: StatusBarConfig) {
+        setStyle(config.style)
+        setBackgroundColor(config.backgroundColor)
+        setOverlaysWebView(config.overlaysWebView)
+    }
+
+    private func handleViewWillTransition() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+            self?.resizeStatusBarBackgroundView()
+            self?.resizeWebView()
+        }
+    }
+
+    func setStyle(_ style: UIStatusBarStyle) {
+        bridge.statusBarStyle = style
+    }
+
+    func setBackgroundColor(_ color: UIColor) {
+        backgroundColor = color
+        backgroundView?.backgroundColor = color
+    }
+
+    func setAnimation(_ animation: String) {
+        if animation == "SLIDE" {
+            bridge.statusBarAnimation = .slide
+        } else if animation == "NONE" {
+            bridge.statusBarAnimation = .none
+        } else {
+            bridge.statusBarAnimation = .fade
+        }
+    }
+
+    func hide(animation: String) {
+        setAnimation(animation)
+        if bridge.statusBarVisible {
+            bridge.statusBarVisible = false
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+                self?.resizeWebView()
+                self?.backgroundView?.removeFromSuperview()
+                self?.backgroundView?.isHidden = true
+            }
+        }
+    }
+
+    func show(animation: String) {
+        setAnimation(animation)
+        if !bridge.statusBarVisible {
+            bridge.statusBarVisible = true
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [self] in
+                resizeWebView()
+                if !isOverlayingWebview {
+                    resizeStatusBarBackgroundView()
+                    bridge.webView?.superview?.addSubview(backgroundView!)
+                }
+                backgroundView?.isHidden = false
+            }
+        }
+    }
+
+    func getInfo() -> StatusBarInfo {
+        let style: String
+        switch bridge.statusBarStyle {
+        case .default:
+            style = "DEFAULT"
+        case .lightContent:
+            style = "DARK"
+        case .darkContent:
+            style = "LIGHT"
+        @unknown default:
+            style = "DEFAULT"
+        }
+
+        return StatusBarInfo(
+            overlays: isOverlayingWebview,
+            visible: bridge.statusBarVisible,
+            style: style,
+            color: UIColor.capacitor.hex(fromColor: backgroundColor),
+            height: getStatusBarFrame().size.height
+        )
+    }
+
+    func setOverlaysWebView(_ overlay: Bool) {
+        if overlay == isOverlayingWebview { return }
+        isOverlayingWebview = overlay
+        if overlay {
+            backgroundView?.removeFromSuperview()
+        } else {
+            initializeBackgroundViewIfNeeded()
+            bridge.webView?.superview?.addSubview(backgroundView!)
+        }
+        resizeWebView()
+    }
+
+    private func resizeWebView() {
+        let bounds: CGRect? = bridge.viewController?.view.window?.windowScene?.keyWindow?.bounds
+
+        guard
+            let webView = bridge.webView,
+            let bounds = bounds
+        else { return }
+        bridge.viewController?.view.frame = bounds
+        webView.frame = bounds
+        let statusBarHeight = getStatusBarFrame().size.height
+        var webViewFrame = webView.frame
+
+        if isOverlayingWebview {
+            let safeAreaTop = webView.safeAreaInsets.top
+            if statusBarHeight >= safeAreaTop && safeAreaTop > 0 {
+                webViewFrame.origin.y = safeAreaTop == 40 ? 20 : statusBarHeight - safeAreaTop
+            } else {
+                webViewFrame.origin.y = 0
+            }
+        } else {
+            webViewFrame.origin.y = statusBarHeight
+        }
+        webViewFrame.size.height -= webViewFrame.origin.y
+        webView.frame = webViewFrame
+    }
+
+    private func resizeStatusBarBackgroundView() {
+        backgroundView?.frame = getStatusBarFrame()
+    }
+
+    private func getStatusBarFrame() -> CGRect {
+        return bridge.viewController?.view.window?.windowScene?.statusBarManager?.statusBarFrame ?? .zero
+    }
+
+    private func initializeBackgroundViewIfNeeded() {
+        if backgroundView == nil {
+            backgroundView = UIView(frame: getStatusBarFrame())
+            backgroundView!.backgroundColor = backgroundColor
+            backgroundView!.autoresizingMask = [.flexibleWidth, .flexibleBottomMargin]
+            backgroundView!.isHidden = !bridge.statusBarVisible
+        }
+    }
+}

--- a/ios/App/Vendor/CapacitorStatusBar/Sources/StatusBarPlugin/StatusBarConfig.swift
+++ b/ios/App/Vendor/CapacitorStatusBar/Sources/StatusBarPlugin/StatusBarConfig.swift
@@ -1,0 +1,7 @@
+import UIKit
+
+public struct StatusBarConfig {
+    var overlaysWebView = true
+    var backgroundColor: UIColor = .black
+    var style: UIStatusBarStyle = .default
+}

--- a/ios/App/Vendor/CapacitorStatusBar/Sources/StatusBarPlugin/StatusBarInfo.swift
+++ b/ios/App/Vendor/CapacitorStatusBar/Sources/StatusBarPlugin/StatusBarInfo.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct StatusBarInfo {
+    public var overlays: Bool?
+    public var visible: Bool?
+    public var style: String?
+    public var color: String?
+    public var height: CGFloat?
+}

--- a/ios/App/Vendor/CapacitorStatusBar/Sources/StatusBarPlugin/StatusBarPlugin.swift
+++ b/ios/App/Vendor/CapacitorStatusBar/Sources/StatusBarPlugin/StatusBarPlugin.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Capacitor
+import UIKit
 
 @objc(StatusBarPlugin)
 public class StatusBarPlugin: CAPPlugin, CAPBridgedPlugin {
@@ -24,14 +25,51 @@ public class StatusBarPlugin: CAPPlugin, CAPBridgedPlugin {
 
     private func statusBarConfig() -> StatusBarConfig {
         var config = StatusBarConfig()
-        config.overlaysWebView = getConfig().getBoolean("overlaysWebView", config.overlaysWebView)
-        if let colorConfig = getConfig().getString("backgroundColor"), let color = UIColor.capacitor.color(fromHex: colorConfig) {
+        let pluginConfig = getConfig()
+        config.overlaysWebView = pluginConfig.getBoolean("overlaysWebView", config.overlaysWebView)
+
+        if let colorConfig = configString("backgroundColor"),
+           let color = Self.color(fromHex: colorConfig) {
             config.backgroundColor = color
         }
-        if let configStyle = getConfig().getString("style") {
+        if let configStyle = configString("style") {
             config.style = style(fromString: configStyle)
         }
         return config
+    }
+
+    private func configString(_ key: String) -> String? {
+        return getConfig().getConfigJSON()[key] as? String
+    }
+
+    private static func color(fromHex value: String) -> UIColor? {
+        let hex = value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "#", with: "")
+
+        guard hex.count == 6 || hex.count == 8,
+              let raw = UInt64(hex, radix: 16) else {
+            return nil
+        }
+
+        let red: CGFloat
+        let green: CGFloat
+        let blue: CGFloat
+        let alpha: CGFloat
+
+        if hex.count == 6 {
+            red = CGFloat((raw >> 16) & 0xFF) / 255.0
+            green = CGFloat((raw >> 8) & 0xFF) / 255.0
+            blue = CGFloat(raw & 0xFF) / 255.0
+            alpha = 1.0
+        } else {
+            red = CGFloat((raw >> 24) & 0xFF) / 255.0
+            green = CGFloat((raw >> 16) & 0xFF) / 255.0
+            blue = CGFloat((raw >> 8) & 0xFF) / 255.0
+            alpha = CGFloat(raw & 0xFF) / 255.0
+        }
+
+        return UIColor(red: red, green: green, blue: blue, alpha: alpha)
     }
 
     private func style(fromString: String) -> UIStatusBarStyle {
@@ -56,10 +94,14 @@ public class StatusBarPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     @objc func setBackgroundColor(_ call: CAPPluginCall) {
-        guard
-            let hexString = call.options["color"] as? String,
-            let color = UIColor.capacitor.color(fromHex: hexString)
-        else { return }
+        guard let hexString = call.options["color"] as? String else {
+            call.reject("A status bar color is required.")
+            return
+        }
+        guard let color = Self.color(fromHex: hexString) else {
+            call.reject("Invalid status bar color. Use #RRGGBB or #RRGGBBAA.")
+            return
+        }
         DispatchQueue.main.async { [weak self] in
             self?.statusBar?.setBackgroundColor(color)
         }
@@ -105,7 +147,10 @@ public class StatusBarPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     @objc func setOverlaysWebView(_ call: CAPPluginCall) {
-        guard let overlay = call.options["overlay"] as? Bool else { return }
+        guard let overlay = call.options["overlay"] as? Bool else {
+            call.reject("The overlay value is required.")
+            return
+        }
         DispatchQueue.main.async { [weak self] in
             self?.statusBar?.setOverlaysWebView(overlay)
             guard

--- a/ios/App/Vendor/CapacitorStatusBar/Sources/StatusBarPlugin/StatusBarPlugin.swift
+++ b/ios/App/Vendor/CapacitorStatusBar/Sources/StatusBarPlugin/StatusBarPlugin.swift
@@ -1,0 +1,130 @@
+import Foundation
+import Capacitor
+
+@objc(StatusBarPlugin)
+public class StatusBarPlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "StatusBarPlugin"
+    public let jsName = "StatusBar"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "setStyle", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "setBackgroundColor", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "show", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "hide", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getInfo", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "setOverlaysWebView", returnType: CAPPluginReturnPromise)
+    ]
+    private var statusBar: StatusBar?
+    private let statusBarVisibilityChanged = "statusBarVisibilityChanged"
+    private let statusBarOverlayChanged = "statusBarOverlayChanged"
+
+    override public func load() {
+        guard let bridge = bridge else { return }
+        statusBar = StatusBar(bridge: bridge, config: statusBarConfig())
+    }
+
+    private func statusBarConfig() -> StatusBarConfig {
+        var config = StatusBarConfig()
+        config.overlaysWebView = getConfig().getBoolean("overlaysWebView", config.overlaysWebView)
+        if let colorConfig = getConfig().getString("backgroundColor"), let color = UIColor.capacitor.color(fromHex: colorConfig) {
+            config.backgroundColor = color
+        }
+        if let configStyle = getConfig().getString("style") {
+            config.style = style(fromString: configStyle)
+        }
+        return config
+    }
+
+    private func style(fromString: String) -> UIStatusBarStyle {
+        switch fromString.lowercased() {
+        case "dark", "lightcontent":
+            return .lightContent
+        case "light", "darkcontent":
+            return .darkContent
+        case "default":
+            return .default
+        default:
+            return .default
+        }
+    }
+
+    @objc func setStyle(_ call: CAPPluginCall) {
+        let options = call.options!
+        if let styleString = options["style"] as? String {
+            statusBar?.setStyle(style(fromString: styleString))
+        }
+        call.resolve([:])
+    }
+
+    @objc func setBackgroundColor(_ call: CAPPluginCall) {
+        guard
+            let hexString = call.options["color"] as? String,
+            let color = UIColor.capacitor.color(fromHex: hexString)
+        else { return }
+        DispatchQueue.main.async { [weak self] in
+            self?.statusBar?.setBackgroundColor(color)
+        }
+        call.resolve()
+    }
+
+    @objc func hide(_ call: CAPPluginCall) {
+        let animation = call.getString("animation", "FADE")
+        DispatchQueue.main.async { [weak self] in
+            self?.statusBar?.hide(animation: animation)
+            guard
+                let info = self?.statusBar?.getInfo(),
+                let dict = self?.toDict(info),
+                let event = self?.statusBarVisibilityChanged
+            else { return }
+            self?.notifyListeners(event, data: dict)
+        }
+        call.resolve()
+    }
+
+    @objc func show(_ call: CAPPluginCall) {
+        let animation = call.getString("animation", "FADE")
+        DispatchQueue.main.async { [weak self] in
+            self?.statusBar?.show(animation: animation)
+            guard
+                let info = self?.statusBar?.getInfo(),
+                let dict = self?.toDict(info),
+                let event = self?.statusBarVisibilityChanged
+            else { return }
+            self?.notifyListeners(event, data: dict)
+        }
+        call.resolve()
+    }
+
+    @objc func getInfo(_ call: CAPPluginCall) {
+        DispatchQueue.main.async { [weak self] in
+            guard
+                let info = self?.statusBar?.getInfo(),
+                let dict = self?.toDict(info)
+            else { return }
+            call.resolve(dict)
+        }
+    }
+
+    @objc func setOverlaysWebView(_ call: CAPPluginCall) {
+        guard let overlay = call.options["overlay"] as? Bool else { return }
+        DispatchQueue.main.async { [weak self] in
+            self?.statusBar?.setOverlaysWebView(overlay)
+            guard
+                let info = self?.statusBar?.getInfo(),
+                let dict = self?.toDict(info),
+                let event = self?.statusBarOverlayChanged
+            else { return }
+            self?.notifyListeners(event, data: dict)
+        }
+        call.resolve()
+    }
+
+    private func toDict(_ info: StatusBarInfo) -> [String: Any] {
+        return [
+            "visible": info.visible!,
+            "style": info.style!,
+            "color": info.color!,
+            "overlays": info.overlays!,
+            "height": info.height!
+        ]
+    }
+}

--- a/ios/App/Vendor/CapawesomeCapacitorAppleSignIn/LICENSE
+++ b/ios/App/Vendor/CapawesomeCapacitorAppleSignIn/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Robin Genz and Capawesome contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ios/App/Vendor/CapawesomeCapacitorAppleSignIn/Package.swift
+++ b/ios/App/Vendor/CapawesomeCapacitorAppleSignIn/Package.swift
@@ -1,0 +1,32 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+// Vendored from @capawesome/capacitor-apple-sign-in 0.1.2 (MIT).
+// Kept in-repository so Xcode Cloud can resolve native dependencies before
+// JavaScript dependencies and custom build scripts are available.
+let package = Package(
+    name: "CapawesomeCapacitorAppleSignIn",
+    platforms: [.iOS(.v15)],
+    products: [
+        .library(
+            name: "CapawesomeCapacitorAppleSignIn",
+            targets: ["AppleSignInPlugin"]
+        )
+    ],
+    dependencies: [
+        .package(
+            url: "https://github.com/ionic-team/capacitor-swift-pm.git",
+            exact: "8.4.2"
+        )
+    ],
+    targets: [
+        .target(
+            name: "AppleSignInPlugin",
+            dependencies: [
+                .product(name: "Capacitor", package: "capacitor-swift-pm"),
+                .product(name: "Cordova", package: "capacitor-swift-pm")
+            ],
+            path: "Sources/AppleSignInPlugin"
+        )
+    ]
+)

--- a/ios/App/Vendor/CapawesomeCapacitorAppleSignIn/Sources/AppleSignInPlugin/AppleSignIn.swift
+++ b/ios/App/Vendor/CapawesomeCapacitorAppleSignIn/Sources/AppleSignInPlugin/AppleSignIn.swift
@@ -1,0 +1,54 @@
+import Foundation
+import AuthenticationServices
+
+@objc public class AppleSignIn: NSObject {
+
+    private var completion: ((_ result: SignInResult?, _ error: Error?) -> Void)?
+    private var authorizationController: ASAuthorizationController?
+
+    @objc public func signIn(_ options: SignInOptions, presentationContextProvider: ASAuthorizationControllerPresentationContextProviding, completion: @escaping (_ result: SignInResult?, _ error: Error?) -> Void) {
+        self.completion = completion
+
+        let provider = ASAuthorizationAppleIDProvider()
+        let request = provider.createRequest()
+        if !options.scopes.isEmpty {
+            request.requestedScopes = options.scopes
+        }
+        if let nonce = options.nonce {
+            request.nonce = nonce
+        }
+
+        DispatchQueue.main.async {
+            let controller = ASAuthorizationController(authorizationRequests: [request])
+            controller.delegate = self
+            controller.presentationContextProvider = presentationContextProvider
+            self.authorizationController = controller
+            controller.performRequests()
+        }
+    }
+}
+
+extension AppleSignIn: ASAuthorizationControllerDelegate {
+    public func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        authorizationController = nil
+        guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential else {
+            completion?(nil, CustomError.signInFailed)
+            completion = nil
+            return
+        }
+        let result = SignInResult(credential: credential)
+        completion?(result, nil)
+        completion = nil
+    }
+
+    public func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        authorizationController = nil
+        let asError = error as? ASAuthorizationError
+        if asError?.code == .canceled {
+            completion?(nil, CustomError.signInCanceled)
+        } else {
+            completion?(nil, error)
+        }
+        completion = nil
+    }
+}

--- a/ios/App/Vendor/CapawesomeCapacitorAppleSignIn/Sources/AppleSignInPlugin/AppleSignInPlugin.swift
+++ b/ios/App/Vendor/CapawesomeCapacitorAppleSignIn/Sources/AppleSignInPlugin/AppleSignInPlugin.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Capacitor
+import AuthenticationServices
+import UIKit
+
+@objc(AppleSignInPlugin)
+public class AppleSignInPlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "AppleSignInPlugin"
+    public let jsName = "AppleSignIn"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "initialize", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "signIn", returnType: CAPPluginReturnPromise)
+    ]
+
+    private let tag = "AppleSignIn"
+    private var implementation: AppleSignIn?
+
+    override public func load() {
+        self.implementation = AppleSignIn()
+    }
+
+    @objc func initialize(_ call: CAPPluginCall) {
+        resolveCall(call)
+    }
+
+    @objc func signIn(_ call: CAPPluginCall) {
+        do {
+            let options = try SignInOptions(call)
+
+            implementation?.signIn(options, presentationContextProvider: self, completion: { result, error in
+                if let error = error {
+                    self.rejectCall(call, error)
+                } else {
+                    self.resolveCall(call, result)
+                }
+            })
+        } catch {
+            rejectCall(call, error)
+        }
+    }
+
+    private func rejectCall(_ call: CAPPluginCall, _ error: Error) {
+        CAPLog.print("[", self.tag, "] ", error)
+        var code: String?
+        if let customError = error as? CustomError {
+            code = customError.code
+        } else if let authorizationError = error as? ASAuthorizationError {
+            code = String(authorizationError.code.rawValue)
+        }
+        call.unavailable(code.map { "\($0): \(error.localizedDescription)" } ?? error.localizedDescription)
+    }
+
+    private func resolveCall(_ call: CAPPluginCall) {
+        call.resolve()
+    }
+
+    private func resolveCall(_ call: CAPPluginCall, _ result: Result?) {
+        if let result = result?.toJSObject() as? JSObject {
+            call.resolve(result)
+        } else {
+            call.resolve()
+        }
+    }
+}
+
+extension AppleSignInPlugin: ASAuthorizationControllerPresentationContextProviding {
+    public func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        return UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap(\.windows)
+            .first { $0.isKeyWindow } ?? ASPresentationAnchor()
+    }
+}

--- a/ios/App/Vendor/CapawesomeCapacitorAppleSignIn/Sources/AppleSignInPlugin/CustomError.swift
+++ b/ios/App/Vendor/CapawesomeCapacitorAppleSignIn/Sources/AppleSignInPlugin/CustomError.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public enum CustomError: Error {
+    case signInCanceled
+    case signInFailed
+
+    var code: String? {
+        switch self {
+        case .signInCanceled:
+            return "SIGN_IN_CANCELED"
+        case .signInFailed:
+            return nil
+        }
+    }
+}
+
+extension CustomError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .signInCanceled:
+            return NSLocalizedString("Sign in was canceled.", comment: "signInCanceled")
+        case .signInFailed:
+            return NSLocalizedString("Sign in failed.", comment: "signInFailed")
+        }
+    }
+}

--- a/ios/App/Vendor/CapawesomeCapacitorAppleSignIn/Sources/AppleSignInPlugin/Result.swift
+++ b/ios/App/Vendor/CapawesomeCapacitorAppleSignIn/Sources/AppleSignInPlugin/Result.swift
@@ -1,0 +1,6 @@
+import Foundation
+import Capacitor
+
+@objc public protocol Result {
+    @objc func toJSObject() -> AnyObject
+}

--- a/ios/App/Vendor/CapawesomeCapacitorAppleSignIn/Sources/AppleSignInPlugin/SignInOptions.swift
+++ b/ios/App/Vendor/CapawesomeCapacitorAppleSignIn/Sources/AppleSignInPlugin/SignInOptions.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Capacitor
+import AuthenticationServices
+
+@objc public class SignInOptions: NSObject {
+    let scopes: [ASAuthorization.Scope]
+    let nonce: String?
+
+    init(_ call: CAPPluginCall) throws {
+        self.scopes = SignInOptions.getScopesFromCall(call)
+        let nonce = call.getString("nonce", "")
+        self.nonce = nonce.isEmpty ? nil : nonce
+    }
+
+    private static func getScopesFromCall(_ call: CAPPluginCall) -> [ASAuthorization.Scope] {
+        guard let scopeStrings = call.getArray("scopes", []) as? [String] else {
+            return []
+        }
+        var scopes: [ASAuthorization.Scope] = []
+        for scope in scopeStrings {
+            switch scope {
+            case "EMAIL":
+                scopes.append(.email)
+            case "FULL_NAME":
+                scopes.append(.fullName)
+            default:
+                break
+            }
+        }
+        return scopes
+    }
+}

--- a/ios/App/Vendor/CapawesomeCapacitorAppleSignIn/Sources/AppleSignInPlugin/SignInResult.swift
+++ b/ios/App/Vendor/CapawesomeCapacitorAppleSignIn/Sources/AppleSignInPlugin/SignInResult.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Capacitor
+import AuthenticationServices
+
+@objc public class SignInResult: NSObject, Result {
+    private let authorizationCode: String
+    private let idToken: String
+    private let user: String
+    private let email: String?
+    private let givenName: String?
+    private let familyName: String?
+    private let realUserStatus: String
+
+    init(credential: ASAuthorizationAppleIDCredential) {
+        self.authorizationCode = String(data: credential.authorizationCode ?? Data(), encoding: .utf8) ?? ""
+        self.idToken = String(data: credential.identityToken ?? Data(), encoding: .utf8) ?? ""
+        self.user = credential.user
+        self.email = credential.email
+        self.givenName = credential.fullName?.givenName
+        self.familyName = credential.fullName?.familyName
+        self.realUserStatus = SignInResult.mapRealUserStatus(credential.realUserStatus)
+    }
+
+    @objc public func toJSObject() -> AnyObject {
+        var result = JSObject()
+        result["authorizationCode"] = authorizationCode
+        result["idToken"] = idToken
+        result["user"] = user
+        result["email"] = email == nil ? NSNull() : email
+        result["givenName"] = givenName == nil ? NSNull() : givenName
+        result["familyName"] = familyName == nil ? NSNull() : familyName
+        result["realUserStatus"] = realUserStatus
+        return result as AnyObject
+    }
+
+    private static func mapRealUserStatus(_ status: ASUserDetectionStatus) -> String {
+        switch status {
+        case .likelyReal:
+            return "LIKELY_REAL"
+        case .unknown:
+            return "UNKNOWN"
+        default:
+            return "UNSUPPORTED"
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "cap:build": "npm run build:capacitor && npx cap sync",
     "mobile:validate:ios": "node scripts/validate-mobile-release.mjs ios",
     "mobile:validate:android": "node scripts/validate-mobile-release.mjs android",
-    "mobile:patch:ios": "node scripts/patch-apple-sign-in-swiftpm.mjs",
+    "mobile:patch:ios": "node scripts/patch-apple-sign-in-swiftpm.mjs && node scripts/patch-capapp-spm-vendored-packages.mjs",
     "cap:ios": "npx cap open ios",
     "cap:android": "npx cap open android"
   },

--- a/scripts/patch-capapp-spm-vendored-packages.mjs
+++ b/scripts/patch-capapp-spm-vendored-packages.mjs
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 
 const manifestPath = "ios/App/CapApp-SPM/Package.swift";
-const replacements = [
+const dependencyReplacements = [
   {
     generated:
       '.package(name: "CapacitorKeyboard", path: "../../../node_modules/@capacitor/keyboard")',
@@ -28,6 +28,15 @@ const replacements = [
   },
 ];
 
+const productIdentityReplacements = [
+  {
+    generated:
+      '.product(name: "CapacitorKeyboard", package: "CapacitorKeyboard")',
+    cloneReady:
+      '.product(name: "CapacitorKeyboard", package: "capacitor-keyboard")',
+  },
+];
+
 const requiredVendorManifests = [
   "ios/App/Vendor/CapacitorSplashScreen/Package.swift",
   "ios/App/Vendor/CapacitorStatusBar/Package.swift",
@@ -41,12 +50,15 @@ for (const vendorManifest of requiredVendorManifests) {
 }
 
 let manifest = readFileSync(manifestPath, "utf8");
-for (const { generated, cloneReady } of replacements) {
+for (const { generated, cloneReady } of [
+  ...dependencyReplacements,
+  ...productIdentityReplacements,
+]) {
   if (manifest.includes(generated)) {
     manifest = manifest.replace(generated, cloneReady);
   } else if (!manifest.includes(cloneReady)) {
     throw new Error(
-      `CapApp-SPM does not contain the generated or clone-ready dependency declaration: ${generated}`,
+      `CapApp-SPM does not contain the generated or clone-ready declaration: ${generated}`,
     );
   }
 }
@@ -57,9 +69,12 @@ if (manifest.includes("node_modules/")) {
   );
 }
 
-for (const { cloneReady } of replacements) {
+for (const { cloneReady } of [
+  ...dependencyReplacements,
+  ...productIdentityReplacements,
+]) {
   if (!manifest.includes(cloneReady)) {
-    throw new Error(`CapApp-SPM is missing clone-ready dependency: ${cloneReady}`);
+    throw new Error(`CapApp-SPM is missing clone-ready declaration: ${cloneReady}`);
   }
 }
 

--- a/scripts/patch-capapp-spm-vendored-packages.mjs
+++ b/scripts/patch-capapp-spm-vendored-packages.mjs
@@ -1,34 +1,67 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 
 const manifestPath = "ios/App/CapApp-SPM/Package.swift";
-const vendorManifest =
-  "ios/App/Vendor/CapawesomeCapacitorAppleSignIn/Package.swift";
-const generatedDependency =
-  '.package(name: "CapawesomeCapacitorAppleSignIn", path: "../../../node_modules/@capawesome/capacitor-apple-sign-in")';
-const vendoredDependency =
-  '.package(name: "CapawesomeCapacitorAppleSignIn", path: "../Vendor/CapawesomeCapacitorAppleSignIn")';
+const replacements = [
+  {
+    generated:
+      '.package(name: "CapacitorKeyboard", path: "../../../node_modules/@capacitor/keyboard")',
+    cloneReady:
+      '.package(url: "https://github.com/ionic-team/capacitor-keyboard.git", exact: "8.0.3")',
+  },
+  {
+    generated:
+      '.package(name: "CapacitorSplashScreen", path: "../../../node_modules/@capacitor/splash-screen")',
+    cloneReady:
+      '.package(name: "CapacitorSplashScreen", path: "../Vendor/CapacitorSplashScreen")',
+  },
+  {
+    generated:
+      '.package(name: "CapacitorStatusBar", path: "../../../node_modules/@capacitor/status-bar")',
+    cloneReady:
+      '.package(name: "CapacitorStatusBar", path: "../Vendor/CapacitorStatusBar")',
+  },
+  {
+    generated:
+      '.package(name: "CapawesomeCapacitorAppleSignIn", path: "../../../node_modules/@capawesome/capacitor-apple-sign-in")',
+    cloneReady:
+      '.package(name: "CapawesomeCapacitorAppleSignIn", path: "../Vendor/CapawesomeCapacitorAppleSignIn")',
+  },
+];
 
-if (!existsSync(vendorManifest)) {
-  throw new Error(`Vendored Apple Sign-In package is missing: ${vendorManifest}`);
+const requiredVendorManifests = [
+  "ios/App/Vendor/CapacitorSplashScreen/Package.swift",
+  "ios/App/Vendor/CapacitorStatusBar/Package.swift",
+  "ios/App/Vendor/CapawesomeCapacitorAppleSignIn/Package.swift",
+];
+
+for (const vendorManifest of requiredVendorManifests) {
+  if (!existsSync(vendorManifest)) {
+    throw new Error(`Vendored Swift package is missing: ${vendorManifest}`);
+  }
 }
 
 let manifest = readFileSync(manifestPath, "utf8");
+for (const { generated, cloneReady } of replacements) {
+  if (manifest.includes(generated)) {
+    manifest = manifest.replace(generated, cloneReady);
+  } else if (!manifest.includes(cloneReady)) {
+    throw new Error(
+      `CapApp-SPM does not contain the generated or clone-ready dependency declaration: ${generated}`,
+    );
+  }
+}
 
-if (manifest.includes(generatedDependency)) {
-  manifest = manifest.replace(generatedDependency, vendoredDependency);
-  writeFileSync(manifestPath, manifest, "utf8");
-} else if (!manifest.includes(vendoredDependency)) {
+if (manifest.includes("node_modules/")) {
   throw new Error(
-    `CapApp-SPM does not contain the generated or vendored Apple Sign-In dependency declaration: ${manifestPath}`,
+    "CapApp-SPM still contains a clone-time dependency on node_modules.",
   );
 }
 
-const patchedManifest = readFileSync(manifestPath, "utf8");
-if (patchedManifest.includes("node_modules/@capawesome/capacitor-apple-sign-in")) {
-  throw new Error("CapApp-SPM still depends on Apple Sign-In through node_modules.");
-}
-if (!patchedManifest.includes(vendoredDependency)) {
-  throw new Error("CapApp-SPM does not reference the vendored Apple Sign-In package.");
+for (const { cloneReady } of replacements) {
+  if (!manifest.includes(cloneReady)) {
+    throw new Error(`CapApp-SPM is missing clone-ready dependency: ${cloneReady}`);
+  }
 }
 
-console.log("Patched CapApp-SPM to use the vendored Apple Sign-In Swift package.");
+writeFileSync(manifestPath, manifest, "utf8");
+console.log("Patched CapApp-SPM to use clone-ready Swift package dependencies.");

--- a/scripts/patch-capapp-spm-vendored-packages.mjs
+++ b/scripts/patch-capapp-spm-vendored-packages.mjs
@@ -1,0 +1,34 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+
+const manifestPath = "ios/App/CapApp-SPM/Package.swift";
+const vendorManifest =
+  "ios/App/Vendor/CapawesomeCapacitorAppleSignIn/Package.swift";
+const generatedDependency =
+  '.package(name: "CapawesomeCapacitorAppleSignIn", path: "../../../node_modules/@capawesome/capacitor-apple-sign-in")';
+const vendoredDependency =
+  '.package(name: "CapawesomeCapacitorAppleSignIn", path: "../Vendor/CapawesomeCapacitorAppleSignIn")';
+
+if (!existsSync(vendorManifest)) {
+  throw new Error(`Vendored Apple Sign-In package is missing: ${vendorManifest}`);
+}
+
+let manifest = readFileSync(manifestPath, "utf8");
+
+if (manifest.includes(generatedDependency)) {
+  manifest = manifest.replace(generatedDependency, vendoredDependency);
+  writeFileSync(manifestPath, manifest, "utf8");
+} else if (!manifest.includes(vendoredDependency)) {
+  throw new Error(
+    `CapApp-SPM does not contain the generated or vendored Apple Sign-In dependency declaration: ${manifestPath}`,
+  );
+}
+
+const patchedManifest = readFileSync(manifestPath, "utf8");
+if (patchedManifest.includes("node_modules/@capawesome/capacitor-apple-sign-in")) {
+  throw new Error("CapApp-SPM still depends on Apple Sign-In through node_modules.");
+}
+if (!patchedManifest.includes(vendoredDependency)) {
+  throw new Error("CapApp-SPM does not reference the vendored Apple Sign-In package.");
+}
+
+console.log("Patched CapApp-SPM to use the vendored Apple Sign-In Swift package.");


### PR DESCRIPTION
## Root cause

Xcode Cloud resolves Swift package dependencies before JavaScript dependencies or custom post-clone output can be relied upon. `CapApp-SPM/Package.swift` contained four local paths under `node_modules`, so Apple could fail immediately after clone. Apple Sign-In was merely the first missing package SwiftPM reported.

## Fix

- removes every `node_modules` path from the committed Swift package graph
- pins Keyboard to the versioned `ionic-team/capacitor-keyboard` Swift package
- vendors the exact native Swift sources for:
  - `@capacitor/splash-screen` 8.0.1
  - `@capacitor/status-bar` 8.0.2
  - `@capawesome/capacitor-apple-sign-in` 0.1.2
- preserves upstream MIT licenses
- keeps the JavaScript npm packages unchanged for Capacitor APIs and Android
- patches `CapApp-SPM` back to clone-ready package references after every `npx cap sync ios`
- adds a macOS gate that resolves Xcode packages before Node/npm bootstrap and again after Capacitor sync

## Failure addressed

`/Volumes/workspace/repository/node_modules/@capawesome/capacitor-apple-sign-in doesn't exist in file system`

## Release gate

The PR must pass both pre-bootstrap and post-bootstrap `xcodebuild -resolvePackageDependencies` on macOS before merge. The fresh Xcode Cloud build on `main` remains the final platform receipt.