### PR TITLE
fix(trust): remove client-side silent astrology upgrades

### DIFF
--- a/.github/workflows/apply-gate3-client-fixes.yml
+++ b/.github/workflows/apply-gate3-client-fixes.yml
@@ -1,0 +1,168 @@
+name: Apply Gate3 Client Trust Fixes
+
+on:
+  push:
+    branches:
+      - fix/gate-3-client-no-silent-upgrades
+    paths:
+      - .github/workflows/apply-gate3-client-fixes.yml
+
+permissions:
+  contents: write
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: fix/gate-3-client-no-silent-upgrades
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Apply Poster and Onboarding fixes
+        shell: bash
+        run: |
+          python3 <<'PY'
+          from pathlib import Path
+          import re
+
+          # PosterPage
+          poster = Path('client/src/pages/PosterPage.tsx')
+          text = poster.read_text()
+          import_line = 'import { loadActiveProfile } from "../lib/profileStorage";'
+          text = text.replace(import_line, import_line + '\nimport { getVerifiedPlacement, placementDisplayStatus } from "../lib/placementVerification";')
+          text = text.replace(
+              'const DEMO: PosterData = {\n  name: "", birthDate: "", sunSign: "Gemini", moonSign: "Pisces",\n  risingSign: "Sagittarius", lifePathNumber: 9, masterNumber: 11,\n};',
+              'const DEMO: PosterData = {\n  name: "", birthDate: "", sunSign: "", moonSign: "",\n  risingSign: undefined, lifePathNumber: 1, masterNumber: undefined,\n};'
+          )
+          text = text.replace(
+              'sunSign:         astro.sun ?? p.sunSign ?? "Gemini",\n        moonSign:        astro.moon ?? p.moonSign ?? "Pisces",\n        risingSign:      astro.rising ?? p.risingSign ?? undefined,',
+              'sunSign:         getVerifiedPlacement(astro.sun)?.sign ?? "",\n        moonSign:        getVerifiedPlacement(astro.moon)?.sign ?? "",\n        risingSign:      getVerifiedPlacement(astro.rising)?.sign ?? undefined,'
+          )
+          text = text.replace(
+              'const planets = Object.entries(json.planets ?? {})\n              .filter(([, v]: any) => typeof v?.longitude === "number")',
+              'const planets = Object.entries(json.planets ?? {})\n              .filter(([, v]: any) => getVerifiedPlacement(v) && typeof v?.longitude === "number")'
+          )
+          text = text.replace(
+              '...(json.sun    ? { sunSign:    json.sun    } : {}),\n              ...(json.moon   ? { moonSign:   json.moon   } : {}),\n              ...(json.rising ? { risingSign: json.rising } : {}),',
+              '...(getVerifiedPlacement(json.sun) ? { sunSign: getVerifiedPlacement(json.sun)!.sign } : { sunSign: "" }),\n              ...(getVerifiedPlacement(json.moon) ? { moonSign: getVerifiedPlacement(json.moon)!.sign } : { moonSign: "" }),\n              ...(getVerifiedPlacement(json.rising) ? { risingSign: getVerifiedPlacement(json.rising)!.sign } : { risingSign: undefined }),'
+          )
+          text = text.replace(
+              'if (json.sun)    update("sunSign", json.sun);\n      if (json.moon)   update("moonSign", json.moon);\n      if (json.rising) update("risingSign", json.rising);',
+              'const verifiedSun = getVerifiedPlacement(json.sun);\n      const verifiedMoon = getVerifiedPlacement(json.moon);\n      const verifiedRising = getVerifiedPlacement(json.rising);\n      update("sunSign", verifiedSun?.sign ?? "");\n      update("moonSign", verifiedMoon?.sign ?? "");\n      update("risingSign", verifiedRising?.sign);\n      if (!verifiedSun || !verifiedMoon || !verifiedRising) {\n        setComputeError(`Astrology remains unresolved: Sun ${placementDisplayStatus(json.sun)}, Moon ${placementDisplayStatus(json.moon)}, Ascendant ${placementDisplayStatus(json.rising)}.`);\n      }'
+          )
+          poster.write_text(text)
+
+          # OnboardingPage
+          onboarding = Path('client/src/pages/OnboardingPage.tsx')
+          text = onboarding.read_text()
+          import_line = 'import { saveActiveProfile } from "../lib/ActiveProfileRepository";'
+          text = text.replace(import_line, import_line + '\nimport { getVerifiedPlacement } from "../lib/placementVerification";')
+
+          text = re.sub(r'\nconst SIGN_BOUNDARIES = \[.*?\n\];\n', '\n', text, flags=re.S)
+          text = re.sub(r'\nfunction getApproxSunSign\(birthDate: string\): string \| null \{.*?\n\}\n', '\n', text, flags=re.S)
+          text = text.replace('  const earlySunSign = useMemo(() => getApproxSunSign(form.birthDate), [form.birthDate]);\n', '')
+          text = text.replace('import { useEffect, useMemo, useState } from "react";', 'import { useEffect, useState } from "react";')
+
+          warmup_pattern = re.compile(r'\n  useEffect\(\(\) => \{\n    if \(!earlySunSign.*?\n  \}, \[earlySunSign, form\.birthDate, form\.birthTime, form\.birthLocation, queryClient\]\);', re.S)
+          warmup_replacement = r'''
+  useEffect(() => {
+    if (!isValidBirthDate(form.birthDate) || !form.birthLocation.trim()) return;
+
+    try {
+      localStorage.setItem("soulOnboardingWarmup", JSON.stringify({
+        status: "pending_verified_calculation",
+        birthDate: form.birthDate,
+        birthTime: form.birthTime || null,
+        birthLocation: form.birthLocation.trim(),
+        startedAt: new Date().toISOString(),
+      }));
+    } catch {}
+
+    queryClient.prefetchQuery({
+      queryKey: ["/api/astro/fullchart", form.birthDate, form.birthTime || "unknown", form.birthLocation.trim()],
+      queryFn: async () => {
+        const res = await apiFetch("/api/astro/fullchart", {
+          method: "POST",
+          body: JSON.stringify({
+            birthDate: form.birthDate,
+            birthTime: form.birthTime || undefined,
+            timeUnknown: !form.birthTime,
+            birthLocation: form.birthLocation.trim(),
+          }),
+        });
+        return res.data;
+      },
+    });
+  }, [form.birthDate, form.birthTime, form.birthLocation, queryClient]);'''
+          if not warmup_pattern.search(text):
+              raise SystemExit('Onboarding warmup effect not found')
+          text = warmup_pattern.sub(warmup_replacement, text, count=1)
+
+          text = text.replace(
+              'const astro = result.astrologyData || result.natalChart || result.chart || {};\n      const sunSign = astro.sunSign || result.sunSign || earlySunSign;',
+              'const astro: any = result.astrologyData || result.natalChart || result.chart || {};\n      const verifiedSun = getVerifiedPlacement(astro.sun ?? result.chart?.sun);\n      const sunSign = verifiedSun?.sign;'
+          )
+          text = text.replace(
+              'localStorage.setItem("soulOnboardingWarmup", JSON.stringify({ status: "complete", sunSign, completedAt: new Date().toISOString() }));',
+              'localStorage.setItem("soulOnboardingWarmup", JSON.stringify({\n          status: sunSign ? "complete_verified" : "complete_unresolved",\n          sunSign: sunSign ?? null,\n          verificationStatus: verifiedSun?.verificationStatus ?? "unresolved",\n          provenance: verifiedSun?.evidence ?? null,\n          completedAt: new Date().toISOString(),\n        }));'
+          )
+          onboarding.write_text(text)
+
+          test = Path('client/src/lib/__tests__/gate3ClientIntegration.test.ts')
+          test.write_text(r'''import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+const poster = fs.readFileSync(path.resolve("client/src/pages/PosterPage.tsx"), "utf8");
+const onboarding = fs.readFileSync(path.resolve("client/src/pages/OnboardingPage.tsx"), "utf8");
+
+describe("Gate 3 client integration", () => {
+  it("removes fabricated poster fallbacks", () => {
+    expect(poster).not.toContain('?? "Gemini"');
+    expect(poster).not.toContain('?? "Pisces"');
+    expect(poster).not.toContain('sunSign: "Gemini"');
+    expect(poster).not.toContain('moonSign: "Pisces"');
+    expect(poster).toContain("getVerifiedPlacement(astro.sun)");
+    expect(poster).toContain("getVerifiedPlacement(astro.moon)");
+  });
+
+  it("removes date-boundary Sun promotion from onboarding", () => {
+    expect(onboarding).not.toContain("SIGN_BOUNDARIES");
+    expect(onboarding).not.toContain("getApproxSunSign");
+    expect(onboarding).not.toContain("earlySunSign");
+    expect(onboarding).toContain("getVerifiedPlacement(astro.sun");
+  });
+
+  it("does not prefetch horoscope or compatibility from an unverified sign", () => {
+    expect(onboarding).toContain('if (sunSign)');
+    expect(onboarding).toContain('status: sunSign ? "complete_verified" : "complete_unresolved"');
+  });
+});
+''')
+
+          workflow = Path('.github/workflows/apply-gate3-client-fixes.yml')
+          if workflow.exists():
+              workflow.unlink()
+          PY
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Gate 3 tests and type checks
+        run: |
+          npm test -- --run client/src/lib/__tests__/placementVerification.test.ts client/src/lib/__tests__/gate3ClientIntegration.test.ts
+          npm run check
+
+      - name: Commit fixes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add client/src/pages/PosterPage.tsx client/src/pages/OnboardingPage.tsx client/src/lib/__tests__/gate3ClientIntegration.test.ts .github/workflows/apply-gate3-client-fixes.yml
+          git commit -m "fix(trust): remove client-side silent astrology upgrades"
+          git push origin HEAD:fix/gate-3-client-no-silent-upgrades

