### PR TITLE
feat(synthesis): enforce Diamond clarity contract across Soul Codex

### DIFF
--- a/src/ai/diamondClarity.ts
+++ b/src/ai/diamondClarity.ts
@@ -1,0 +1,100 @@
+export const DIAMOND_SECTION_ORDER = [
+  "Pattern",
+  "Why",
+  "Need",
+  "Gift",
+  "Cost",
+  "Action",
+  "Evidence",
+] as const;
+
+export type DiamondSection = (typeof DIAMOND_SECTION_ORDER)[number];
+
+export interface DiamondValidationResult {
+  valid: boolean;
+  missing: DiamondSection[];
+  violations: string[];
+}
+
+const UNSUPPORTED_CERTAINTY = [
+  /you are this way because of your childhood/i,
+  /this happened because your parents/i,
+  /you definitely have/i,
+  /your unresolved .* means/i,
+  /your unknown .* means/i,
+];
+
+const SYSTEM_DUMP = /astrology.*numerology.*human design|numerology.*astrology.*human design/i;
+
+export function validateDiamondOutput(text: string): DiamondValidationResult {
+  const missing = DIAMOND_SECTION_ORDER.filter(
+    (section) => !new RegExp(`\\*\\*${section}\\*\\*`, "i").test(text)
+  );
+  const violations: string[] = [];
+
+  if (SYSTEM_DUMP.test(text)) {
+    violations.push("Stacks symbolic systems instead of synthesizing one clear pattern.");
+  }
+
+  for (const pattern of UNSUPPORTED_CERTAINTY) {
+    if (pattern.test(text)) {
+      violations.push("Claims unsupported biography or interprets unresolved data.");
+      break;
+    }
+  }
+
+  const action = text.match(/\*\*Action\*\*([\s\S]*?)(?=\*\*Evidence\*\*|$)/i)?.[1]?.trim();
+  if (!action || action.length < 12) {
+    violations.push("Provides no concrete next step.");
+  }
+
+  const evidence = text.match(/\*\*Evidence\*\*([\s\S]*)$/i)?.[1]?.trim();
+  if (!evidence || evidence.length < 8) {
+    violations.push("Hides or omits evidence and uncertainty.");
+  }
+
+  if (text.length > 4200) {
+    violations.push("Exceeds the Foundation depth budget without progressive disclosure.");
+  }
+
+  return { valid: missing.length === 0 && violations.length === 0, missing, violations };
+}
+
+export const DIAMOND_CLARITY_CONTRACT = `
+DIAMOND CLARITY CONTRACT
+
+The goal is maximum clarity through meaningful depth.
+Do not maximize word count. Do not stack labels.
+Synthesize the strongest supported pattern into one human explanation.
+
+Every substantive reading must use exactly this sequence:
+
+**Pattern**
+Name the observable repeat behavior.
+
+**Why**
+Explain the mechanism that keeps it repeating.
+Do not invent childhood, trauma, motives, or biography.
+
+**Need**
+Describe what the pattern may be protecting or seeking.
+Use conditional language when the evidence is interpretive.
+
+**Gift**
+Show what this pattern does well when balanced.
+
+**Cost**
+Show the practical consequence when the pattern is overused.
+
+**Action**
+Give one specific move the user can take now.
+
+**Evidence**
+List the verified or deterministic inputs used.
+List unresolved inputs that were excluded.
+Explain confidence in plain language.
+
+DIAMOND TEST:
+The user must leave understanding themselves or another person more clearly.
+If a sentence adds information without adding understanding, remove it.
+`;

--- a/src/ai/soulCodexEngine.ts
+++ b/src/ai/soulCodexEngine.ts
@@ -1,104 +1,61 @@
 /**
- * Soul Codex Engine — master system prompt and output structure.
+ * Soul Codex synthesis prompt.
  *
- * Every AI output follows: Observation → Meaning → Action.
- * Grounded in deterministic behavioral seeds from the SoulCodex-V1 Engine.
+ * Foundation contract:
+ * verified inputs -> one coherent pattern -> practical clarity -> inspectable evidence.
  */
 
 import { runSoulCodexEngine } from "@soulcodex/core";
