### PR TITLE
fix(gate3): consolidate trust boundary and remove silent astrology upgrades

### DIFF
--- a/client/src/pages/OnboardingPage.tsx
+++ b/client/src/pages/OnboardingPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { useLocation } from "wouter";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiRequest, apiFetch } from "../lib/queryClient";
@@ -7,6 +7,7 @@ import ScButton from "@/components/ScButton";
 import { IconCircle, IconLogo, IconSparkles } from "@/components/Icons";
 import { saveActiveProfile as saveActiveProfileLegacy } from "../lib/profileStorage";
 import { saveActiveProfile } from "../lib/ActiveProfileRepository";
+import { getVerifiedPlacement } from "../lib/placementVerification";
 
 type PressurePattern =
   | "spiral_inward"
@@ -76,21 +77,6 @@ const TOTAL_STEPS = 5;
 const STEP_LABELS = ["Birth", "Pressure", "Conflict", "Decisions", "Energy"];
 const WARMUP_MODES: WarmupMode[] = ["love", "attraction", "friendship", "growth"];
 
-const SIGN_BOUNDARIES = [
-  { sign: "Capricorn", month: 1, day: 1 },
-  { sign: "Aquarius", month: 1, day: 20 },
-  { sign: "Pisces", month: 2, day: 19 },
-  { sign: "Aries", month: 3, day: 21 },
-  { sign: "Taurus", month: 4, day: 20 },
-  { sign: "Gemini", month: 5, day: 21 },
-  { sign: "Cancer", month: 6, day: 21 },
-  { sign: "Leo", month: 7, day: 23 },
-  { sign: "Virgo", month: 8, day: 23 },
-  { sign: "Libra", month: 9, day: 23 },
-  { sign: "Scorpio", month: 10, day: 23 },
-  { sign: "Sagittarius", month: 11, day: 22 },
-  { sign: "Capricorn", month: 12, day: 22 },
-];
 
 const PRESSURE_OPTIONS: { value: PressurePattern; label: string; description: string }[] = [
   { value: "spiral_inward", label: "I spiral inward", description: "My thoughts loop and I overthink every angle." },
@@ -136,19 +122,6 @@ const LOADING_LINES = [
   "Preparing your Soul Codex...",
 ];
 
-function getApproxSunSign(birthDate: string): string | null {
-  const parts = birthDate.split("-").map(Number);
-  if (parts.length !== 3 || parts.some((n) => !Number.isFinite(n))) return null;
-  const month = parts[1];
-  const day = parts[2];
-  let current = SIGN_BOUNDARIES[0].sign;
-  for (const boundary of SIGN_BOUNDARIES) {
-    if (month > boundary.month || (month === boundary.month && day >= boundary.day)) {
-      current = boundary.sign;
-    }
-  }
-  return current;
-}
 
 function isValidBirthDate(value: string): boolean {
   if (!value) return false;
@@ -176,7 +149,6 @@ export default function OnboardingPage() {
     drain_pattern_secondary: "",
   });
 
-  const earlySunSign = useMemo(() => getApproxSunSign(form.birthDate), [form.birthDate]);
   const pressureCount = [form.primary_pressure_pattern, form.secondary_pressure_pattern].filter(Boolean).length;
   const decisionCount = [form.decision_friction_primary, form.decision_friction_secondary].filter(Boolean).length;
   const drainCount = [form.drain_pattern_primary, form.drain_pattern_secondary].filter(Boolean).length;
@@ -197,47 +169,10 @@ export default function OnboardingPage() {
   };
 
   useEffect(() => {
-    if (!earlySunSign || !isValidBirthDate(form.birthDate)) return;
-
-    try {
-      localStorage.setItem("soulOnboardingWarmup", JSON.stringify({
-        status: "running",
-        sunSign: earlySunSign,
-        birthDate: form.birthDate,
-        birthTime: form.birthTime || null,
-        birthLocation: form.birthLocation || null,
-        startedAt: new Date().toISOString(),
-      }));
-    } catch {}
-
-    prefetchCompatibility(earlySunSign);
-
-    queryClient.prefetchQuery({
-      queryKey: ["/api/astro/horoscope/daily", earlySunSign],
-      queryFn: async () => {
-        const res = await apiFetch(`/api/astro/horoscope/daily?sign=${earlySunSign}`);
-        return res.data;
-      },
-    });
-
-    if (form.birthLocation.trim()) {
-      queryClient.prefetchQuery({
-        queryKey: ["/api/astro/fullchart", form.birthDate, form.birthTime || "unknown", form.birthLocation.trim()],
-        queryFn: async () => {
-          const res = await apiFetch("/api/astro/fullchart", {
-            method: "POST",
-            body: JSON.stringify({
-              birthDate: form.birthDate,
-              birthTime: form.birthTime || undefined,
-              timeUnknown: !form.birthTime,
-              birthLocation: form.birthLocation.trim(),
-            }),
-          });
-          return res.data;
-        },
-      });
-    }
-  }, [earlySunSign, form.birthDate, form.birthTime, form.birthLocation, queryClient]);
+    if (!isValidBirthDate(form.birthDate) || !form.birthLocation.trim()) return;
+    try { localStorage.setItem("soulOnboardingWarmup", JSON.stringify({ status: "pending_verified_calculation", birthDate: form.birthDate, birthTime: form.birthTime || null, birthLocation: form.birthLocation.trim(), startedAt: new Date().toISOString() })); } catch {}
+    queryClient.prefetchQuery({ queryKey: ["/api/astro/fullchart", form.birthDate, form.birthTime || "unknown", form.birthLocation.trim()], queryFn: async () => { const res = await apiFetch("/api/astro/fullchart", { method: "POST", body: JSON.stringify({ birthDate: form.birthDate, birthTime: form.birthTime || undefined, timeUnknown: !form.birthTime, birthLocation: form.birthLocation.trim() }) }); return res.data; } });
+  }, [form.birthDate, form.birthTime, form.birthLocation, queryClient]);
 
   const mutation = useMutation({
     mutationFn: async (data: FormData) => {
@@ -333,8 +268,9 @@ export default function OnboardingPage() {
       if (!isGuest) localStorage.setItem("onboardingData", JSON.stringify(form));
       if (result?.confidence) localStorage.setItem(isGuest ? "soulGuestConfidence" : "soulConfidence", JSON.stringify(result.confidence));
 
-      const astro = result.astrologyData || result.natalChart || result.chart || {};
-      const sunSign = astro.sunSign || result.sunSign || earlySunSign;
+      const astro: any = result.astrologyData || result.natalChart || result.chart || {};
+      const verifiedSun = getVerifiedPlacement(astro.sun ?? result.chart?.sun);
+      const sunSign = verifiedSun?.sign;
       if (sunSign) {
         const lifePath = (result.numerologyData || result.numerology)?.lifePathNumber || result.numerology?.lifePath;
         const hdType = (result.humanDesignData || result.humanDesign)?.type;
@@ -349,7 +285,7 @@ export default function OnboardingPage() {
       }
 
       try {
-        localStorage.setItem("soulOnboardingWarmup", JSON.stringify({ status: "complete", sunSign, completedAt: new Date().toISOString() }));
+        localStorage.setItem("soulOnboardingWarmup", JSON.stringify({ status: sunSign ? "complete_verified" : "complete_unresolved", sunSign: sunSign ?? null, verificationStatus: verifiedSun?.verificationStatus ?? "unresolved", provenance: verifiedSun?.evidence ?? null, completedAt: new Date().toISOString() }));
       } catch {}
       setSuccessResult(result);
     },

--- a/client/src/pages/PosterPage.tsx
+++ b/client/src/pages/PosterPage.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo, useEffect } from "react";
 import { Link } from "wouter";
 import BirthChartPosterSVG, { type PosterData } from "../components/BirthChartPosterSVG";
 import { loadActiveProfile } from "../lib/profileStorage";
+import { getVerifiedPlacement, placementDisplayStatus } from "../lib/placementVerification";
 
 const ZODIAC_SIGNS = [
   "Aries","Taurus","Gemini","Cancer","Leo","Virgo",
@@ -79,8 +80,8 @@ function getProfile() {
 }
 
 const DEMO: PosterData = {
-  name: "", birthDate: "", sunSign: "Gemini", moonSign: "Pisces",
-  risingSign: "Sagittarius", lifePathNumber: 9, masterNumber: 11,
+  name: "", birthDate: "", sunSign: "", moonSign: "",
+  risingSign: undefined, lifePathNumber: 1, masterNumber: undefined,
 };
 
 export default function PosterPage() {
@@ -122,9 +123,9 @@ export default function PosterPage() {
         birthDate:       p.birthDate ?? p.dob ?? "",
         birthTime:       p.birthTime ?? p.time ?? "",
         birthLocation:   p.birthLocation ?? p.location ?? p.city ?? "",
-        sunSign:         astro.sun ?? p.sunSign ?? "Gemini",
-        moonSign:        astro.moon ?? p.moonSign ?? "Pisces",
-        risingSign:      astro.rising ?? p.risingSign ?? undefined,
+        sunSign:         getVerifiedPlacement(astro.sun)?.sign ?? "",
+        moonSign:        getVerifiedPlacement(astro.moon)?.sign ?? "",
+        risingSign:      getVerifiedPlacement(astro.rising)?.sign ?? undefined,
         lifePathNumber:  num.lifePathNumber ?? p.lifePathNumber ?? 9,
         masterNumber:    num.masterNumber ?? p.masterNumber ?? undefined,
         planets: astro.planets
@@ -154,15 +155,15 @@ export default function PosterPage() {
           .then(json => {
             if (!json.ok) return;
             const planets = Object.entries(json.planets ?? {})
-              .filter(([, v]: any) => typeof v?.longitude === "number")
+              .filter(([, v]: any) => getVerifiedPlacement(v) && typeof v?.longitude === "number")
               .map(([name, v]: any) => ({ name, longitude: v.longitude }));
             setData(prev => ({
               ...prev,
               planets,
               houseCusps: json.houses?.cusps ?? [],
-              ...(json.sun    ? { sunSign:    json.sun    } : {}),
-              ...(json.moon   ? { moonSign:   json.moon   } : {}),
-              ...(json.rising ? { risingSign: json.rising } : {}),
+              ...(getVerifiedPlacement(json.sun) ? { sunSign: getVerifiedPlacement(json.sun)!.sign } : { sunSign: "" }),
+              ...(getVerifiedPlacement(json.moon) ? { moonSign: getVerifiedPlacement(json.moon)!.sign } : { moonSign: "" }),
+              ...(getVerifiedPlacement(json.rising) ? { risingSign: getVerifiedPlacement(json.rising)!.sign } : { risingSign: undefined }),
             }));
             setProfileAstro(json);
           })
@@ -193,9 +194,13 @@ export default function PosterPage() {
         .map(([name, v]: any) => ({ name, longitude: v.longitude }));
       update("planets", planets);
       update("houseCusps", json.houses?.cusps ?? []);
-      if (json.sun)    update("sunSign", json.sun);
-      if (json.moon)   update("moonSign", json.moon);
-      if (json.rising) update("risingSign", json.rising);
+      const verifiedSun = getVerifiedPlacement(json.sun);
+      const verifiedMoon = getVerifiedPlacement(json.moon);
+      const verifiedRising = getVerifiedPlacement(json.rising);
+      update("sunSign", verifiedSun?.sign ?? "");
+      update("moonSign", verifiedMoon?.sign ?? "");
+      update("risingSign", verifiedRising?.sign);
+      if (!verifiedSun || !verifiedMoon || !verifiedRising) { setComputeError(`Astrology remains unresolved: Sun ${placementDisplayStatus(json.sun)}, Moon ${placementDisplayStatus(json.moon)}, Ascendant ${placementDisplayStatus(json.rising)}.`); }
       setProfileAstro(json);
     } catch (err: any) { setComputeError(err?.message ?? "Network error."); }
     finally { setComputing(false); }

--- a/server/services/astrology.ts
+++ b/server/services/astrology.ts
@@ -1,148 +1,144 @@
 interface BirthData {
   birthDate: string;
-  birthTime: string;
-  latitude: number;
-  longitude: number;
-  timezone: string;
+  birthTime?: string;
+  latitude?: number;
+  longitude?: number;
+  timezone?: string;
+}
+
+interface PlacementVerification {
+  sign: string | null;
+  status: "verified" | "pending_ephemeris" | "requires_verified_birth_time" | "requires_location";
+  confidence: number | null;
+  source: string | null;
+  reason?: string;
 }
 
 interface AstrologyData {
-  sunSign: string;
-  moonSign: string;
-  risingSign: string;
-  planets: {
-    sun: { sign: string; house: number; degree: number };
-    moon: { sign: string; house: number; degree: number };
-    mercury: { sign: string; house: number; degree: number };
-    venus: { sign: string; house: number; degree: number };
-    mars: { sign: string; house: number; degree: number };
-    jupiter: { sign: string; house: number; degree: number };
-    saturn: { sign: string; house: number; degree: number };
-    uranus: { sign: string; house: number; degree: number };
-    neptune: { sign: string; house: number; degree: number };
-    pluto: { sign: string; house: number; degree: number };
+  sun: PlacementVerification;
+  moon: PlacementVerification;
+  rising: PlacementVerification;
+  planets?: {
+    sun?: { sign?: string; house?: number; degree?: number };
+    moon?: { sign?: string; house?: number; degree?: number };
+    [key: string]: any;
   };
-  houses: Array<{ sign: string; degree: number }>;
-  aspects: Array<{ planet1: string; planet2: string; aspect: string; orb: number }>;
-  northNode: { sign: string; house: number; degree: number };
-  southNode: { sign: string; house: number; degree: number };
-  chiron: { sign: string; house: number; degree: number };
+  houses?: Array<{ sign?: string; degree?: number }>;
+  aspects?: Array<{ planet1: string; planet2: string; aspect: string; orb: number }>;
+  northNode?: { sign?: string; house?: number; degree?: number };
+  southNode?: { sign?: string; house?: number; degree?: number };
+  chiron?: { sign?: string; house?: number; degree?: number };
+  verification: {
+    complete: boolean;
+    missingData: string[];
+    suggestions: string;
+    lastUpdated: string;
+  };
 }
 
-const ZODIAC_SIGNS = [
-  'Aries', 'Taurus', 'Gemini', 'Cancer', 'Leo', 'Virgo',
-  'Libra', 'Scorpio', 'Sagittarius', 'Capricorn', 'Aquarius', 'Pisces'
-];
-
-function calculateSunSign(birthDate: string): string {
-  const date = new Date(birthDate);
-  const month = date.getMonth() + 1;
-  const day = date.getDate();
-
-  // Simplified sun sign calculation
-  if ((month === 3 && day >= 21) || (month === 4 && day <= 19)) return 'Aries';
-  if ((month === 4 && day >= 20) || (month === 5 && day <= 20)) return 'Taurus';
-  if ((month === 5 && day >= 21) || (month === 6 && day <= 20)) return 'Gemini';
-  if ((month === 6 && day >= 21) || (month === 7 && day <= 22)) return 'Cancer';
-  if ((month === 7 && day >= 23) || (month === 8 && day <= 22)) return 'Leo';
-  if ((month === 8 && day >= 23) || (month === 9 && day <= 22)) return 'Virgo';
-  if ((month === 9 && day >= 23) || (month === 10 && day <= 22)) return 'Libra';
-  if ((month === 10 && day >= 23) || (month === 11 && day <= 21)) return 'Scorpio';
-  if ((month === 11 && day >= 22) || (month === 12 && day <= 21)) return 'Sagittarius';
-  if ((month === 12 && day >= 22) || (month === 1 && day <= 19)) return 'Capricorn';
-  if ((month === 1 && day >= 20) || (month === 2 && day <= 18)) return 'Aquarius';
-  return 'Pisces';
+function getSunPlacement(_birthData: BirthData): PlacementVerification {
+  return {
+    sign: null,
+    status: "pending_ephemeris",
+    confidence: null,
+    source: null,
+    reason: "Awaiting verified ephemeris engine for accurate calculation",
+  };
 }
 
-function calculateMoonSign(birthDate: string, birthTime: string): string {
-  // Simplified moon sign calculation - in a real app this would use ephemeris data
-  const date = new Date(birthDate);
-  const dayOfYear = Math.floor((date.getTime() - new Date(date.getFullYear(), 0, 0).getTime()) / (1000 * 60 * 60 * 24));
-  const timeHours = parseInt(birthTime.split(':')[0]);
-  
-  const index = (dayOfYear + timeHours) % 12;
-  return ZODIAC_SIGNS[index];
+function getMoonPlacement(birthData: BirthData): PlacementVerification {
+  if (!birthData.birthTime) {
+    return {
+      sign: null,
+      status: "requires_verified_birth_time",
+      confidence: null,
+      source: null,
+      reason: "Birth time required for Moon sign calculation",
+    };
+  }
+
+  return {
+    sign: null,
+    status: "pending_ephemeris",
+    confidence: null,
+    source: null,
+    reason: "Awaiting verified ephemeris engine for accurate calculation",
+  };
 }
 
-function calculateRisingSign(birthDate: string, birthTime: string, latitude: number): string {
-  // Simplified rising sign calculation - in a real app this would use sidereal time and house system
-  const date = new Date(birthDate);
-  const timeHours = parseInt(birthTime.split(':')[0]);
-  const timeMinutes = parseInt(birthTime.split(':')[1]);
-  
-  const totalMinutes = timeHours * 60 + timeMinutes;
-  const latitudeAdjustment = Math.floor(latitude / 10);
-  
-  const index = (Math.floor(totalMinutes / 120) + latitudeAdjustment) % 12;
-  return ZODIAC_SIGNS[index];
+function getRisingPlacement(birthData: BirthData): PlacementVerification {
+  if (!birthData.birthTime) {
+    return {
+      sign: null,
+      status: "requires_verified_birth_time",
+      confidence: null,
+      source: null,
+      reason: "Birth time and location required for Rising sign calculation",
+    };
+  }
+
+  if (birthData.latitude === undefined || birthData.longitude === undefined) {
+    return {
+      sign: null,
+      status: "requires_location",
+      confidence: null,
+      source: null,
+      reason: "Precise birth location required for Rising sign calculation",
+    };
+  }
+
+  return {
+    sign: null,
+    status: "pending_ephemeris",
+    confidence: null,
+    source: null,
+    reason: "Awaiting verified ephemeris engine for accurate calculation",
+  };
 }
 
 export function calculateAstrology(birthData: BirthData): AstrologyData {
-  const sunSign = calculateSunSign(birthData.birthDate);
-  const moonSign = calculateMoonSign(birthData.birthDate, birthData.birthTime);
-  const risingSign = calculateRisingSign(birthData.birthDate, birthData.birthTime, parseFloat(birthData.latitude.toString()));
+  const sun = getSunPlacement(birthData);
+  const moon = getMoonPlacement(birthData);
+  const rising = getRisingPlacement(birthData);
 
-  // Simplified planetary calculations - in production this would use Swiss Ephemeris
-  const planets = {
-    sun: { sign: sunSign, house: 1, degree: 15.5 },
-    moon: { sign: moonSign, house: 4, degree: 23.2 },
-    mercury: { sign: ZODIAC_SIGNS[(ZODIAC_SIGNS.indexOf(sunSign) + 1) % 12], house: 3, degree: 8.7 },
-    venus: { sign: ZODIAC_SIGNS[(ZODIAC_SIGNS.indexOf(sunSign) + 2) % 12], house: 2, degree: 19.3 },
-    mars: { sign: ZODIAC_SIGNS[(ZODIAC_SIGNS.indexOf(sunSign) + 3) % 12], house: 6, degree: 12.8 },
-    jupiter: { sign: ZODIAC_SIGNS[(ZODIAC_SIGNS.indexOf(sunSign) + 4) % 12], house: 9, degree: 26.1 },
-    saturn: { sign: ZODIAC_SIGNS[(ZODIAC_SIGNS.indexOf(sunSign) + 5) % 12], house: 10, degree: 4.9 },
-    uranus: { sign: ZODIAC_SIGNS[(ZODIAC_SIGNS.indexOf(sunSign) + 6) % 12], house: 11, degree: 18.4 },
-    neptune: { sign: ZODIAC_SIGNS[(ZODIAC_SIGNS.indexOf(sunSign) + 7) % 12], house: 12, degree: 21.7 },
-    pluto: { sign: ZODIAC_SIGNS[(ZODIAC_SIGNS.indexOf(sunSign) + 8) % 12], house: 8, degree: 14.2 }
-  };
-
-  const houses = Array.from({ length: 12 }, (_, i) => ({
-    sign: ZODIAC_SIGNS[(ZODIAC_SIGNS.indexOf(risingSign) + i) % 12],
-    degree: (i * 30 + Math.random() * 30) % 360
-  }));
-
-  const aspects = [
-    { planet1: 'sun', planet2: 'moon', aspect: 'sextile', orb: 2.3 },
-    { planet1: 'venus', planet2: 'mars', aspect: 'trine', orb: 1.8 },
-    { planet1: 'jupiter', planet2: 'saturn', aspect: 'square', orb: 3.1 }
-  ];
-
-  const northNode = { 
-    sign: ZODIAC_SIGNS[(ZODIAC_SIGNS.indexOf(moonSign) + 6) % 12], 
-    house: 5, 
-    degree: 11.3 
-  };
-  
-  const southNode = { 
-    sign: ZODIAC_SIGNS[(ZODIAC_SIGNS.indexOf(northNode.sign) + 6) % 12], 
-    house: 11, 
-    degree: 11.3 
-  };
-
-  const chiron = { 
-    sign: ZODIAC_SIGNS[(ZODIAC_SIGNS.indexOf(sunSign) + 9) % 12], 
-    house: 7, 
-    degree: 16.8 
-  };
+  const missingData: string[] = [];
+  if (!birthData.birthTime) missingData.push("verified_birth_time");
+  if (birthData.latitude === undefined || birthData.longitude === undefined) missingData.push("precise_location");
+  if (!sun.sign) missingData.push("ephemeris_engine");
 
   return {
-    sunSign,
-    moonSign,
-    risingSign,
-    planets,
-    houses,
-    aspects,
-    northNode,
-    southNode,
-    chiron
+    sun,
+    moon,
+    rising,
+    planets: undefined,
+    houses: undefined,
+    aspects: undefined,
+    northNode: undefined,
+    southNode: undefined,
+    chiron: undefined,
+    verification: {
+      complete: false,
+      missingData,
+      suggestions: missingData.length > 0
+        ? `To calculate your astrology: ${missingData.map((item) => {
+            if (item === "verified_birth_time") return "provide exact birth time";
+            if (item === "precise_location") return "provide precise birth location";
+            if (item === "ephemeris_engine") return "activate ephemeris calculation engine";
+            return item;
+          }).join(", ")}.`
+        : "Your astrology chart is ready for calculation.",
+      lastUpdated: new Date().toISOString(),
+    },
   };
 }
 
 export function getTarotBirthCards(birthDate: string): { card1: string; card2: string; interpretation: string } {
   const date = new Date(birthDate);
   const sum = date.getDate() + (date.getMonth() + 1) + date.getFullYear();
-  const digitalRoot = sum.toString().split('').reduce((acc, digit) => acc + parseInt(digit), 0);
-  const finalSum = digitalRoot > 9 ? digitalRoot.toString().split('').reduce((acc, digit) => acc + parseInt(digit), 0) : digitalRoot;
+  const digitalRoot = sum.toString().split("").reduce((acc, digit) => acc + parseInt(digit, 10), 0);
+  const finalSum = digitalRoot > 9
+    ? digitalRoot.toString().split("").reduce((acc, digit) => acc + parseInt(digit, 10), 0)
+    : digitalRoot;
 
   const tarotCards = [
     { card1: "The Fool", card2: "The World", interpretation: "Journey of infinite potential and cosmic completion" },
@@ -153,7 +149,7 @@ export function getTarotBirthCards(birthDate: string): { card1: string; card2: s
     { card1: "The Hermit", card2: "Wheel of Fortune", interpretation: "Inner guidance navigating life's cycles" },
     { card1: "Justice", card2: "The Hanged Man", interpretation: "Divine balance through surrender and perspective" },
     { card1: "Death", card2: "Temperance", interpretation: "Transformation through divine alchemy" },
-    { card1: "The Devil", card2: "The Tower", interpretation: "Breaking free from illusion and limitation" }
+    { card1: "The Devil", card2: "The Tower", interpretation: "Breaking free from illusion and limitation" },
   ];
 
   return tarotCards[finalSum % tarotCards.length];


### PR DESCRIPTION
## Summary

Consolidates the release-critical Gate 3 trust fixes onto a fresh branch from current `main`.

### Backend
- Removes date-boundary and simplified Moon/Rising approximations from the production astrology service
- Returns explicit unresolved states instead of fabricated placements
- Preserves missing-data reasons for birth time, location, and ephemeris requirements

### Onboarding
- Stops promoting naked sign strings into trusted profile state
- Requires verified placement evidence before compatibility or horoscope warmups
- Stores unresolved completion state honestly when verification is unavailable

### Poster and exports
- Removes hardcoded Gemini/Pisces fallbacks
- Renders or exports only placements that pass the centralized verification gate
- Surfaces unresolved placement status instead of decorating guesses as facts

### Trust contract
- Reuses the centralized placement verification helper already on `main`
- Interpretation and presentation layers cannot originate verification

## Merge condition

All CI, container, and PWA checks must pass. Gate 3 remains failed until this PR is green and the repo-wide silent-upgrade re-audit reports zero critical violations.

## Supersedes

This clean PR supersedes the stale overlapping work in PRs #132 and #133.