--- a/FIX-GATE-3-IMPLEMENTATION-PLAN.md
+++ b/FIX-GATE-3-IMPLEMENTATION-PLAN.md
@@ -1,0 +1,334 @@
+# Gate 3 Blocker Fixes — Implementation Plan
+
+**Branch:** `fix/gate-3-no-silent-upgrades`  
+**Target:** Complete all 3 blockers, re-audit, achieve Gate 3 PASS  
+**Philosophy:** Never return fake precision. Empty fields are honest. Unresolved states are valid.
+
+---
+
+## Priority Order (Correct Sequence)
+
+### 1. BLOCKER 0: Backend Astrology Service (ROOT CAUSE)
+
+**File:** `/server/services/astrology.ts`  
+**Current Problem:** Returns approximate sun/moon/rising without verification context  
+**Solution:** Return explicit unresolved states with verification metadata
+
+**Current Flow (WRONG):**
+```typescript
+calculateSunSign(birthDate) → "Virgo"  // Approximate from date boundary
+calculateMoonSign(...) → "Scorpio"      // Simplified formula
+calculateRisingSign(...) → "Leo"        // Simplified formula
+
+// Returns as verified astrology
+return { sunSign: "Virgo", moonSign: "Scorpio", ... }
+```
+
+**Fixed Flow (CORRECT):**
+```typescript
+calculateAstrology(birthData) → {
+  sun: {
+    sign: null,
+    status: "pending_ephemeris",
+    reason: "Requires verified ephemeris engine",
+    confidence: null,
+    engine: null
+  },
+  moon: {
+    sign: null,
+    status: "requires_verified_birth_time",
+    reason: "Birth time required for accurate calculation",
+    confidence: null
+  },
+  rising: {
+    sign: null,
+    status: "requires_verified_birth_time",
+    reason: "Birth time and location required",
+    confidence: null
+  },
+  verification: {
+    complete: false,
+    missingData: ["verified_ephemeris_engine", "birth_time"],
+    suggestions: "Provide complete birth time for accurate chart"
+  }
+}
+```
+
+**Implementation Steps:**
+
+1. Rename `calculateAstrology()` to `calculateAstrologyApproximate()` temporarily
+2. Create new `calculateAstrology()` that:
+   - Checks prerequisites (birth time, location, etc.)
+   - Returns `null` values with verification states for unmet prerequisites
+   - Never returns approximate calculations as facts
+   - Includes metadata: source, engine, confidence, limitations
+3. Update response type to include verification fields
+4. Audit every location that calls this service
+5. Update clients to handle `null` astrology gracefully
+
+**Acceptance Criteria:**
+- [ ] No approximate sun/moon/rising returned without `status: "pending_*"`
+- [ ] All `null` values have explicit reason
+- [ ] Verification metadata included in every response
+- [ ] Clients that receive `null` astrology show "Pending verification" not fallback signs
+- [ ] No test fails when astrology is null
+
+**Commits:**
+```
+fix(backend): replace approximate astrology with explicit unresolved states
+
+- Remove date-boundary sun sign calculation from production flow
+- Remove simplified moon/rising formulas from production flow
+- Return null astrology with verification status
+- Include metadata: reason, confidence, engine
+- Update response schema to include verification layer
+
+Fixes Blocker 0: Backend Astrology Service
+Prevents: Silent delivery of approximate data as verified
+Result: Downstream systems cannot receive unverified astrology
+```
+
+---
+
+### 2. BLOCKER 2: OnboardingPage Provenance
+
+**File:** `/client/src/pages/OnboardingPage.tsx`  
+**Current Problem:** Stores approximate sun sign as profile.sunSign without provenance  
+**Solution:** Store with verification state, never cache approximate calculations
+
+**Current Flow (WRONG):**
+```typescript
+const earlySunSign = getApproxSunSign(birthDate);  // Approximate
+profile.sunSign = earlySunSign;  // Stored as if verified
+// No indication this is approximate, no provenance
+```
+
+**Fixed Flow (CORRECT):**
+```typescript
+const birthDateProvenance = {
+  value: birthDate,
+  source: "user_entered",
+  verified: true
+};
+
+// NEVER store approximate calculation
+profile.astrologyData = {
+  sun: {
+    sign: null,
+    status: "pending_ephemeris",
+    source: null
+  },
+  _provenance: {
+    birthDate: birthDateProvenance,
+    birthTime: birthTime ? { value, source: "user_entered", verified: true } : null,
+    astrology: {
+      status: "pending_verification",
+      reason: birthTime ? "Awaiting ephemeris calculation" : "Birth time required"
+    }
+  }
+};
+```
+
+**Implementation Steps:**
+
+1. Stop storing `earlySunSign` in profile
+2. Keep UI feedback about approximate sun (show it during onboarding only)
+3. Add provenance layer to astrologyData
+4. Profile saves with null astrology and provenance metadata
+5. Remove all fallback chains that use earlySunSign
+
+**Acceptance Criteria:**
+- [ ] New profiles have `profile.astrologyData.sun.sign === null`
+- [ ] Provenance metadata is stored for all data
+- [ ] No `earlySunSign` persisted to profile
+- [ ] UI shows "Approximate for feedback" during onboarding
+- [ ] After save, shows "Pending verification" not a sign name
+- [ ] Profiles created before fix migrate correctly (sun → null, add provenance)
+
+**Commits:**
+```
+fix(onboarding): remove approximate sun from profile storage
+
+- Stop caching approximate sun sign calculation
+- Store with explicit verification state
+- Add provenance metadata layer
+- Show "Pending verification" after save instead of sign name
+- Maintain UI feedback during onboarding process
+
+Fixes Blocker 2: OnboardingPage Provenance
+Prevents: Approximate data being cascaded as profile truth
+Result: Profile reflects actual verification state
+```
+
+---
+
+### 3. BLOCKER 1: PosterPage Fallback Signs
+
+**File:** `/client/src/pages/PosterPage.tsx`  
+**Current Problem:** Renders hardcoded fallback signs ("Gemini"/"Pisces") when astrology unavailable  
+**Solution:** Show honest "unavailable" state instead of invented data
+
+**Current Flow (WRONG):**
+```typescript
+const DEMO = {
+  sunSign: "Gemini",      // Hardcoded fallback
+  moonSign: "Pisces",     // Never happened
+  risingSign: "Sagittarius"
+};
+
+sunSign: astro.sun ?? p.sunSign ?? "Gemini"  // Silently invents
+```
+
+**Fixed Flow (CORRECT):**
+```typescript
+if (!astro?.sun?.sign && !profile?.sunSign) {
+  return (
+    <div className="unavailable-state">
+      <p>Astrology chart unavailable</p>
+      <p>Complete your birth time to generate a personalized poster</p>
+      <button onClick={() => navigate("/start")}>Add Birth Time</button>
+    </div>
+  );
+}
+
+// Only render if data exists and is verified
+if (profile.astrologyData?.sun?.status !== "verified") {
+  return <PendingVerificationState />;
+}
+
+// Safe to render with real data
+const poster = <BirthChartPosterSVG data={profile} />;
+```
+
+**Implementation Steps:**
+
+1. Remove hardcoded DEMO object
+2. Remove fallback chains (`?? "Gemini"`)
+3. Add guard before rendering: check verification status
+4. Show "unavailable" UI if astrology is null
+5. Show "pending" UI if astrology status is not "verified"
+
+**Acceptance Criteria:**
+- [ ] No hardcoded sign names remain in PosterPage
+- [ ] No fallback chains to sign names
+- [ ] Profile with null astrology shows "unavailable" message
+- [ ] Profile with pending astrology shows "pending" message
+- [ ] Only verified astrology renders actual chart
+- [ ] DEMO object removed completely
+
+**Commits:**
+```
+fix(poster): remove hardcoded fallback signs
+
+- Remove DEMO object with hardcoded astrology
+- Remove fallback chains that resolve to sign names
+- Add verification guards before rendering
+- Show "unavailable" and "pending" states honestly
+
+Fixes Blocker 1: PosterPage Hardcoded Fallbacks
+Prevents: Users seeing fabricated charts
+Result: Chart only renders with real verified data
+```
+
+---
+
+## Regression Tests (Critical)
+
+After fixes, add tests that FAIL if silent upgrades reappear:
+
+**Test: No Unverified Astrology in Production Profiles**
+```typescript
+test("ProfilePage rejects null sun sign without verification label", () => {
+  const profileWithNullAstro = {
+    ...testProfile,
+    astrologyData: { sun: { sign: null, status: "pending_ephemeris" } }
+  };
+  
+  const { container } = render(<ProfilePage profile={profileWithNullAstro} />);
+  
+  // Must NOT contain sign name
+  expect(container.textContent).not.toMatch(/Virgo|Scorpio|Gemini/);
+  
+  // Must contain verification message
+  expect(container.textContent).toMatch(/Pending verification|Awaiting/);
+});
+
+test("PosterPage refuses null astrology", () => {
+  const profileWithNullAstro = {
+    ...testProfile,
+    astrologyData: { sun: { sign: null, status: "pending_ephemeris" } }
+  };
+  
+  const { container } = render(<PosterPage profile={profileWithNullAstro} />);
+  
+  // Must show unavailable state, not a chart
+  expect(container.textContent).toMatch(/unavailable|complete.*birth/i);
+  expect(container.querySelector("svg")).toBeNull();  // No chart rendered
+});
+
+test("Backend never returns approximate astrology as verified", async () => {
+  const birthData = { birthDate: "2000-01-15" };  // No time
+  const result = await calculateAstrology(birthData);
+  
+  // Must return null, not approximation
+  expect(result.sun.sign).toBeNull();
+  expect(result.sun.status).toBe("pending_ephemeris");
+  expect(result.verification.complete).toBe(false);
+});
+```
+
+---
+
+## Audit Re-Run Protocol
+
+After all fixes committed:
+
+1. **Automated Scan:**
+   ```bash
+   grep -r "Virgo\|Scorpio\|Gemini\|Leo\|Capricorn\|Pisces\|Taurus\|Cancer" \
+     --include="*.ts" --include="*.tsx" \
+     packages/core client/src server \
+     | grep -v test | grep -v fixture | grep -v comment
+   ```
+   Expected: Only in test fixtures, comments, or documentation
+
+2. **Verification State Audit:**
+   - Every `sunSign`, `moonSign`, `risingSign` must have `status` field
+   - Every rendering must check status before display
+   - Every null value must have explicit reason
+
+3. **Flow Trace:**
+   - Birth data → Backend calculation → Verification state → Storage → UI rendering
+   - At each step, verify state is preserved and honored
+
+4. **Gate 3 Re-Submission:**
+   - All regression tests pass
+   - Automated scan returns zero violations
+   - Manual review confirms honest uncertainty states
+   - Sign-off with corrected acceptance criteria
+
+---
+
+## Timeline
+
+- Blocker 0 (Backend): ~4 hours (complex, affects whole system)
+- Blocker 2 (Onboarding): ~2 hours (refactor provenance)
+- Blocker 1 (Poster): ~1 hour (simplest fix)
+- Regression tests: ~2 hours
+- Re-audit: ~1 hour
+- **Total: ~10 hours work**
+
+---
+
+## Success Criteria
+
+Gate 3 passes when:
+
+✅ No astrology placement renders without verification context  
+✅ Backend returns only verified or explicitly unresolved data  
+✅ Profile stores provenance with all data  
+✅ UI shows "pending" not fallback values  
+✅ Regression tests prove silent upgrades fail  
+✅ Re-audit returns zero violations  
+
+This is the discipline that prevents Foundation v0.1.0 from shipping with fake precision.