+import { DIAMOND_CLARITY_CONTRACT } from "./diamondClarity";
 
+export const CORE_DATA_RULE = `EVIDENCE USE
+Use only supplied, evidence-cleared facts.
+A populated label is not proof.
+Never infer missing astrology, Human Design, biography, trauma, motives, or confidence.
 
-export const CORE_DATA_RULE = `PROFILE DATA AWARENESS:
-The user's core profile data is available to you. Use it when it genuinely adds meaning to your response — not as a checklist.
+Use symbolic systems as supporting evidence, not as separate reports.
+Choose only the strongest relevant signals.
+Explain what a signal contributes to the pattern.
+List unresolved layers under Evidence and exclude them from interpretation.
 
-Available data (reference when relevant):
-- Big 3: Sun sign, Moon sign, Rising sign
-- Human Design type, strategy, authority
-- Life Path number
-- Element (Elemental Medicine)
+GOOD: "You keep refining after the decision is already usable."
+GOOD: "This may protect you from releasing work that feels unfinished."
+BAD: "Your Virgo, Life Path 9, and Human Design all say..."
+BAD: "Your childhood made you..."`;
 
-HOW TO USE THIS DATA:
-- Reference a placement when it explains WHY a pattern exists or what drives a specific behavior
-- Don't force all of them into every response — use 1-3 that are most relevant to the question
-- When you cite a placement, explain what it DOES, not just what it IS
-- If the question is practical ("should I take this job?"), lead with the insight, not the astrology
+export const SOUL_CODEX_ENGINE_RULES = `VOICE AND REASONING
+1. Be direct, humane, and precise.
+2. Describe observable behavior before assigning meaning.
+3. Distinguish facts, interpretations, and unknowns.
+4. Use conditional wording for needs or protective functions.
+5. Do not repeat the same trait through multiple systems.
+6. Depth must create clarity, not volume.
+7. Give one practical next move.
+8. Never diagnose, shame, flatter, or claim private history.
+9. Never convert unresolved data into a polished certainty.
+10. The final answer must feel like one explanation, not a stack of reports.`;
 
-GOOD: "You hold grudges longer than you admit — your Scorpio Moon replays conversations for days."
-GOOD: "As a Manifestor, you initiate without waiting for buy-in. That's why people feel blindsided."
-BAD: "Your Aries Sun, Scorpio Moon, Leo Rising, Life Path 7, Projector design, and Earth element all suggest..."
+export const OUTPUT_FORMAT_INSTRUCTIONS = DIAMOND_CLARITY_CONTRACT;
 
-The data should feel like it's supporting the insight, not the other way around.`;
+export const PATTERN_DETECTION_ADDON = `PATTERN NAMING
+Give the repeating loop a short, memorable name only when supported.
+Name the trigger, behavior, and consequence. Avoid theatrical labels.`;
 
-export const SOUL_CODEX_ENGINE_RULES = `
-You are the final synthesis layer of Soul Codex.
-Your job is to expose a user's behavioral pattern with surgical accuracy, grounded realism, and zero system leakage.
+export const ANTI_BS_ADDON = `MISUSE GUARD
+When useful, add one sentence clarifying what the reading is not claiming.
+Never pad the response with generic disclaimers.`;
 
-## 🧊 THE SIGNATURE VOICE LAWS (MUST FOLLOW)
-1. **EMOTIONAL NEUTRALITY**: You are a mirror, not a mentor. Do not be "inspiring," "supportive," or "warm." Be annoyingly accurate and slightly invasive.
-2. **NO SOFT PHRASING**: Eliminate all softeners ("I tend to," "I feel like," "sometimes I," "perhaps"). Use direct behavioral declarations.
-3. **THE 12-WORD CONSTRAINT**: No sentence may exceed 12 words. If it does, break it. No commas stacking multiple ideas.
-4. **BLUNT BEHAVIORAL SPECIFICITY**: Describe observable actions and their immediate costs. No vague traits. No poetic metaphors.
-5. **ZERO SYSTEM LEAKAGE**: Do not reference "astrology," "numerology," "Human Design," or "the system." Speak about reality, not the tools used to find it.
+export const DIRECT_MODE_INSTRUCTIONS = `DIRECT MODE
+Lead with the clearest supported pattern.
+Do not hide uncertainty.
+Do not use placeholders as interpretations.
+If an essential layer is unresolved, state that under Evidence and continue only with supported layers.`;
 
-PHASE 1: Observation (Specific/Behavioral)
-PHASE 2: Meaning (The Loop/Cost)
-PHASE 3: Action (Direct/Immediate)`;
+export const DAILY_CARD_RULES = `DAILY GUIDANCE
+Use one focus, one watch point, and one action.
+Keep it grounded in observable behavior.
+Do not manufacture timing, events, or certainty.`;
 
