### PR TITLE
feat(compatibility): reuse one verified Soul Profile across match intelligence

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,7 +11,7 @@ import Home from "./pages/home";
 import LocalFirstInputForm from "./pages/local-first-input-form";
 import Profile from "./pages/profile";
 import OfflineProfilePage from "./pages/offline-profile";
-import CompatibilityPage from "./pages/CompatibilityPage";
+import CompatibilityExplorerPage from "./pages/CompatibilityExplorerPage";
 import CompatibilityHubPage from "./pages/CompatibilityHubPage";
 import TimelinePage from "./pages/TimelinePage";
 import AstrocartographyPage from "./pages/AstrocartographyPage";
@@ -86,7 +86,7 @@ function Router() {
       <Route path="/" component={Home} />
       <Route path="/create" component={LocalFirstInputForm} />
       <Route path="/compatibility" component={CompatibilityHubPage} />
-      <Route path="/compatibility/explorer" component={CompatibilityPage} />
+      <Route path="/compatibility/explorer" component={CompatibilityExplorerPage} />
       <Route path="/timeline" component={TimelinePage} />
       <Route path="/astrocartography/:id">
         {() => <PremiumRoute component={AstrocartographyPage} />}

--- a/client/src/pages/CompatibilityExplorerPage.tsx
+++ b/client/src/pages/CompatibilityExplorerPage.tsx
@@ -1,0 +1,202 @@
+import { useEffect, useMemo, useState } from "react";
+import Navigation from "../components/navigation";
+import { loadActiveProfile } from "../lib/ActiveProfileRepository";
+import { getVerifiedPlacement, placementDisplayStatus } from "../lib/placementVerification";
+
+type Mode = "love" | "attraction" | "friendship" | "growth";
+
+type Match = {
+  sign: { name: string; element: string };
+  score: number;
+  scores: Record<Mode, number>;
+  headline: string;
+  why: string;
+  tension?: string;
+};
+
+type Result = {
+  available: boolean;
+  reason?: string;
+  all: Match[];
+  best: Match[];
+  challenging: Match[];
+  picks?: Record<string, Match | null>;
+  unresolved?: { astrology?: string[]; humanDesign?: string[] };
+  formula?: { layers?: string[]; inputs?: Record<string, unknown> };
+};
+
+const MODES: Array<{ key: Mode; label: string; description: string }> = [
+  { key: "love", label: "Life Partner", description: "Emotional fit, trust, commitment, and long-term stability." },
+  { key: "attraction", label: "Sexual Chemistry", description: "Physical magnetism, desire, intensity, and energetic pull." },
+  { key: "friendship", label: "Intellectual Match", description: "Conversation, humor, mental ease, trust, and friendship." },
+  { key: "growth", label: "Growth Potential", description: "The connection most likely to expose patterns and develop maturity." },
+];
+
+function profileName(profile: any): string {
+  return profile?.name || profile?.firstName || profile?.codename || "Your";
+}
+
+function placementCandidate(profile: any, key: "sun" | "moon" | "rising") {
+  return profile?.astrologyData?.[key] ?? profile?.astrology?.[key] ?? profile?.natalChart?.[key] ?? profile?.chart?.[key];
+}
+
+function matchScore(match: Match, mode: Mode) {
+  return match.scores?.[mode] ?? match.score ?? 0;
+}
+
+export default function CompatibilityExplorerPage() {
+  const [profile, setProfile] = useState<any>(null);
+  const [mode, setMode] = useState<Mode>("love");
+  const [result, setResult] = useState<Result | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    const loaded = loadActiveProfile();
+    setProfile(loaded.profile ?? null);
+    if (!loaded.profile) setLoading(false);
+  }, []);
+
+  const verifiedSun = useMemo(() => getVerifiedPlacement(placementCandidate(profile, "sun")), [profile]);
+  const sunStatus = placementDisplayStatus(placementCandidate(profile, "sun"));
+
+  useEffect(() => {
+    if (!profile) return;
+    let cancelled = false;
+
+    async function load() {
+      setLoading(true);
+      setError("");
+      try {
+        const response = await fetch("/api/compatibility/archetype-matches", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify({ profile, mode }),
+        });
+        const payload = await response.json();
+        if (!cancelled) {
+          setResult(payload);
+          if (!response.ok && response.status !== 422) setError(payload?.message || "Compatibility could not be generated.");
+        }
+      } catch (cause) {
+        if (!cancelled) setError(cause instanceof Error ? cause.message : "Compatibility could not be generated.");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    void load();
+    return () => { cancelled = true; };
+  }, [profile, mode]);
+
+  const ranked = useMemo(
+    () => [...(result?.all ?? [])].sort((a, b) => matchScore(b, mode) - matchScore(a, mode)),
+    [result, mode]
+  );
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <Navigation />
+      <main className="mx-auto max-w-6xl px-4 pb-20 pt-28">
+        <header className="mb-8 text-center">
+          <p className="text-xs font-semibold uppercase tracking-[0.22em] text-primary">Relationship Intelligence</p>
+          <h1 className="mt-3 text-4xl font-bold md:text-6xl">{profileName(profile)} Compatibility Map</h1>
+          <p className="mx-auto mt-4 max-w-3xl text-muted-foreground">
+            Your saved Soul Profile is reused here. No second onboarding, no repeated birthday form, and no placement is treated as fact without verification evidence.
+          </p>
+        </header>
+
+        {!profile && (
+          <section className="rounded-2xl border bg-card p-6 text-center">
+            <h2 className="text-xl font-semibold">Create your Soul Profile once</h2>
+            <p className="mt-2 text-muted-foreground">Compatibility will automatically use it across every relationship layer.</p>
+            <a href="/create" className="mt-5 inline-flex rounded-lg bg-primary px-5 py-3 font-semibold text-primary-foreground">Create profile</a>
+          </section>
+        )}
+
+        {profile && !verifiedSun && (
+          <section className="rounded-2xl border border-amber-500/30 bg-amber-500/5 p-6">
+            <p className="text-xs font-semibold uppercase tracking-wider text-amber-600">Interpretation paused</p>
+            <h2 className="mt-2 text-2xl font-semibold">Verified Sun placement required</h2>
+            <p className="mt-3 text-muted-foreground">
+              Current status: <strong>{sunStatus}</strong>. Your saved profile remains active, but the sign-ranking engine will not convert a legacy or approximate sign into relationship advice.
+            </p>
+            <p className="mt-3 text-sm text-muted-foreground">Numerology and other supported layers remain preserved for the future multi-system compatibility engine.</p>
+          </section>
+        )}
+
+        {profile && (
+          <section className="mt-8 grid gap-3 md:grid-cols-4">
+            {MODES.map((item) => (
+              <button
+                key={item.key}
+                onClick={() => setMode(item.key)}
+                className={`rounded-2xl border p-4 text-left transition ${mode === item.key ? "border-primary bg-primary/10" : "bg-card hover:border-primary/40"}`}
+              >
+                <strong>{item.label}</strong>
+                <span className="mt-2 block text-sm text-muted-foreground">{item.description}</span>
+              </button>
+            ))}
+          </section>
+        )}
+
+        {loading && profile && <p className="mt-8 text-center text-muted-foreground">Building the evidence-cleared compatibility map…</p>}
+        {error && <p className="mt-8 rounded-xl border border-destructive/30 bg-destructive/5 p-4 text-destructive">{error}</p>}
+
+        {result?.available && !loading && (
+          <>
+            <section className="mt-10">
+              <div className="mb-5 flex items-end justify-between gap-4">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wider text-primary">Best natural matches</p>
+                  <h2 className="mt-1 text-3xl font-bold">{MODES.find((item) => item.key === mode)?.label}</h2>
+                </div>
+                <span className="text-sm text-muted-foreground">Ranked across all 12 signs</span>
+              </div>
+              <div className="grid gap-4 md:grid-cols-2">
+                {ranked.slice(0, 4).map((match, index) => (
+                  <article key={match.sign.name} className="rounded-2xl border bg-card p-5">
+                    <div className="flex items-center justify-between gap-4">
+                      <div>
+                        <span className="text-xs text-muted-foreground">#{index + 1}</span>
+                        <h3 className="text-2xl font-semibold">{match.sign.name}</h3>
+                      </div>
+                      <strong className="text-2xl text-primary">{matchScore(match, mode)}</strong>
+                    </div>
+                    <p className="mt-4 font-medium">{match.headline}</p>
+                    <p className="mt-3 text-sm leading-6 text-muted-foreground">{match.why}</p>
+                    {match.tension && <p className="mt-4 rounded-lg bg-muted p-3 text-sm"><strong>Watch point:</strong> {match.tension}</p>}
+                  </article>
+                ))}
+              </div>
+            </section>
+
+            <section className="mt-10 rounded-2xl border bg-card p-6">
+              <p className="text-xs font-semibold uppercase tracking-wider text-primary">Hardest matches</p>
+              <h2 className="mt-2 text-2xl font-bold">Highest friction and strongest lessons</h2>
+              <div className="mt-5 grid gap-4 md:grid-cols-3">
+                {(result.challenging ?? []).map((match) => (
+                  <article key={match.sign.name} className="rounded-xl border p-4">
+                    <div className="flex justify-between gap-3"><strong>{match.sign.name}</strong><span>{matchScore(match, mode)}</span></div>
+                    <p className="mt-3 text-sm text-muted-foreground">{match.tension || match.why}</p>
+                  </article>
+                ))}
+              </div>
+            </section>
+
+            <details className="mt-8 rounded-2xl border bg-card p-5">
+              <summary className="cursor-pointer font-semibold">Why the app reached these conclusions</summary>
+              <ul className="mt-4 space-y-2 text-sm text-muted-foreground">
+                {(result.formula?.layers ?? []).map((layer) => <li key={layer}>• {layer}</li>)}
+              </ul>
+              {(result.unresolved?.astrology?.length || result.unresolved?.humanDesign?.length) ? (
+                <p className="mt-4 text-sm text-amber-600">Unresolved layers were excluded rather than guessed.</p>
+              ) : null}
+            </details>
+          </>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/routes/compatibility.ts
+++ b/routes/compatibility.ts
@@ -1,9 +1,49 @@
 import { Router } from "express";
 import { calculateArchetypeMatches, type ArchetypeMatch, type RelationshipMode } from "../services/archetype-matches";
+import { extractVerifiedAstrology } from "../server/lib/verified-astrology";
 
 const router = Router();
 
 const MODE_KEYS: RelationshipMode[] = ["love", "attraction", "friendship", "growth"];
+
+interface EvidenceLike {
+  source?: string | null;
+  engine?: string | null;
+  calculatedAt?: string | null;
+}
+
+interface VerifiedValueLike {
+  value?: string | null;
+  type?: string | null;
+  verificationStatus?: string | null;
+  status?: string | null;
+  evidence?: EvidenceLike | null;
+  provenance?: EvidenceLike | null;
+}
+
+function hasEvidence(value: VerifiedValueLike | null | undefined): boolean {
+  const state = value?.verificationStatus ?? value?.status;
+  const evidence = value?.provenance ?? value?.evidence;
+  return state === "verified" && Boolean(evidence?.source && evidence?.engine && evidence?.calculatedAt);
+}
+
+function verifiedHumanDesignType(profile: any): string | undefined {
+  const candidate = profile?.humanDesignData?.type ?? profile?.humanDesign?.type;
+  if (typeof candidate === "object" && candidate && hasEvidence(candidate)) {
+    return candidate.value ?? candidate.type ?? undefined;
+  }
+  return undefined;
+}
+
+function deterministicLifePath(profile: any): number | undefined {
+  const raw =
+    profile?.lifePathNumber ??
+    profile?.numerologyData?.lifePathNumber ??
+    profile?.numerologyData?.lifePath ??
+    profile?.numerology?.lifePath?.value;
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed >= 1 && parsed <= 9 ? parsed : undefined;
+}
 
 function averageScore(match: ArchetypeMatch): number {
   return Math.round((match.scores.love + match.scores.attraction + match.scores.friendship + match.scores.growth) / 4);
@@ -13,17 +53,49 @@ function topBy(matches: ArchetypeMatch[], mode: RelationshipMode): ArchetypeMatc
   return [...matches].sort((a, b) => b.scores[mode] - a.scores[mode])[0] ?? null;
 }
 
-function buildMatchResponse(
-  sunSign: string,
-  lifePathNumber?: number,
-  hdType?: string,
-  mode: RelationshipMode = "love"
-) {
-  const all = calculateArchetypeMatches(sunSign, lifePathNumber, hdType, mode);
+export function buildCompatibilityProfileInput(profile: any) {
+  const astrology = extractVerifiedAstrology(profile);
+  return {
+    sunSign: astrology.sun,
+    lifePathNumber: deterministicLifePath(profile),
+    humanDesignType: verifiedHumanDesignType(profile),
+    unresolved: {
+      astrology: astrology.unresolved,
+      humanDesign: verifiedHumanDesignType(profile) ? [] : ["Human Design type"],
+    },
+  };
+}
+
+function buildMatchResponse(profile: any, mode: RelationshipMode = "love") {
+  const input = buildCompatibilityProfileInput(profile);
+  if (!input.sunSign) {
+    return {
+      available: false,
+      reason: "A verified Sun placement is required for the sign compatibility explorer.",
+      unresolved: input.unresolved,
+      all: [],
+      best: [],
+      challenging: [],
+      picks: {},
+      formula: {
+        inputs: {
+          sunSign: null,
+          lifePathNumber: input.lifePathNumber ?? null,
+          humanDesignType: input.humanDesignType ?? null,
+          mode,
+        },
+        layers: ["Verified Sun placement required before sign-pair interpretation"],
+        modes: MODE_KEYS,
+      },
+    };
+  }
+
+  const all = calculateArchetypeMatches(input.sunSign, input.lifePathNumber, input.humanDesignType, mode);
   const ranked = [...all].sort((a, b) => b.score - a.score);
   const averageRanked = [...all].sort((a, b) => averageScore(b) - averageScore(a));
 
   return {
+    available: true,
     all: ranked,
     best: ranked.slice(0, 4),
     challenging: ranked.slice(-3).reverse(),
@@ -35,18 +107,19 @@ function buildMatchResponse(
       easiest: averageRanked[0] ?? null,
       hardest: averageRanked[averageRanked.length - 1] ?? null,
     },
+    unresolved: input.unresolved,
     formula: {
       inputs: {
-        sunSign,
-        lifePathNumber: lifePathNumber ?? null,
-        humanDesignType: hdType ?? null,
+        sunSign: input.sunSign,
+        lifePathNumber: input.lifePathNumber ?? null,
+        humanDesignType: input.humanDesignType ?? null,
         mode,
       },
       layers: [
-        "Sun-sign aspect pattern",
+        "Verified Sun-sign pair pattern",
         "Ruling planet chemistry",
-        "Life Path number resonance",
-        "Human Design type element fit",
+        ...(input.lifePathNumber ? ["Deterministic Life Path resonance"] : []),
+        ...(input.humanDesignType ? ["Verified Human Design type fit"] : []),
         "Known high-friction and high-flow sign pairs",
       ],
       modes: MODE_KEYS,
@@ -56,13 +129,14 @@ function buildMatchResponse(
 
 router.post("/compatibility/archetype-matches", (req, res) => {
   try {
-    const { sunSign, lifePathNumber, hdType, mode = "love" } = req.body ?? {};
-    if (!sunSign) return res.status(400).json({ message: "sunSign is required" });
+    const { profile, mode = "love" } = req.body ?? {};
+    if (!profile || typeof profile !== "object") {
+      return res.status(400).json({ message: "A saved Soul Profile is required. Do not resubmit naked sign strings." });
+    }
 
     const safeMode = MODE_KEYS.includes(mode) ? mode : "love";
-    const parsedLifePath = lifePathNumber ? Number(lifePathNumber) : undefined;
-    const result = buildMatchResponse(sunSign, parsedLifePath, hdType, safeMode);
-    res.json(result);
+    const result = buildMatchResponse(profile, safeMode);
+    res.status(result.available ? 200 : 422).json(result);
   } catch (err: any) {
     res.status(500).json({ message: err?.message || "Compatibility match generation failed" });
   }

--- a/tests/compatibility-profile-contract.test.ts
+++ b/tests/compatibility-profile-contract.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { buildCompatibilityProfileInput } from "../routes/compatibility";
+
+const evidence = {
+  source: "independent ephemeris comparison",
+  engine: "engine-a+engine-b",
+  calculatedAt: "2026-08-02T17:00:00Z",
+};
+
+describe("compatibility saved-profile contract", () => {
+  it("rejects naked legacy astrology strings", () => {
+    const input = buildCompatibilityProfileInput({
+      sunSign: "Virgo",
+      moonSign: "Scorpio",
+      risingSign: "Capricorn",
+      lifePathNumber: 9,
+    });
+
+    expect(input.sunSign).toBeUndefined();
+    expect(input.lifePathNumber).toBe(9);
+    expect(input.unresolved.astrology).toContain("Sun");
+  });
+
+  it("rejects a populated Sun placement that is still pending", () => {
+    const input = buildCompatibilityProfileInput({
+      astrologyData: {
+        sun: {
+          sign: "Virgo",
+          verificationStatus: "pending_independent_verification",
+          evidence,
+        },
+      },
+    });
+
+    expect(input.sunSign).toBeUndefined();
+  });
+
+  it("accepts an evidence-complete verified Sun placement", () => {
+    const input = buildCompatibilityProfileInput({
+      astrologyData: {
+        sun: {
+          sign: "Virgo",
+          verificationStatus: "verified",
+          evidence,
+        },
+      },
+      numerologyData: { lifePath: 9 },
+    });
+
+    expect(input.sunSign).toBe("Virgo");
+    expect(input.lifePathNumber).toBe(9);
+    expect(input.unresolved.astrology).not.toContain("Sun");
+  });
+
+  it("does not consume a naked Human Design type", () => {
+    const input = buildCompatibilityProfileInput({
+      astrologyData: {
+        sun: { sign: "Virgo", verificationStatus: "verified", evidence },
+      },
+      humanDesignType: "Reflector",
+    });
+
+    expect(input.humanDesignType).toBeUndefined();
+    expect(input.unresolved.humanDesign).toEqual(["Human Design type"]);
+  });
+
+  it("accepts an evidence-complete Human Design type object", () => {
+    const input = buildCompatibilityProfileInput({
+      astrologyData: {
+        sun: { sign: "Virgo", verificationStatus: "verified", evidence },
+      },
+      humanDesignData: {
+        type: {
+          value: "Reflector",
+          verificationStatus: "verified",
+          evidence: {
+            source: "verified birth inputs",
+            engine: "human-design-engine-v1",
+            calculatedAt: "2026-08-02T17:00:00Z",
+          },
+        },
+      },
+    });
+
+    expect(input.humanDesignType).toBe("Reflector");
+    expect(input.unresolved.humanDesign).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Moves the Compatibility explorer onto the same saved Soul Profile used by the rest of Soul Codex and enforces the trust boundary before sign-based interpretation.

## What changes

- Compatibility no longer accepts a naked `sunSign` request
- The API accepts the saved profile object and extracts only evidence-complete verified placements
- Legacy or pending Sun values cannot produce sign rankings
- Deterministic Life Path data remains available
- Human Design contributes only when its type is verified with source, engine, and timestamp
- The explorer reuses the active profile instead of asking the user to build themselves again
- Best life partner, sexual chemistry, intellectual match, growth potential, easiest flow, hardest lesson, and all-sign ranking remain supported
- Evidence and unresolved layers are inspectable

## Diamond standard

The page must create clarity, not merely more scores. It explains why matches flow, where friction begins, and which unresolved layers were excluded rather than guessed.

## Regression protection

Adversarial tests prove that:
- naked legacy signs are rejected
- pending placements remain unresolved
- verified placements require complete evidence
- naked Human Design labels are ignored
- verified Human Design objects may contribute

## Release boundary

This PR does not begin the visual-design pass. It completes profile reuse and compatibility trust plumbing first, exactly as the Foundation finish line requires.