--- a/GATE-3-CLIENT-FIX-PLAN.md
+++ b/GATE-3-CLIENT-FIX-PLAN.md
@@ -1,0 +1,24 @@
+# Gate 3 Client Fix Plan
+
+This branch completes the client-side half of the No Silent Upgrade gate.
+
+## Required source fixes
+
+### PosterPage
+
+- Remove demo/fallback zodiac values from user-facing state.
+- Replace `Gemini`/`Pisces` fallbacks with empty values plus explicit pending/unavailable presentation.
+- Never export a poster containing fabricated astrology.
+- Preserve manual sign selectors only as clearly user-entered values with provenance.
+
+### OnboardingPage
+
+- Remove `SIGN_BOUNDARIES` and `getApproxSunSign` from authoritative profile flow.
+- Do not prefetch horoscope or compatibility using an unverified date-boundary estimate.
+- Do not fall back to `earlySunSign` after API profile creation.
+- Store provenance and verification state with every astrology placement.
+- When ephemeris results are unavailable, continue onboarding without astrology-derived warmups.
+
+## Regression gate
+
+`tests/gate3-no-silent-upgrades.test.ts` intentionally fails until both source files are corrected. Do not weaken the test to obtain green CI.

--- a/client/src/lib/__tests__/gate3ClientIntegration.test.ts
+++ b/client/src/lib/__tests__/gate3ClientIntegration.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+const poster = fs.readFileSync(path.resolve("client/src/pages/PosterPage.tsx"), "utf8");
+const onboarding = fs.readFileSync(path.resolve("client/src/pages/OnboardingPage.tsx"), "utf8");
+describe("Gate 3 client integration", () => {
+  it("removes fabricated poster fallbacks", () => { expect(poster).not.toContain('?? "Gemini"'); expect(poster).not.toContain('?? "Pisces"'); expect(poster).not.toContain('sunSign: "Gemini"'); expect(poster).not.toContain('moonSign: "Pisces"'); expect(poster).toContain("getVerifiedPlacement(astro.sun)"); });
+  it("removes date-boundary Sun promotion", () => { expect(onboarding).not.toContain("SIGN_BOUNDARIES"); expect(onboarding).not.toContain("getApproxSunSign"); expect(onboarding).not.toContain("earlySunSign"); expect(onboarding).toContain("getVerifiedPlacement(astro.sun"); });
+});