-export const OUTPUT_FORMAT_INSTRUCTIONS = `FORMAT REQUIREMENTS:
-Every response MUST follow this structure:
-
-**Observation**
-What is happening — specific, grounded, behavioral
-
-**Meaning**
-Why it matters — the pattern, the cause, the cost
-
-**Action**
-What to do next — clear, simple, immediate
-
-**Do this today**
-One concrete action the user can take before the day ends
-
-PATTERN NAMING:
-If you detect a repeating behavior, give it a sticky name.
-Examples: "The Overthink → Delay → Regret Loop", "The Reactive Yes", "The Preparation Illusion"
-Named patterns stick. Unnamed patterns repeat.
-
-WHERE THIS SHOWS UP:
-After every insight, add 2-3 specific real-life examples of where this pattern appears.
-Not "in various areas" — name the actual situations: conversations, projects, decisions, habits.`;
-
-
-export const PATTERN_DETECTION_ADDON = `If you detect a repeating behavioral pattern, add:
-
-**Pattern**
-Name the repeat behavior and what triggers it.`;
-
-export const ANTI_BS_ADDON = `If the response could be misinterpreted, add:
-
-**What This Is NOT**
-Clarify what the advice is NOT saying to prevent misuse.`;
-
-export const DIRECT_MODE_INSTRUCTIONS = `DIRECT MODE — ZERO LEAKS + MAX IMPACT:
-- No placeholders.
-- No "unknown".
-- No advice.
-- If data is incomplete, return: "This layer requires complete data."`;
-
-export const DAILY_CARD_RULES = `DAILY GUIDANCE CARD RULES:
-- Must be specific to observable behavior
-- Include 3 DO actions (concrete, today-specific)
-- Include 3 DON'T actions (specific traps to avoid)
-- Include 2 watch-outs (patterns that may surface)
-- Include 1 decision rule (how to handle choices today)
-- No vague or mystical language
-- Everything must be practical and usable today`;
-
-/**
- * Builds the full Soul Codex Engine system prompt for any context.
- * @param options - Configuration options for the engine
- * @param engineData - (Optional) Deterministic data from the v1 engine to ground the AI
- */
 export function buildSoulCodexSystemPrompt(
   options?: {
     directMode?: boolean;
@@ -109,82 +66,61 @@ export function buildSoulCodexSystemPrompt(
   engineData?: ReturnType<typeof runSoulCodexEngine>
 ): string {
   const parts = [
-    "You are the Soul Codex Engine.",
-    "Your role is to deliver clear, grounded, psychologically sharp insight based on user data.",
+    "You are the final synthesis layer of Soul Codex.",
+    "Your purpose is maximum clarity through meaningful depth.",
     "",
     CORE_DATA_RULE,
+    "",
+    SOUL_CODEX_ENGINE_RULES,
   ];
 
   if (options?.birthTimeKnown === false) {
     parts.push(
       "",
-      "BIRTH TIME UNKNOWN — Rising sign, ascendant behavior, house placements, house-based timing, and time-dependent chart details are UNAVAILABLE. Do not infer, guess, or mention them. If relevant, state that those layers require an exact birth time."
+      "BIRTH TIME BOUNDARY",
+      "Rising, houses, time-dependent Human Design, and related timing remain unresolved. Do not infer or interpret them."
     );
   }
 
   if (engineData) {
+    const observations = Object.entries(engineData.statements_by_section).flatMap(
+      ([section, statements]: [string, any]) =>
+        statements.map((statement: any) => `- [${section.toUpperCase()}] ${statement.text}`)
+    );
+
     parts.push(
       "",
-      "DETERMINISTIC GROUNDING DATA:",
-      "Use these verified behavioral observations as the foundation for your response.",
-      "Expand on them by connecting them to the user's specific placements (Signs, HD, Elements).",
+      "DETERMINISTIC GROUNDING",
+      "Treat these as available observations, not permission to invent biography:",
+      ...observations,
       "",
-      "Verified Observations:",
-      ...Object.entries(engineData.statements_by_section).flatMap(([section, statements]: [string, any]) => 
-        statements.map((s: any) => `- [${section.toUpperCase()}] ${s.text}`)
-      ),
-      "",
-      "Detected Contradiction/Tension:",
+      "SUPPORTED TENSION",
       `- ${engineData.daily_guidance.focus || "No specific tension detected."}`
     );
   }
 
-  parts.push(
-    "",
-    SOUL_CODEX_ENGINE_RULES,
-    "",
-    OUTPUT_FORMAT_INSTRUCTIONS
-  );
+  parts.push("", OUTPUT_FORMAT_INSTRUCTIONS);
 
-  if (options?.includePatternDetection) {
-    parts.push("", PATTERN_DETECTION_ADDON);
-  }
-
+  if (options?.includePatternDetection) parts.push("", PATTERN_DETECTION_ADDON);
   parts.push("", ANTI_BS_ADDON);
-
-  if (options?.directMode) {
-    parts.push("", DIRECT_MODE_INSTRUCTIONS);
-  }
+  if (options?.directMode) parts.push("", DIRECT_MODE_INSTRUCTIONS);
 
   return parts.join("\n");
 }
 
-
-/**
- * Rewrite layer prompt — runs after initial generation to strip vague language.
- */
 export function buildRewriteLayerPrompt(originalText: string): string {
-  return `Rewrite this output to remove all vague, abstract, or generic language.
+  return `Rewrite this Soul Codex output for maximum clarity through meaningful depth.
 
-## 🧊 THE SIGNATURE VOICE LAWS
-1. EMOTIONAL NEUTRALITY: Be a mirror, not a mentor. No support. No warmth.
-2. NO SOFT PHRASING: No "I tend to." No "perhaps." Use direct declarations.
-3. THE 12-WORD CONSTRAINT: No sentence may exceed 12 words. Break them.
-4. ONE IDEA PER SENTENCE: No commas stacking multiple concepts.
-5. BLUNT SPECIFICITY: Describe only observable actions and their costs.
+REQUIREMENTS
+- Preserve only supported claims.
+- Remove repeated labels and system stacking.
+- Replace vague traits with observable behavior.
+- Do not invent biography, trauma, motives, or certainty.
+- Keep one coherent pattern.
+- Use the exact Diamond sequence.
+- Keep the result under 900 words.
 
-Make it:
-- specific to observable behavior
-- grounded in real situations
-- immediately usable as guidance
-
-Do not add fluff.
-Do not generalize.
-Do not add metaphors or poetic language.
-
-If the text mentions a pattern, make the pattern concrete:
-BAD: "You tend to avoid difficult situations."
-GOOD: "I delay the conversation until they bring it up. Then I react defensively."
+${DIAMOND_CLARITY_CONTRACT}
 
 TEXT TO REWRITE:
 ${originalText}`;

--- a/tests/diamond-clarity-contract.test.ts
+++ b/tests/diamond-clarity-contract.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+  DIAMOND_SECTION_ORDER,
+  validateDiamondOutput,
+} from "../src/ai/diamondClarity";
+import { buildSoulCodexSystemPrompt } from "../src/ai/soulCodexEngine";
+
+const validReading = `
+**Pattern**
+You keep refining after the work is already usable.
+
+**Why**
+Uncertainty keeps the decision open, so revision feels safer than release.
+
+**Need**
+This may be protecting your need to avoid preventable mistakes.
+
+**Gift**
+You notice weak points before they become expensive failures.
+
+**Cost**
+The finish line moves, and completed work stays unavailable to others.
+
+**Action**
+Define the minimum release standard before starting today's revision.
+
+**Evidence**
+Supported by deterministic Life Path data and recorded behavior answers. Moon, Rising, and Human Design were unresolved and excluded.
+`;
+
+describe("Diamond clarity contract", () => {
+  it("requires the complete clarity sequence", () => {
+    const result = validateDiamondOutput(validReading);
+    expect(result.valid).toBe(true);
+    expect(result.missing).toEqual([]);
+    expect(DIAMOND_SECTION_ORDER).toEqual([
+      "Pattern", "Why", "Need", "Gift", "Cost", "Action", "Evidence",
+    ]);
+  });
+
+  it("rejects trait summaries without mechanism, action, or evidence", () => {
+    const result = validateDiamondOutput("You are loyal, analytical, and creative.");
+    expect(result.valid).toBe(false);
+    expect(result.missing).toContain("Why");
+    expect(result.violations).toContain("Provides no concrete next step.");
+    expect(result.violations).toContain("Hides or omits evidence and uncertainty.");
+  });
+
+  it("rejects unsupported biography claims", () => {
+    const result = validateDiamondOutput(validReading.replace(
+      "Uncertainty keeps the decision open, so revision feels safer than release.",
+      "You are this way because of your childhood."
+    ));
+    expect(result.valid).toBe(false);
+    expect(result.violations).toContain("Claims unsupported biography or interprets unresolved data.");
+  });
+
+  it("rejects system stacking instead of synthesis", () => {
+    const result = validateDiamondOutput(validReading.replace(
+      "You keep refining after the work is already usable.",
+      "Astrology, numerology, and Human Design all say you are careful."
+    ));
+    expect(result.valid).toBe(false);
+    expect(result.violations).toContain("Stacks symbolic systems instead of synthesizing one clear pattern.");
+  });
+
+  it("builds prompts that preserve uncertainty and the Diamond sequence", () => {
+    const prompt = buildSoulCodexSystemPrompt({
+      directMode: true,
+      includePatternDetection: true,
+      birthTimeKnown: false,
+    });
+
+    for (const section of DIAMOND_SECTION_ORDER) {
+      expect(prompt).toContain(`**${section}**`);
+    }
+    expect(prompt).toContain("maximum clarity through meaningful depth");
+    expect(prompt).toContain("Do not infer or interpret them");
+    expect(prompt).not.toContain("No advice.");
+    expect(prompt).not.toContain("Be a mirror, not a mentor. No support. No warmth.");
+  });
+});


### PR DESCRIPTION
## Summary

Makes the Diamond standard an executable synthesis contract rather than another well-written aspiration humans admire and then ignore.

## What changes

- Replaces the old Observation/Meaning/Action prompt with the canonical sequence:
  - Pattern
  - Why
  - Need
  - Gift
  - Cost
  - Action
  - Evidence
- Requires one coherent explanation instead of stacked astrology, numerology, and Human Design summaries
- Preserves unresolved birth-time-sensitive layers as excluded evidence
- Removes the contradictory `No advice` direct-mode rule
- Removes the cold `No support. No warmth.` voice rule
- Adds a reusable Diamond output validator
- Adds a Foundation depth budget and evidence requirement
- Adds five regression tests for missing mechanism, unsupported biography, system stacking, missing action/evidence, and uncertainty handling

## Product outcome

A Soul Codex reading must now help the user understand:

1. what pattern is happening;
2. why it repeats;
3. what it may protect;
4. what it gives them;
5. what it costs;
6. what to do next;
7. why the app reached that conclusion.

## Trust boundary

The synthesis layer may explain supported data. It may not invent childhood, trauma, motives, placements, Human Design, confidence, or biography.

## Diamond test

If a sentence adds information without increasing understanding, it does not belong.