### PR TITLE
fix(gate3): enforce verified astrology at every AI ingress

### DIFF
--- a/routes/ai-respond.ts
+++ b/routes/ai-respond.ts
@@ -1,18 +1,15 @@
 /**
  * Shared AI endpoint — POST /api/ai/respond
  *
- * Every AI feature can route through this single gateway.
- * Returns a consistent AIResponse shape. Never returns a dead error.
+ * Every AI feature routes through this gateway. Astrology enters prompts only
+ * after the server-side verification filter clears it.
  */
 
 import type { Express } from "express";
 import { routeAIRequest } from "../services/ai-router";
-import {
-  buildSoulCodexSystemPrompt,
-  SOUL_CODEX_ENGINE_RULES,
-  CORE_DATA_RULE,
-} from "../src/ai/soulCodexEngine";
+import { buildSoulCodexSystemPrompt } from "../src/ai/soulCodexEngine";
 import type { AIPromptType } from "../src/types/ai";
+import { extractVerifiedAstrology } from "../server/lib/verified-astrology";
 
 function buildPromptForType(
   type: AIPromptType,
@@ -21,83 +18,61 @@ function buildPromptForType(
   timeline?: any,
   dailyCard?: any
 ): { prompt: string; systemPrompt?: string } {
-  const astro = profile?.astrologyData || {};
   const numData = profile?.numerologyData || {};
   const hdData = profile?.humanDesignData || {};
   const elemData = profile?.elementalMedicineData || {};
   const archData = profile?.archetypeData || profile?.archetype || {};
+  const verifiedAstrology = extractVerifiedAstrology(profile);
 
   const archetype =
     archData?.archetype ||
     archData?.name ||
     (typeof profile?.archetype === "string" ? profile.archetype : profile?.archetype?.name) ||
-    "Unknown";
-  const sunSign = astro?.sunSign || profile?.sunSign || "Unknown";
-  const moonSign = astro?.moonSign || profile?.moonSign || "Unknown";
-  const risingSign = astro?.risingSign || profile?.risingSign || "";
+    "Unresolved";
   const lifePath = numData?.lifePath || profile?.lifePath || "";
   const hdType = hdData?.type || profile?.hdType || "";
   const hdStrategy = hdData?.strategy || "";
   const primaryElement = elemData?.primaryElement || archData?.element || profile?.element || "";
   const phase = timeline?.phase || timeline?.currentPhase || "current phase";
   const focus = dailyCard?.focus || "one grounded next step";
+  const birthTimeKnown = Boolean(verifiedAstrology.rising);
 
-  const birthTimeKnown = !!risingSign;
+  const astrologyLines = [
+    verifiedAstrology.sun ? `- Sun: ${verifiedAstrology.sun}` : null,
+    verifiedAstrology.moon ? `- Moon: ${verifiedAstrology.moon}` : null,
+    verifiedAstrology.rising ? `- Rising: ${verifiedAstrology.rising}` : null,
+    verifiedAstrology.unresolved.length
+      ? `- Unresolved astrology: ${verifiedAstrology.unresolved.join(", ")}. Do not infer or interpret these placements.`
+      : null,
+  ].filter(Boolean).join("\n");
 
   const profileBlock = `
 User Profile:
 - Archetype: ${archetype}
-- Sun: ${sunSign} | Moon: ${moonSign}${risingSign ? ` | Rising: ${risingSign}` : ""}
+${astrologyLines || "- Astrology: unresolved; do not infer placements."}
 ${lifePath ? `- Life Path: ${lifePath}` : ""}
 ${hdType ? `- Human Design: ${hdType}${hdStrategy ? ` (Strategy: ${hdStrategy})` : ""}` : ""}
 ${primaryElement ? `- Element (Elemental Medicine): ${primaryElement}` : ""}
 - Phase: ${phase}
-- Focus: ${focus}${!birthTimeKnown ? `\n\nBIRTH TIME UNKNOWN — Rising sign, ascendant behavior, house placements, and house-based timing are unavailable. Do not infer, guess, or mention them. If relevant, state that those layers require an exact birth time.` : ""}`.trim();
+- Focus: ${focus}`.trim();
 
-  const systemPrompt = buildSoulCodexSystemPrompt({ includePatternDetection: true, birthTimeKnown });
+  const systemPrompt = `${buildSoulCodexSystemPrompt({ includePatternDetection: true, birthTimeKnown })}\n\nTRUST RULE: Use only explicitly supplied profile facts. Never invent, recover, infer, or upgrade unresolved placements.`;
 
   switch (type) {
     case "soul_guide":
-      return {
-        systemPrompt,
-        prompt: `${profileBlock}\n\nUser question:\n${question}\n\nRespond with Observation, Meaning, Action. Reference their core data by name.`,
-      };
-
+      return { systemPrompt, prompt: `${profileBlock}\n\nUser question:\n${question}\n\nRespond with Observation, Meaning, Action. Reference only available core data.` };
     case "daily_guidance":
-      return {
-        systemPrompt,
-        prompt: `${profileBlock}\n\nGenerate a daily guidance card. Use the Observation → Meaning → Action format. Reference at least 3 of their core data points by name. Write in first person (I/my/me).`,
-      };
-
+      return { systemPrompt, prompt: `${profileBlock}\n\nGenerate a daily guidance card using Observation → Meaning → Action. Use only available, supported data.` };
     case "daily_horoscope":
-      return {
-        systemPrompt,
-        prompt: `${profileBlock}\n\nWrite a daily horoscope using Observation → Meaning → Action. Reference Sun, Moon, and at least one other core data point. Write in first person. Keep it to 4-6 sentences total.`,
-      };
-
+      return { systemPrompt, prompt: `${profileBlock}\n\nWrite daily guidance from verified astrology only. If no verified astrology is available, clearly state that the astrology layer is paused and use supported non-astrology context instead.` };
     case "codex_reading":
-      return {
-        systemPrompt,
-        prompt: `${profileBlock}\n\nGenerate a premium Codex reading. Be psychologically sharp, behavior-based, and directly useful. Reference all available core data points. Write in first person. Minimum 400 words.`,
-      };
-
+      return { systemPrompt, prompt: `${profileBlock}\n\nGenerate a psychologically sharp Codex reading. Reference all available supported data and omit unresolved layers. Minimum 400 words.` };
     case "biography":
-      return {
-        systemPrompt,
-        prompt: `${profileBlock}\n\nWrite a 2-3 paragraph first-person behavioral profile. Reference Sun, Moon, ${birthTimeKnown ? "Rising, " : ""}Life Path, Human Design, and Element by name where available. Every sentence must describe something observable.`,
-      };
-
+      return { systemPrompt, prompt: `${profileBlock}\n\nWrite a 2-3 paragraph first-person behavioral profile. Every sentence must describe something observable and supported by available data.` };
     case "compatibility":
-      return {
-        systemPrompt,
-        prompt: `${profileBlock}\n\n${question || "Generate a compatibility reading between these two profiles."}`,
-      };
-
+      return { systemPrompt, prompt: `${profileBlock}\n\n${question || "Generate a compatibility reading between these two evidence-cleared profiles."}` };
     default:
-      return {
-        systemPrompt,
-        prompt: `${profileBlock}\n\n${question || "Provide insight based on this profile."}`,
-      };
+      return { systemPrompt, prompt: `${profileBlock}\n\n${question || "Provide insight based on the supported profile data."}` };
   }
 }
 
@@ -105,10 +80,7 @@ export function registerAIRespondRoute(app: Express) {
   app.post("/api/ai/respond", async (req, res) => {
     try {
       const { type, question, profile, timeline, dailyCard } = req.body || {};
-
-      if (!type) {
-        return res.status(400).json({ error: "Missing AI request type" });
-      }
+      if (!type) return res.status(400).json({ error: "Missing AI request type" });
 
       const { prompt, systemPrompt } = buildPromptForType(
         type as AIPromptType,
@@ -134,12 +106,8 @@ export function registerAIRespondRoute(app: Express) {
       return res.status(200).json({
         status: "fallback",
         provider: "deterministic",
-        content:
-          "Your Codex is available. Live AI interpretation is temporarily paused — use the strongest visible signal on the page as your guide for now.",
-        meta: {
-          reason: error?.message || "Unexpected server error",
-          promptType: req.body?.type,
-        },
+        content: "Your Codex is available. Live AI interpretation is temporarily paused. Use the strongest supported signal visible on the page.",
+        meta: { reason: error?.message || "Unexpected server error", promptType: req.body?.type },
       });
     }
   });

--- a/routes/chat.ts
+++ b/routes/chat.ts
@@ -4,31 +4,22 @@ import { routeAIStream } from "../services/ai-router";
 import { entitlementService } from "../services/entitlement-service";
 import { buildSoulCodexSystemPrompt } from "../src/ai/soulCodexEngine";
 import { runSoulCodexEngine } from "@soulcodex/core";
-
-
+import { buildVerifiedAstrologyLines, extractVerifiedAstrology } from "../server/lib/verified-astrology";
 
 export function registerChatRoutes(app: Express) {
   app.post("/api/chat/soul-guide", async (req, res) => {
     try {
       const { message, history = [], profileContext } = req.body || {};
-
       if (!message || typeof message !== "string") {
         return res.status(400).json({ message: "Message is required" });
       }
 
-
-
-      const userId   = (req as any).user?.id;
+      const userId = (req as any).user?.id;
       const sessionId = (req as any).sessionID;
-      const session  = (req as any).session;
-
-      // ── Premium check ────────────────────────────────────────────────────
+      const session = (req as any).session;
       let isPremium = false;
 
-      if ((req as any).session?.isPremium) {
-        isPremium = true;
-      }
-
+      if (session?.isPremium) isPremium = true;
       if (!isPremium) {
         const ownerProfileId = process.env.OWNER_PROFILE_ID;
         if (ownerProfileId && userId) {
@@ -41,7 +32,6 @@ export function registerChatRoutes(app: Express) {
           if (!isPremium && userId === ownerProfileId) isPremium = true;
         }
       }
-
       if (!isPremium) {
         try {
           const status = await entitlementService.getUserPremiumStatus({ userId, sessionId });
@@ -51,64 +41,49 @@ export function registerChatRoutes(app: Express) {
         }
       }
 
-      // ── Profile context ──────────────────────────────────────────────────
       let profile: any = null;
-      if (userId) {
-        profile = await storage.getProfileByUserId(userId);
-      } else if (sessionId) {
-        profile = await storage.getProfileBySessionId(sessionId);
-      }
+      if (userId) profile = await storage.getProfileByUserId(userId);
+      else if (sessionId) profile = await storage.getProfileBySessionId(sessionId);
 
       const hasProfileData = !!profile || !!profileContext;
       const dynamicLimit = hasProfileData ? 2 : 1;
-
-      // ── Usage gate ───────────────────────────────────────────────────────
       if (!isPremium) {
         const chatCount: number = session?.chatCount ?? 0;
         if (chatCount >= dynamicLimit) {
-          return res.status(403).json({
-            error: "limit_reached",
-            used: chatCount,
-            limit: dynamicLimit,
-          });
+          return res.status(403).json({ error: "limit_reached", used: chatCount, limit: dynamicLimit });
         }
-        // Increment before streaming so failed streams still count
         if (session) session.chatCount = chatCount + 1;
       }
 
-      // ── Engine Data ─────────────────────────────────────────────────────
       let systemInstruction = "";
-      
       if (profile) {
+        const verifiedAstrology = extractVerifiedAstrology(profile);
         const engineData = runSoulCodexEngine({
           toneMode: "challenging",
           astrology: {
-            sun: profile.sunSign,
-            moon: profile.moonSign,
-            rising: profile.risingSign,
+            sun: verifiedAstrology.sun,
+            moon: verifiedAstrology.moon,
+            rising: verifiedAstrology.rising,
           },
-          human_design: {
-            type: profile.hdType,
-          },
-          numerology: {
-            life_path: profile.lifePath,
-          },
+          human_design: { type: profile.hdType },
+          numerology: { life_path: profile.lifePath },
           mirror: profile.mirrorProfile,
         });
 
         systemInstruction = buildSoulCodexSystemPrompt({
           directMode: true,
           includePatternDetection: true,
-          birthTimeKnown: !!profile.risingSign,
+          birthTimeKnown: Boolean(verifiedAstrology.rising),
         }, engineData);
+        if (verifiedAstrology.unresolved.length) {
+          systemInstruction += `\n\nTRUST BOUNDARY: ${verifiedAstrology.unresolved.join(", ")} unresolved. Do not infer, name, or interpret them.`;
+        }
       } else if (profileContext) {
         systemInstruction = buildProfileContextPrompt(profileContext);
       } else {
         systemInstruction = buildGeneralPrompt();
       }
 
-
-      // ── Stream ───────────────────────────────────────────────────────────
       res.setHeader("Content-Type", "text/event-stream");
       res.setHeader("Cache-Control", "no-cache");
       res.setHeader("Connection", "keep-alive");
@@ -122,11 +97,8 @@ export function registerChatRoutes(app: Express) {
       });
 
       for await (const { chunk } of stream) {
-        if (chunk) {
-          res.write(`data: ${JSON.stringify({ content: chunk })}\n\n`);
-        }
+        if (chunk) res.write(`data: ${JSON.stringify({ content: chunk })}\n\n`);
       }
-
       res.write("data: [DONE]\n\n");
       res.end();
     } catch (error) {
@@ -137,17 +109,13 @@ export function registerChatRoutes(app: Express) {
     }
   });
 
-  // Return current question usage for the session
   app.get("/api/chat/soul-guide/usage", async (req, res) => {
     try {
-      const userId    = (req as any).user?.id;
+      const userId = (req as any).user?.id;
       const sessionId = (req as any).sessionID;
-      const session   = (req as any).session;
+      const session = (req as any).session;
+      let isPremium = Boolean(session?.isPremium);
 
-      let isPremium = false;
-      if ((req as any).session?.isPremium) {
-        isPremium = true;
-      }
       if (!isPremium) {
         const ownerProfileId = process.env.OWNER_PROFILE_ID;
         if (ownerProfileId && userId) {
@@ -165,20 +133,16 @@ export function registerChatRoutes(app: Express) {
         } catch {}
       }
 
-      const hasLocalProfile = req.query.hasProfile === 'true';
+      const hasLocalProfile = req.query.hasProfile === "true";
       let profile: any = null;
       if (userId) {
         try { profile = await storage.getProfileByUserId(userId); } catch {}
       } else if (sessionId) {
-        try {
-          profile = await storage.getProfileBySessionId(sessionId);
-        } catch {}
+        try { profile = await storage.getProfileBySessionId(sessionId); } catch {}
       }
-      
-      const hasProfileData = !!profile || hasLocalProfile;
-      const limit = hasProfileData ? 2 : 1;
 
-      const used  = isPremium ? 0 : (session?.chatCount ?? 0);
+      const limit = profile || hasLocalProfile ? 2 : 1;
+      const used = isPremium ? 0 : (session?.chatCount ?? 0);
       res.json({ isPremium, used, limit, remaining: isPremium ? null : Math.max(0, limit - used) });
     } catch (err) {
       console.error("[soul-guide usage]", err);
@@ -188,15 +152,10 @@ export function registerChatRoutes(app: Express) {
 }
 
 function buildProfileContextPrompt(profile: any): string {
-  const parts = [];
+  const parts: string[] = [];
   if (profile.name) parts.push(`- Name: ${profile.name}`);
   if (profile.archetype) parts.push(`- Archetype: ${profile.archetype}`);
-  if (profile.sunSign || profile.moonSign || profile.risingSign) {
-    parts.push(`- Astrology: Sun ${profile.sunSign || 'Omit'}, Moon ${profile.moonSign || 'Omit'}${profile.risingSign ? `, Rising ${profile.risingSign}` : ''}`);
-  }
-  if (!profile.risingSign) {
-    parts.push(`\nBIRTH TIME UNKNOWN — Rising sign, ascendant behavior, house placements, and house-based timing are unavailable. Do not infer, guess, or mention them. If relevant, state that those layers require an exact birth time.`);
-  }
+  parts.push(...buildVerifiedAstrologyLines(profile));
   if (profile.hdType) parts.push(`- Human Design: ${profile.hdType}`);
   if (profile.lifePath) parts.push(`- Numerology: Life Path ${profile.lifePath}`);
   if (profile.element) parts.push(`- Element: ${profile.element}`);
@@ -205,36 +164,19 @@ function buildProfileContextPrompt(profile: any): string {
 
   return `
 You are the final synthesis layer of Soul Codex.
-Your job is to expose the user's behavioral pattern with surgical accuracy, grounded realism, and zero system leakage.
-
----
-## 🧬 IDENTITY RULES
-Identity must be:
-- Behavioral (what I DO)
-- Observable (what others could notice)
-- Pattern-based (repeated loop)
-
-NOT:
-- preferences, vague traits, or poetic filler.
-
----
-## 🧪 SANITIZATION
-- No placeholders ("unknown", "N/A").
-- No advice or "growth mindset" language.
+Use only supplied, evidence-cleared data. Never infer missing astrology, Human Design, biography, or confidence.
 
 USER SOUL BLUEPRINT:
-${parts.join('\n')}
+${parts.join("\n")}
 
-YOUR MISSION:
-Explain the behavioral loop formed by these specific placements. Use their Human Design Strategy to expose HOW they move through the world today. No fluff.
+Explain observable behavioral patterns with clarity. If a symbolic layer is unresolved, omit its interpretation rather than completing the pattern yourself.
 `;
 }
 
 function buildGeneralPrompt(): string {
   return `
 You are the Soul Guide.
-Your job is to encourage the user to create a profile so you can expose their behavioral patterns with surgical accuracy.
-
-TONE: Blunt, real, grounded. No fluff. No advice.
+Encourage the user to create a profile so supported behavioral patterns can be analyzed.
+TONE: Blunt, real, grounded. No invented personal facts.
 `;
 }

--- a/server/lib/__tests__/verified-astrology.test.ts
+++ b/server/lib/__tests__/verified-astrology.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { buildVerifiedAstrologyLines, extractVerifiedAstrology } from "../verified-astrology";
+
+const evidence = {
+  source: "independent ephemeris comparison",
+  engine: "engine-a+engine-b",
+  calculatedAt: "2026-08-02T00:00:00Z",
+};
+
+describe("server verified astrology filter", () => {
+  it("rejects legacy naked sign strings", () => {
+    expect(extractVerifiedAstrology({
+      sunSign: "Virgo",
+      moonSign: "Virgo",
+      risingSign: "Scorpio",
+    })).toEqual({
+      sun: undefined,
+      moon: undefined,
+      rising: undefined,
+      unresolved: ["Sun", "Moon", "Ascendant"],
+    });
+  });
+
+  it("rejects populated placements marked pending", () => {
+    expect(extractVerifiedAstrology({
+      astrologyData: {
+        sun: { sign: "Virgo", status: "pending_ephemeris" },
+        moon: { sign: "Virgo", verificationStatus: "pending_independent_verification" },
+        rising: { sign: "Scorpio", verificationStatus: "calculated", provenance: evidence },
+      },
+    })).toEqual(expect.objectContaining({ unresolved: ["Sun", "Moon", "Ascendant"] }));
+  });
+
+  it("rejects a verified label without source, engine, and timestamp", () => {
+    expect(extractVerifiedAstrology({
+      astrologyData: {
+        sun: { sign: "Virgo", verificationStatus: "verified" },
+      },
+    }).sun).toBeUndefined();
+  });
+
+  it("accepts only evidence-complete verified placements", () => {
+    expect(extractVerifiedAstrology({
+      astrologyData: {
+        sun: { sign: "Virgo", verificationStatus: "verified", provenance: evidence },
+        moon: { sign: "Scorpio", verificationStatus: "verified", evidence },
+      },
+    })).toEqual({
+      sun: "Virgo",
+      moon: "Scorpio",
+      rising: undefined,
+      unresolved: ["Ascendant"],
+    });
+  });
+
+  it("builds explicit refusal language for unresolved placements", () => {
+    const lines = buildVerifiedAstrologyLines({ moonSign: "Virgo", risingSign: "Scorpio" });
+    expect(lines.join("\n")).toContain("Do not infer or interpret these placements");
+    expect(lines.join("\n")).not.toContain("Virgo");
+    expect(lines.join("\n")).not.toContain("Scorpio");
+  });
+});

--- a/server/lib/verified-astrology.ts
+++ b/server/lib/verified-astrology.ts
@@ -1,0 +1,63 @@
+export interface PlacementEvidence {
+  source?: string | null;
+  engine?: string | null;
+  calculatedAt?: string | null;
+}
+
+export interface PlacementLike {
+  sign?: string | null;
+  status?: string | null;
+  verificationStatus?: string | null;
+  evidence?: PlacementEvidence | null;
+  provenance?: PlacementEvidence | null;
+}
+
+export interface VerifiedAstrology {
+  sun?: string;
+  moon?: string;
+  rising?: string;
+  unresolved: string[];
+}
+
+function verifiedSign(value: PlacementLike | null | undefined): string | undefined {
+  if (!value?.sign) return undefined;
+  const state = value.verificationStatus ?? value.status;
+  if (state !== "verified") return undefined;
+  const evidence = value.provenance ?? value.evidence;
+  if (!evidence?.source || !evidence?.engine || !evidence?.calculatedAt) return undefined;
+  return value.sign;
+}
+
+function placementFromProfile(profile: any, key: "sun" | "moon" | "rising"): PlacementLike | undefined {
+  return (
+    profile?.astrologyData?.[key] ??
+    profile?.astrology?.[key] ??
+    profile?.natalChart?.[key] ??
+    profile?.chart?.[key]
+  );
+}
+
+export function extractVerifiedAstrology(profile: any): VerifiedAstrology {
+  const sun = verifiedSign(placementFromProfile(profile, "sun"));
+  const moon = verifiedSign(placementFromProfile(profile, "moon"));
+  const rising = verifiedSign(placementFromProfile(profile, "rising"));
+  const unresolved = [
+    !sun ? "Sun" : null,
+    !moon ? "Moon" : null,
+    !rising ? "Ascendant" : null,
+  ].filter((value): value is string => Boolean(value));
+
+  return { sun, moon, rising, unresolved };
+}
+
+export function buildVerifiedAstrologyLines(profile: any): string[] {
+  const astrology = extractVerifiedAstrology(profile);
+  const lines: string[] = [];
+  if (astrology.sun) lines.push(`- Sun: ${astrology.sun}`);
+  if (astrology.moon) lines.push(`- Moon: ${astrology.moon}`);
+  if (astrology.rising) lines.push(`- Rising: ${astrology.rising}`);
+  if (astrology.unresolved.length) {
+    lines.push(`- Unresolved astrology: ${astrology.unresolved.join(", ")}. Do not infer or interpret these placements.`);
+  }
+  return lines;
+}

--- a/server/services/openai-service.ts
+++ b/server/services/openai-service.ts
@@ -1,4 +1,5 @@
 import { generateText, isGeminiAvailable } from "../../gemini";
+import { extractVerifiedAstrology } from "../lib/verified-astrology";
 
 interface BiographyRequest {
   name: string;
@@ -9,33 +10,43 @@ interface BiographyRequest {
   archetype: any;
 }
 
-export async function generateBiography(data: BiographyRequest): Promise<string> {
-  if (!isGeminiAvailable()) {
-    return generateFallbackBiography(data);
+function verifiedAstrologyFor(data: BiographyRequest) {
+  return extractVerifiedAstrology({ astrologyData: data.astrologyData });
+}
+
+function astrologyPromptLines(data: BiographyRequest): string[] {
+  const astrology = verifiedAstrologyFor(data);
+  const lines: string[] = [];
+  if (astrology.sun) lines.push(`- Sun: ${astrology.sun}`);
+  if (astrology.moon) lines.push(`- Moon: ${astrology.moon}`);
+  if (astrology.rising) lines.push(`- Rising: ${astrology.rising}`);
+  if (astrology.unresolved.length) {
+    lines.push(`- Unresolved astrology: ${astrology.unresolved.join(", ")}. Do not infer or interpret these placements.`);
   }
+  return lines;
+}
+
+export async function generateBiography(data: BiographyRequest): Promise<string> {
+  if (!isGeminiAvailable()) return generateFallbackBiography(data);
 
   try {
-    const prompt = `You are an expert mystical biographer. Create a compelling 2-3 paragraph first-person biographical narrative for ${data.name}.
+    const prompt = `You are an expert behavioral biographer. Create a compelling 2-3 paragraph first-person narrative for ${data.name}.
 
 Profile Summary:
 - Archetype: ${data.archetypeTitle}
-- Sun Sign: ${data.astrologyData?.sunSign || 'Unknown'}
-- Moon Sign: ${data.astrologyData?.moonSign || 'Unknown'}
-- Rising Sign: ${data.astrologyData?.risingSign || 'Unknown'}
-- Life Path Number: ${data.numerologyData?.lifePath || 'Unknown'}
-- Enneagram Type: ${data.personalityData?.enneagram?.type || 'Unknown'}
-- MBTI Type: ${data.personalityData?.mbti?.type || 'Unknown'}
+${astrologyPromptLines(data).join("\n")}
+- Life Path Number: ${data.numerologyData?.lifePath || "Unresolved"}
+- Enneagram Type: ${data.personalityData?.enneagram?.type || "Unresolved"}
+- MBTI Type: ${data.personalityData?.mbti?.type || "Unresolved"}
 
 Core Themes from Analysis:
-${data.archetype?.themes?.join(', ') || 'Transformation, self-discovery, spiritual growth'}
+${data.archetype?.themes?.join(", ") || "No verified themes supplied"}
 
-Write in first person as if ${data.name} is introducing themselves. Focus on:
-1. Their core essence and spiritual nature
-2. How they transform challenges into wisdom
-3. Their unique gifts and life purpose
-4. Keep it mystical yet grounded and authentic
-
-Return only the biographical text, no additional formatting.`;
+Rules:
+1. Use only supplied profile facts.
+2. Do not invent or infer unresolved astrology, biography, motives, trauma, or confidence.
+3. Describe observable patterns and practical meaning.
+4. Return only the biographical text.`;
 
     const result = await generateText({ prompt, temperature: 0.8 });
     return result || generateFallbackBiography(data);
@@ -46,21 +57,17 @@ Return only the biographical text, no additional formatting.`;
 }
 
 export async function generateDailyGuidance(data: BiographyRequest): Promise<string> {
-  if (!isGeminiAvailable()) {
-    return generateFallbackGuidance(data);
-  }
+  if (!isGeminiAvailable()) return generateFallbackGuidance(data);
 
   try {
-    const prompt = `Create personalized daily guidance for ${data.name} based on their spiritual profile.
+    const prompt = `Create brief, actionable daily guidance for ${data.name}.
 
-Profile:
+Supported profile:
 - Archetype: ${data.archetypeTitle}
-- Sun/Moon/Rising: ${data.astrologyData?.sunSign}/${data.astrologyData?.moonSign}/${data.astrologyData?.risingSign}
-- Life Path: ${data.numerologyData?.lifePath}
+${astrologyPromptLines(data).join("\n")}
+- Life Path: ${data.numerologyData?.lifePath || "Unresolved"}
 
-Generate a brief, actionable daily insight (2-3 sentences) that aligns with their cosmic blueprint. Focus on practical spiritual guidance for today.
-
-Return only the guidance text.`;
+Use only supported data. Do not infer unresolved astrology. Return 2-3 grounded sentences.`;
 
     const result = await generateText({ prompt, temperature: 0.7 });
     return result || generateFallbackGuidance(data);
@@ -71,14 +78,22 @@ Return only the guidance text.`;
 }
 
 function generateFallbackBiography(data: BiographyRequest): string {
-  return `I am ${data.name}, a soul walking the path of the ${data.archetypeTitle}. With my ${data.astrologyData?.sunSign || 'cosmic'} Sun illuminating my core essence and my ${data.astrologyData?.moonSign || 'intuitive'} Moon guiding my emotional depths, I navigate life's journey with purpose and wonder.
+  const astrology = verifiedAstrologyFor(data);
+  const supported: string[] = [];
+  if (astrology.sun) supported.push(`${astrology.sun} Sun`);
+  if (astrology.moon) supported.push(`${astrology.moon} Moon`);
+  if (astrology.rising) supported.push(`${astrology.rising} Rising`);
+  if (data.numerologyData?.lifePath) supported.push(`Life Path ${data.numerologyData.lifePath}`);
 
-My Life Path ${data.numerologyData?.lifePath || 'number'} reveals the lessons I came here to learn and the gifts I have to share. Each day brings new opportunities for growth, transformation, and deeper self-understanding.
+  const evidenceSentence = supported.length
+    ? `The supported layers currently available are ${supported.join(", ")}.`
+    : "The symbolic layers needed for a personalized biography are still unresolved.";
 
-I embrace my unique cosmic blueprint, knowing that my journey is both deeply personal and universally connected to the greater tapestry of existence.`;
+  return `I am ${data.name}, and my current Soul Codex centers on the ${data.archetypeTitle}. ${evidenceSentence}\n\nThis reading stays with what has actually been supplied and verified. Unresolved astrology is intentionally omitted rather than turned into a polished guess.\n\nMy next useful step is to compare the supported pattern with my lived experience and keep only what creates clarity.`;
 }
 
 function generateFallbackGuidance(data: BiographyRequest): string {
-  const sunSign = data.astrologyData?.sunSign || 'your sign';
-  return `Today, dear ${data.name}, embrace the energy of ${sunSign} and let your inner ${data.archetypeTitle} guide you toward meaningful connections and insights.`;
+  const astrology = verifiedAstrologyFor(data);
+  const anchor = astrology.sun ? `your verified ${astrology.sun} Sun` : `your ${data.archetypeTitle} pattern`;
+  return `Today, use ${anchor} as a reflection point only where it matches your lived experience. Unresolved astrology remains paused, so focus on one grounded action you can verify through your own behavior.`;
 }


### PR DESCRIPTION
## Summary

Closes the three critical AI-ingress trust leaks found by the post-merge Gate 3 audit.

### Server trust filter
- Adds one server-side `extractVerifiedAstrology()` boundary
- Rejects naked legacy `sunSign`, `moonSign`, and `risingSign` strings
- Requires `verified` state plus source, engine, and calculation timestamp
- Emits explicit unresolved-placement refusal language

### AI routes
- `routes/chat.ts` now feeds only evidence-cleared placements into the Soul Guide engine
- `routes/ai-respond.ts` builds prompts from verified placements only
- Missing Sun, Moon, or Ascendant cannot be reconstructed from legacy fields or prompt wording

### Biography and deterministic fallbacks
- `server/services/openai-service.ts` no longer inserts unverified astrology into Gemini prompts
- Deterministic fallback biography and guidance omit unresolved placements
- Generic fallback language remains useful without dressing guesses as identity facts

### Regression protection
- Adversarial tests cover naked strings, pending placements, fake verified labels, complete evidence, and refusal language

## Validation

- CI Tests: passed
- Ultimate SoulCodex CI: passed
- Railway Container Smoke: passed

## Merge condition

Satisfied. Post-merge Gate 3 receipt must be updated only after a fresh repository-wide re-audit confirms zero critical AI-ingress violations.

## Resolves findings from

PR #139 post-merge Gate 3 audit.