--- a/client/src/lib/__tests__/pr133WorkflowTrigger.test.ts
+++ b/client/src/lib/__tests__/pr133WorkflowTrigger.test.ts
@@ -1,0 +1,7 @@
+import { describe, expect, it } from "vitest";
+
+describe("PR133 Gate 3 patch trigger", () => {
+  it("keeps the trust-fix lane active while enforcement is applied", () => {
+    expect(true).toBe(true);
+  });
+});

--- a/client/src/lib/placementVerification.ts
+++ b/client/src/lib/placementVerification.ts
@@ -1,0 +1,39 @@
+export type VerificationState =
+  | "verified"
+  | "calculated"
+  | "pending_independent_verification"
+  | "pending_ephemeris"
+  | "requires_verified_birth_time"
+  | "requires_location"
+  | "approximate"
+  | "unresolved"
+  | "unknown";
+
+export interface PlacementEvidence {
+  source?: string | null;
+  engine?: string | null;
+  calculatedAt?: string | null;
+  comparisonSource?: string | null;
+  confidence?: number | null;
+}
+
+export interface PlacementLike {
+  sign?: string | null;
+  degree?: number | null;
+  verificationStatus?: VerificationState | string | null;
+  status?: VerificationState | string | null;
+  provenance?: PlacementEvidence | null;
+  evidence?: PlacementEvidence | null;
+}
+
+export function getVerifiedPlacement(value: PlacementLike | null | undefined) {
+  if (!value?.sign) return null;
+  if ((value.verificationStatus ?? value.status) !== "verified") return null;
+  const evidence = value.provenance ?? value.evidence;
+  if (!evidence?.source || !evidence?.engine || !evidence?.calculatedAt) return null;
+  return { sign: value.sign, degree: value.degree, verificationStatus: "verified" as const, evidence };
+}
+
+export function trustedSign(value: PlacementLike | null | undefined): string | undefined {
+  return getVerifiedPlacement(value)?.sign;
+}

--- a/client/src/pages/OnboardingPage.tsx
+++ b/client/src/pages/OnboardingPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { useLocation } from "wouter";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiRequest, apiFetch } from "../lib/queryClient";
@@ -7,6 +7,7 @@ import ScButton from "@/components/ScButton";
 import { IconCircle, IconLogo, IconSparkles } from "@/components/Icons";
 import { saveActiveProfile as saveActiveProfileLegacy } from "../lib/profileStorage";
 import { saveActiveProfile } from "../lib/ActiveProfileRepository";
+import { getVerifiedPlacement } from "../lib/placementVerification";
 
 type PressurePattern =
   | "spiral_inward"
@@ -76,21 +77,6 @@ const TOTAL_STEPS = 5;
 const STEP_LABELS = ["Birth", "Pressure", "Conflict", "Decisions", "Energy"];
 const WARMUP_MODES: WarmupMode[] = ["love", "attraction", "friendship", "growth"];
 
-const SIGN_BOUNDARIES = [
-  { sign: "Capricorn", month: 1, day: 1 },
-  { sign: "Aquarius", month: 1, day: 20 },
-  { sign: "Pisces", month: 2, day: 19 },
-  { sign: "Aries", month: 3, day: 21 },
-  { sign: "Taurus", month: 4, day: 20 },
-  { sign: "Gemini", month: 5, day: 21 },
-  { sign: "Cancer", month: 6, day: 21 },
-  { sign: "Leo", month: 7, day: 23 },
-  { sign: "Virgo", month: 8, day: 23 },
-  { sign: "Libra", month: 9, day: 23 },
-  { sign: "Scorpio", month: 10, day: 23 },
-  { sign: "Sagittarius", month: 11, day: 22 },
-  { sign: "Capricorn", month: 12, day: 22 },
-];
 
 const PRESSURE_OPTIONS: { value: PressurePattern; label: string; description: string }[] = [
   { value: "spiral_inward", label: "I spiral inward", description: "My thoughts loop and I overthink every angle." },
@@ -136,19 +122,6 @@ const LOADING_LINES = [
   "Preparing your Soul Codex...",
 ];
 
-function getApproxSunSign(birthDate: string): string | null {
-  const parts = birthDate.split("-").map(Number);
-  if (parts.length !== 3 || parts.some((n) => !Number.isFinite(n))) return null;
-  const month = parts[1];
-  const day = parts[2];
-  let current = SIGN_BOUNDARIES[0].sign;
-  for (const boundary of SIGN_BOUNDARIES) {
-    if (month > boundary.month || (month === boundary.month && day >= boundary.day)) {
-      current = boundary.sign;
-    }
-  }
-  return current;
-}
 
 function isValidBirthDate(value: string): boolean {
   if (!value) return false;
@@ -176,7 +149,6 @@ export default function OnboardingPage() {
     drain_pattern_secondary: "",
   });
 
-  const earlySunSign = useMemo(() => getApproxSunSign(form.birthDate), [form.birthDate]);
   const pressureCount = [form.primary_pressure_pattern, form.secondary_pressure_pattern].filter(Boolean).length;
   const decisionCount = [form.decision_friction_primary, form.decision_friction_secondary].filter(Boolean).length;
   const drainCount = [form.drain_pattern_primary, form.drain_pattern_secondary].filter(Boolean).length;
@@ -197,47 +169,10 @@ export default function OnboardingPage() {
   };
 
   useEffect(() => {
-    if (!earlySunSign || !isValidBirthDate(form.birthDate)) return;
-
-    try {
-      localStorage.setItem("soulOnboardingWarmup", JSON.stringify({
-        status: "running",
-        sunSign: earlySunSign,
-        birthDate: form.birthDate,
-        birthTime: form.birthTime || null,
-        birthLocation: form.birthLocation || null,
-        startedAt: new Date().toISOString(),
-      }));
-    } catch {}
-
-    prefetchCompatibility(earlySunSign);
-
-    queryClient.prefetchQuery({
-      queryKey: ["/api/astro/horoscope/daily", earlySunSign],
-      queryFn: async () => {
-        const res = await apiFetch(`/api/astro/horoscope/daily?sign=${earlySunSign}`);
-        return res.data;
-      },
-    });
-
-    if (form.birthLocation.trim()) {
-      queryClient.prefetchQuery({
-        queryKey: ["/api/astro/fullchart", form.birthDate, form.birthTime || "unknown", form.birthLocation.trim()],
-        queryFn: async () => {
-          const res = await apiFetch("/api/astro/fullchart", {
-            method: "POST",
-            body: JSON.stringify({
-              birthDate: form.birthDate,
-              birthTime: form.birthTime || undefined,
-              timeUnknown: !form.birthTime,
-              birthLocation: form.birthLocation.trim(),
-            }),
-          });
-          return res.data;
-        },
-      });
-    }
-  }, [earlySunSign, form.birthDate, form.birthTime, form.birthLocation, queryClient]);
+    if (!isValidBirthDate(form.birthDate) || !form.birthLocation.trim()) return;
+    try { localStorage.setItem("soulOnboardingWarmup", JSON.stringify({ status: "pending_verified_calculation", birthDate: form.birthDate, birthTime: form.birthTime || null, birthLocation: form.birthLocation.trim(), startedAt: new Date().toISOString() })); } catch {}
+    queryClient.prefetchQuery({ queryKey: ["/api/astro/fullchart", form.birthDate, form.birthTime || "unknown", form.birthLocation.trim()], queryFn: async () => { const res = await apiFetch("/api/astro/fullchart", { method: "POST", body: JSON.stringify({ birthDate: form.birthDate, birthTime: form.birthTime || undefined, timeUnknown: !form.birthTime, birthLocation: form.birthLocation.trim() }) }); return res.data; } });
+  }, [form.birthDate, form.birthTime, form.birthLocation, queryClient]);
 
   const mutation = useMutation({
     mutationFn: async (data: FormData) => {
@@ -333,8 +268,9 @@ export default function OnboardingPage() {
       if (!isGuest) localStorage.setItem("onboardingData", JSON.stringify(form));
       if (result?.confidence) localStorage.setItem(isGuest ? "soulGuestConfidence" : "soulConfidence", JSON.stringify(result.confidence));
 
-      const astro = result.astrologyData || result.natalChart || result.chart || {};
-      const sunSign = astro.sunSign || result.sunSign || earlySunSign;
+      const astro: any = result.astrologyData || result.natalChart || result.chart || {};
+      const verifiedSun = getVerifiedPlacement(astro.sun ?? result.chart?.sun);
+      const sunSign = verifiedSun?.sign;
       if (sunSign) {
         const lifePath = (result.numerologyData || result.numerology)?.lifePathNumber || result.numerology?.lifePath;
         const hdType = (result.humanDesignData || result.humanDesign)?.type;
@@ -349,7 +285,7 @@ export default function OnboardingPage() {
       }
 
       try {
-        localStorage.setItem("soulOnboardingWarmup", JSON.stringify({ status: "complete", sunSign, completedAt: new Date().toISOString() }));
+        localStorage.setItem("soulOnboardingWarmup", JSON.stringify({ status: sunSign ? "complete_verified" : "complete_unresolved", sunSign: sunSign ?? null, verificationStatus: verifiedSun?.verificationStatus ?? "unresolved", provenance: verifiedSun?.evidence ?? null, completedAt: new Date().toISOString() }));
       } catch {}
       setSuccessResult(result);
     },

--- a/client/src/pages/PosterPage.tsx
+++ b/client/src/pages/PosterPage.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo, useEffect } from "react";
 import { Link } from "wouter";
 import BirthChartPosterSVG, { type PosterData } from "../components/BirthChartPosterSVG";
 import { loadActiveProfile } from "../lib/profileStorage";
+import { getVerifiedPlacement, placementDisplayStatus } from "../lib/placementVerification";
 
 const ZODIAC_SIGNS = [
   "Aries","Taurus","Gemini","Cancer","Leo","Virgo",
@@ -79,8 +80,8 @@ function getProfile() {
 }
 
 const DEMO: PosterData = {
-  name: "", birthDate: "", sunSign: "Gemini", moonSign: "Pisces",
-  risingSign: "Sagittarius", lifePathNumber: 9, masterNumber: 11,
+  name: "", birthDate: "", sunSign: "", moonSign: "",
+  risingSign: undefined, lifePathNumber: 1, masterNumber: undefined,
 };
 
 export default function PosterPage() {
@@ -122,9 +123,9 @@ export default function PosterPage() {
         birthDate:       p.birthDate ?? p.dob ?? "",
         birthTime:       p.birthTime ?? p.time ?? "",
         birthLocation:   p.birthLocation ?? p.location ?? p.city ?? "",
-        sunSign:         astro.sun ?? p.sunSign ?? "Gemini",
-        moonSign:        astro.moon ?? p.moonSign ?? "Pisces",
-        risingSign:      astro.rising ?? p.risingSign ?? undefined,
+        sunSign:         getVerifiedPlacement(astro.sun)?.sign ?? "",
+        moonSign:        getVerifiedPlacement(astro.moon)?.sign ?? "",
+        risingSign:      getVerifiedPlacement(astro.rising)?.sign ?? undefined,
         lifePathNumber:  num.lifePathNumber ?? p.lifePathNumber ?? 9,
         masterNumber:    num.masterNumber ?? p.masterNumber ?? undefined,
         planets: astro.planets
@@ -154,15 +155,15 @@ export default function PosterPage() {
           .then(json => {
             if (!json.ok) return;
             const planets = Object.entries(json.planets ?? {})
-              .filter(([, v]: any) => typeof v?.longitude === "number")
+              .filter(([, v]: any) => getVerifiedPlacement(v) && typeof v?.longitude === "number")
               .map(([name, v]: any) => ({ name, longitude: v.longitude }));
             setData(prev => ({
               ...prev,
               planets,
               houseCusps: json.houses?.cusps ?? [],
-              ...(json.sun    ? { sunSign:    json.sun    } : {}),
-              ...(json.moon   ? { moonSign:   json.moon   } : {}),
-              ...(json.rising ? { risingSign: json.rising } : {}),
+              ...(getVerifiedPlacement(json.sun) ? { sunSign: getVerifiedPlacement(json.sun)!.sign } : { sunSign: "" }),
+              ...(getVerifiedPlacement(json.moon) ? { moonSign: getVerifiedPlacement(json.moon)!.sign } : { moonSign: "" }),
+              ...(getVerifiedPlacement(json.rising) ? { risingSign: getVerifiedPlacement(json.rising)!.sign } : { risingSign: undefined }),
             }));
             setProfileAstro(json);
           })
@@ -193,9 +194,13 @@ export default function PosterPage() {
         .map(([name, v]: any) => ({ name, longitude: v.longitude }));
       update("planets", planets);
       update("houseCusps", json.houses?.cusps ?? []);
-      if (json.sun)    update("sunSign", json.sun);
-      if (json.moon)   update("moonSign", json.moon);
-      if (json.rising) update("risingSign", json.rising);
+      const verifiedSun = getVerifiedPlacement(json.sun);
+      const verifiedMoon = getVerifiedPlacement(json.moon);
+      const verifiedRising = getVerifiedPlacement(json.rising);
+      update("sunSign", verifiedSun?.sign ?? "");
+      update("moonSign", verifiedMoon?.sign ?? "");
+      update("risingSign", verifiedRising?.sign);
+      if (!verifiedSun || !verifiedMoon || !verifiedRising) { setComputeError(`Astrology remains unresolved: Sun ${placementDisplayStatus(json.sun)}, Moon ${placementDisplayStatus(json.moon)}, Ascendant ${placementDisplayStatus(json.rising)}.`); }
       setProfileAstro(json);
     } catch (err: any) { setComputeError(err?.message ?? "Network error."); }
     finally { setComputing(false); }

--- a/server/services/astrology.ts
+++ b/server/services/astrology.ts
@@ -1,32 +1,40 @@
 interface BirthData {
   birthDate: string;
-  birthTime: string;
-  latitude: number;
-  longitude: number;
-  timezone: string;
+  birthTime?: string;
+  latitude?: number;
+  longitude?: number;
+  timezone?: string;
+}
+
+interface PlacementVerification {
+  sign: string | null;
+  status: "verified" | "pending_ephemeris" | "requires_verified_birth_time" | "requires_location";
+  confidence: number | null;
+  source: string | null;
+  reason?: string;
 }
 
 interface AstrologyData {
-  sunSign: string;
-  moonSign: string;
-  risingSign: string;
-  planets: {
-    sun: { sign: string; house: number; degree: number };
-    moon: { sign: string; house: number; degree: number };
-    mercury: { sign: string; house: number; degree: number };
-    venus: { sign: string; house: number; degree: number };
-    mars: { sign: string; house: number; degree: number };
-    jupiter: { sign: string; house: number; degree: number };
-    saturn: { sign: string; house: number; degree: number };
-    uranus: { sign: string; house: number; degree: number };
-    neptune: { sign: string; house: number; degree: number };
-    pluto: { sign: string; house: number; degree: number };
+  sun: PlacementVerification;
+  moon: PlacementVerification;
+  rising: PlacementVerification;
+  planets?: {
+    sun?: { sign?: string; house?: number; degree?: number };
+    moon?: { sign?: string; house?: number; degree?: number };
+    [key: string]: any;
   };
-  houses: Array<{ sign: string; degree: number }>;
-  aspects: Array<{ planet1: string; planet2: string; aspect: string; orb: number }>;
-  northNode: { sign: string; house: number; degree: number };
-  southNode: { sign: string; house: number; degree: number };
-  chiron: { sign: string; house: number; degree: number };
+  houses?: Array<{ sign?: string; degree?: number }>;
+  aspects?: Array<{ planet1: string; planet2: string; aspect: string; orb: number }>;
+  northNode?: { sign?: string; house?: number; degree?: number };
+  southNode?: { sign?: string; house?: number; degree?: number };
+  chiron?: { sign?: string; house?: number; degree?: number };
+
+  verification: {
+    complete: boolean;
+    missingData: string[];
+    suggestions: string;
+    lastUpdated: string;
+  };
 }
 
 const ZODIAC_SIGNS = [
@@ -34,107 +42,128 @@ const ZODIAC_SIGNS = [
   'Libra', 'Scorpio', 'Sagittarius', 'Capricorn', 'Aquarius', 'Pisces'
 ];
 
-function calculateSunSign(birthDate: string): string {
-  const date = new Date(birthDate);
-  const month = date.getMonth() + 1;
-  const day = date.getDate();
+// DEPRECATED: Old approximate calculation functions
+// These are kept for reference but no longer used in production
+// They were replaced because they silently returned fake precision
 
-  // Simplified sun sign calculation
-  if ((month === 3 && day >= 21) || (month === 4 && day <= 19)) return 'Aries';
-  if ((month === 4 && day >= 20) || (month === 5 && day <= 20)) return 'Taurus';
-  if ((month === 5 && day >= 21) || (month === 6 && day <= 20)) return 'Gemini';
-  if ((month === 6 && day >= 21) || (month === 7 && day <= 22)) return 'Cancer';
-  if ((month === 7 && day >= 23) || (month === 8 && day <= 22)) return 'Leo';
-  if ((month === 8 && day >= 23) || (month === 9 && day <= 22)) return 'Virgo';
-  if ((month === 9 && day >= 23) || (month === 10 && day <= 22)) return 'Libra';
-  if ((month === 10 && day >= 23) || (month === 11 && day <= 21)) return 'Scorpio';
-  if ((month === 11 && day >= 22) || (month === 12 && day <= 21)) return 'Sagittarius';
-  if ((month === 12 && day >= 22) || (month === 1 && day <= 19)) return 'Capricorn';
-  if ((month === 1 && day >= 20) || (month === 2 && day <= 18)) return 'Aquarius';
-  return 'Pisces';
+// function calculateSunSign(birthDate: string): string - REMOVED
+// function calculateMoonSign(...): string - REMOVED
+// function calculateRisingSign(...): string - REMOVED
+
+// All three have been replaced with verification-aware functions below
+
+function getSunPlacement(birthData: BirthData): PlacementVerification {
+  // Sun sign requires no birth time, but we don't calculate from date boundaries
+  // Accurate sun requires ephemeris engine (future implementation)
+  return {
+    sign: null,
+    status: "pending_ephemeris",
+    confidence: null,
+    source: null,
+    reason: "Awaiting verified ephemeris engine for accurate calculation"
+  };
 }
 
-function calculateMoonSign(birthDate: string, birthTime: string): string {
-  // Simplified moon sign calculation - in a real app this would use ephemeris data
-  const date = new Date(birthDate);
-  const dayOfYear = Math.floor((date.getTime() - new Date(date.getFullYear(), 0, 0).getTime()) / (1000 * 60 * 60 * 24));
-  const timeHours = parseInt(birthTime.split(':')[0]);
-  
-  const index = (dayOfYear + timeHours) % 12;
-  return ZODIAC_SIGNS[index];
+function getMoonPlacement(birthData: BirthData): PlacementVerification {
+  // Moon requires birth time for any meaningful calculation
+  if (!birthData.birthTime) {
+    return {
+      sign: null,
+      status: "requires_verified_birth_time",
+      confidence: null,
+      source: null,
+      reason: "Birth time required for Moon sign calculation"
+    };
+  }
+
+  return {
+    sign: null,
+    status: "pending_ephemeris",
+    confidence: null,
+    source: null,
+    reason: "Awaiting verified ephemeris engine for accurate calculation"
+  };
 }
 
-function calculateRisingSign(birthDate: string, birthTime: string, latitude: number): string {
-  // Simplified rising sign calculation - in a real app this would use sidereal time and house system
-  const date = new Date(birthDate);
-  const timeHours = parseInt(birthTime.split(':')[0]);
-  const timeMinutes = parseInt(birthTime.split(':')[1]);
-  
-  const totalMinutes = timeHours * 60 + timeMinutes;
-  const latitudeAdjustment = Math.floor(latitude / 10);
-  
-  const index = (Math.floor(totalMinutes / 120) + latitudeAdjustment) % 12;
-  return ZODIAC_SIGNS[index];
+function getRisingPlacement(birthData: BirthData): PlacementVerification {
+  // Rising sign requires both birth time and accurate location
+  if (!birthData.birthTime) {
+    return {
+      sign: null,
+      status: "requires_verified_birth_time",
+      confidence: null,
+      source: null,
+      reason: "Birth time and location required for Rising sign calculation"
+    };
+  }
+
+  if (birthData.latitude === undefined || birthData.longitude === undefined) {
+    return {
+      sign: null,
+      status: "requires_location",
+      confidence: null,
+      source: null,
+      reason: "Precise birth location required for Rising sign calculation"
+    };
+  }
+
+  return {
+    sign: null,
+    status: "pending_ephemeris",
+    confidence: null,
+    source: null,
+    reason: "Awaiting verified ephemeris engine for accurate calculation"
+  };
 }
 
 export function calculateAstrology(birthData: BirthData): AstrologyData {
-  const sunSign = calculateSunSign(birthData.birthDate);
-  const moonSign = calculateMoonSign(birthData.birthDate, birthData.birthTime);
-  const risingSign = calculateRisingSign(birthData.birthDate, birthData.birthTime, parseFloat(birthData.latitude.toString()));
+  // TRUST BOUNDARY: This function no longer returns approximate data
+  // It returns explicit unresolved states with verification context
+  // Clients MUST handle null values with verification status
 
-  // Simplified planetary calculations - in production this would use Swiss Ephemeris
-  const planets = {
-    sun: { sign: sunSign, house: 1, degree: 15.5 },
-    moon: { sign: moonSign, house: 4, degree: 23.2 },
-    mercury: { sign: ZODIAC_SIGNS[(ZODIAC_SIGNS.indexOf(sunSign) + 1) % 12], house: 3, degree: 8.7 },
-    venus: { sign: ZODIAC_SIGNS[(ZODIAC_SIGNS.indexOf(sunSign) + 2) % 12], house: 2, degree: 19.3 },
-    mars: { sign: ZODIAC_SIGNS[(ZODIAC_SIGNS.indexOf(sunSign) + 3) % 12], house: 6, degree: 12.8 },
-    jupiter: { sign: ZODIAC_SIGNS[(ZODIAC_SIGNS.indexOf(sunSign) + 4) % 12], house: 9, degree: 26.1 },
-    saturn: { sign: ZODIAC_SIGNS[(ZODIAC_SIGNS.indexOf(sunSign) + 5) % 12], house: 10, degree: 4.9 },
-    uranus: { sign: ZODIAC_SIGNS[(ZODIAC_SIGNS.indexOf(sunSign) + 6) % 12], house: 11, degree: 18.4 },
-    neptune: { sign: ZODIAC_SIGNS[(ZODIAC_SIGNS.indexOf(sunSign) + 7) % 12], house: 12, degree: 21.7 },
-    pluto: { sign: ZODIAC_SIGNS[(ZODIAC_SIGNS.indexOf(sunSign) + 8) % 12], house: 8, degree: 14.2 }
-  };
+  const sun = getSunPlacement(birthData);
+  const moon = getMoonPlacement(birthData);
+  const rising = getRisingPlacement(birthData);
 
-  const houses = Array.from({ length: 12 }, (_, i) => ({
-    sign: ZODIAC_SIGNS[(ZODIAC_SIGNS.indexOf(risingSign) + i) % 12],
-    degree: (i * 30 + Math.random() * 30) % 360
-  }));
+  const missingData: string[] = [];
+  if (!birthData.birthTime) missingData.push("verified_birth_time");
+  if (birthData.latitude === undefined || birthData.longitude === undefined) missingData.push("precise_location");
+  if (!sun.sign) missingData.push("ephemeris_engine");
 
-  const aspects = [
-    { planet1: 'sun', planet2: 'moon', aspect: 'sextile', orb: 2.3 },
-    { planet1: 'venus', planet2: 'mars', aspect: 'trine', orb: 1.8 },
-    { planet1: 'jupiter', planet2: 'saturn', aspect: 'square', orb: 3.1 }
-  ];
-
-  const northNode = { 
-    sign: ZODIAC_SIGNS[(ZODIAC_SIGNS.indexOf(moonSign) + 6) % 12], 
-    house: 5, 
-    degree: 11.3 
-  };
-  
-  const southNode = { 
-    sign: ZODIAC_SIGNS[(ZODIAC_SIGNS.indexOf(northNode.sign) + 6) % 12], 
-    house: 11, 
-    degree: 11.3 
-  };
-
-  const chiron = { 
-    sign: ZODIAC_SIGNS[(ZODIAC_SIGNS.indexOf(sunSign) + 9) % 12], 
-    house: 7, 
-    degree: 16.8 
-  };
+  // Only provide planetary data if we have verified base placements
+  // For now, we don't because we don't have ephemeris
+  const planets = undefined;
+  const houses = undefined;
+  const aspects = undefined;
+  const northNode = undefined;
+  const southNode = undefined;
+  const chiron = undefined;
 
   return {
-    sunSign,
-    moonSign,
-    risingSign,
+    sun,
+    moon,
+    rising,
     planets,
     houses,
     aspects,
     northNode,
     southNode,
-    chiron
+    chiron,
+
+    // VERIFICATION LAYER (new)
+    verification: {
+      complete: false,
+      missingData,
+      suggestions: missingData.length > 0
+        ? `To calculate your astrology: ${missingData.map(d => {
+            if (d === "verified_birth_time") return "provide exact birth time";
+            if (d === "precise_location") return "provide precise birth location";
+            if (d === "ephemeris_engine") return "activate ephemeris calculation engine";
+            return d;
+          }).join(", ")}.`
+        : "Your astrology chart is ready for calculation.",
+      lastUpdated: new Date().toISOString()
+    }
   };
 }
 

--- a/tests/gate3-no-silent-upgrades.test.ts
+++ b/tests/gate3-no-silent-upgrades.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const read = (path: string) => readFileSync(resolve(root, path), "utf8");
+
+describe("Gate 3: no silent astrology upgrades", () => {
+  it("PosterPage does not fabricate zodiac signs when profile data is absent", () => {
+    const source = read("client/src/pages/PosterPage.tsx");
+
+    expect(source).not.toMatch(/sunSign:\s*astro\.sun\s*\?\?\s*p\.sunSign\s*\?\?\s*["']Gemini["']/);
+    expect(source).not.toMatch(/moonSign:\s*astro\.moon\s*\?\?\s*p\.moonSign\s*\?\?\s*["']Pisces["']/);
+  });
+
+  it("Onboarding does not promote an approximate date-boundary Sun sign", () => {
+    const source = read("client/src/pages/OnboardingPage.tsx");
+
+    expect(source).not.toContain("const SIGN_BOUNDARIES");
+    expect(source).not.toContain("function getApproxSunSign");
+    expect(source).not.toMatch(/astro\.sunSign\s*\|\|\s*result\.sunSign\s*\|\|\s*earlySunSign/);
+  });
+
+  it("backend astrology returns explicit unresolved states instead of approximate signs", () => {
+    const source = read("server/services/astrology.ts");
+
+    expect(source).toContain('status: "pending_ephemeris"');
+    expect(source).toContain("sign: null");
+    expect(source).not.toContain("calculateMoonSign(");
+    expect(source).not.toContain("calculateRisingSign(");
+  });
+});


### PR DESCRIPTION
## Superseded

This draft is superseded by merged PR #138, which carried the client trust repairs, centralized verification use, and backend unresolved-state behavior on a fresh branch from current `main`.

Canonical merged implementation: #138
Merge commit: `971940cee85d35ca9ddeaa985033df5d1dcb969e`

Closed without merge because this branch was stale and contained overlapping scaffolding that no longer belonged in the release lane.