### PR TITLE
feat(synthesis): enforce Diamond clarity at runtime

### DIFF
--- a/routes/chat.ts
+++ b/routes/chat.ts
@@ -1,10 +1,45 @@
 import type { Express } from "express";
 import { storage } from "../storage";
-import { routeAIStream } from "../services/ai-router";
+import { routeAIRequest, routeAIStream } from "../services/ai-router";
 import { entitlementService } from "../services/entitlement-service";
-import { buildSoulCodexSystemPrompt } from "../src/ai/soulCodexEngine";
+import { buildRewriteLayerPrompt, buildSoulCodexSystemPrompt } from "../src/ai/soulCodexEngine";
+import { validateDiamondOutput } from "../src/ai/diamondClarity";
 import { runSoulCodexEngine } from "@soulcodex/core";
 import { buildVerifiedAstrologyLines, extractVerifiedAstrology } from "../server/lib/verified-astrology";
+
+const SAFE_DIAMOND_REFUSAL = `**Pattern**
+The first response did not meet Soul Codex clarity standards.
+
+**Why**
+It lacked enough supported structure to reach a trustworthy conclusion.
+
+**Need**
+This protects you from receiving polished certainty without adequate evidence.
+
+**Gift**
+The system can stop instead of pretending an incomplete answer is reliable.
+
+**Cost**
+You receive less detail now rather than a confident but unsupported reading.
+
+**Action**
+Ask one narrower question or complete the missing profile information.
+
+**Evidence**
+The runtime clarity validator rejected the generated response. No unresolved placement was promoted into interpretation.`;
+
+export function enforceDiamondRuntimeOutput(text: string): {
+  content: string;
+  valid: boolean;
+  violations: string[];
+} {
+  const validation = validateDiamondOutput(text);
+  return {
+    content: validation.valid ? text : SAFE_DIAMOND_REFUSAL,
+    valid: validation.valid,
+    violations: [...validation.missing.map((section) => `Missing ${section}`), ...validation.violations],
+  };
+}
 
 export function registerChatRoutes(app: Express) {
   app.post("/api/chat/soul-guide", async (req, res) => {
@@ -88,17 +123,34 @@ export function registerChatRoutes(app: Express) {
       res.setHeader("Cache-Control", "no-cache");
       res.setHeader("Connection", "keep-alive");
 
-      const stream = routeAIStream({
+      let generated = "";
+      for await (const { chunk } of routeAIStream({
         promptType: "soul_guide",
         systemInstruction,
         history,
         message,
         temperature: 0.8,
-      });
-
-      for await (const { chunk } of stream) {
-        if (chunk) res.write(`data: ${JSON.stringify({ content: chunk })}\n\n`);
+      })) {
+        generated += chunk || "";
       }
+
+      let checked = enforceDiamondRuntimeOutput(generated);
+
+      if (!checked.valid && generated.trim()) {
+        console.warn("[Diamond Runtime] Initial output rejected:", checked.violations);
+        const rewrite = await routeAIRequest({
+          promptType: "soul_guide_rewrite",
+          systemPrompt: systemInstruction,
+          prompt: buildRewriteLayerPrompt(generated),
+          temperature: 0.3,
+        });
+        checked = enforceDiamondRuntimeOutput(rewrite.content || "");
+        if (!checked.valid) {
+          console.warn("[Diamond Runtime] Rewrite rejected:", checked.violations);
+        }
+      }
+
+      res.write(`data: ${JSON.stringify({ content: checked.content })}\n\n`);
       res.write("data: [DONE]\n\n");
       res.end();
     } catch (error) {
@@ -119,27 +171,18 @@ export function registerChatRoutes(app: Express) {
       if (!isPremium) {
         const ownerProfileId = process.env.OWNER_PROFILE_ID;
         if (ownerProfileId && userId) {
-          try {
-            const dbProfile = await storage.getProfileByUserId(userId);
-            if (dbProfile?.id === ownerProfileId) isPremium = true;
-          } catch {}
+          try { const dbProfile = await storage.getProfileByUserId(userId); if (dbProfile?.id === ownerProfileId) isPremium = true; } catch {}
           if (!isPremium && userId === ownerProfileId) isPremium = true;
         }
       }
       if (!isPremium) {
-        try {
-          const status = await entitlementService.getUserPremiumStatus({ userId, sessionId });
-          isPremium = status.isPremium;
-        } catch {}
+        try { const status = await entitlementService.getUserPremiumStatus({ userId, sessionId }); isPremium = status.isPremium; } catch {}
       }
 
       const hasLocalProfile = req.query.hasProfile === "true";
       let profile: any = null;
-      if (userId) {
-        try { profile = await storage.getProfileByUserId(userId); } catch {}
-      } else if (sessionId) {
-        try { profile = await storage.getProfileBySessionId(sessionId); } catch {}
-      }
+      if (userId) { try { profile = await storage.getProfileByUserId(userId); } catch {} }
+      else if (sessionId) { try { profile = await storage.getProfileBySessionId(sessionId); } catch {} }
 
       const limit = profile || hasLocalProfile ? 2 : 1;
       const used = isPremium ? 0 : (session?.chatCount ?? 0);

--- a/routes/chat.ts
+++ b/routes/chat.ts
@@ -139,7 +139,7 @@ export function registerChatRoutes(app: Express) {
       if (!checked.valid && generated.trim()) {
         console.warn("[Diamond Runtime] Initial output rejected:", checked.violations);
         const rewrite = await routeAIRequest({
-          promptType: "soul_guide_rewrite",
+          promptType: "validation",
           systemPrompt: systemInstruction,
           prompt: buildRewriteLayerPrompt(generated),
           temperature: 0.3,

--- a/src/ai/diamondRuntime.ts
+++ b/src/ai/diamondRuntime.ts
@@ -1,0 +1,40 @@
+import { validateDiamondOutput } from "./diamondClarity";
+
+export const SAFE_DIAMOND_REFUSAL = `**Pattern**
+The first response did not meet Soul Codex clarity standards.
+
+**Why**
+It lacked enough supported structure to reach a trustworthy conclusion.
+
+**Need**
+This protects you from receiving polished certainty without adequate evidence.
+
+**Gift**
+The system can stop instead of pretending an incomplete answer is reliable.
+
+**Cost**
+You receive less detail now rather than a confident but unsupported reading.
+
+**Action**
+Ask one narrower question or complete the missing profile information.
+
+**Evidence**
+The runtime clarity validator rejected the generated response. No unresolved placement was promoted into interpretation.`;
+
+export interface DiamondRuntimeResult {
+  content: string;
+  valid: boolean;
+  violations: string[];
+}
+
+export function enforceDiamondRuntimeOutput(text: string): DiamondRuntimeResult {
+  const validation = validateDiamondOutput(text);
+  return {
+    content: validation.valid ? text : SAFE_DIAMOND_REFUSAL,
+    valid: validation.valid,
+    violations: [
+      ...validation.missing.map((section) => `Missing ${section}`),
+      ...validation.violations,
+    ],
+  };
+}

--- a/tests/diamond-runtime-firewall.test.ts
+++ b/tests/diamond-runtime-firewall.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  enforceDiamondRuntimeOutput,
+  SAFE_DIAMOND_REFUSAL,
+} from "../src/ai/diamondRuntime";
+
+const validReading = `**Pattern**
+You keep refining work after it is already usable.
+
+**Why**
+Keeping the decision open makes revision feel safer than release.
+
+**Need**
+This may protect your need to avoid preventable mistakes.
+
+**Gift**
+You notice weak points before they become expensive failures.
+
+**Cost**
+The finish line moves and useful work remains unavailable.
+
+**Action**
+Define the minimum release standard before revising again today.
+
+**Evidence**
+Supported by deterministic Life Path data and recorded behavior answers. Moon and Rising remained unresolved and were excluded.`;
+
+describe("Diamond runtime output firewall", () => {
+  it("passes a valid Diamond reading unchanged", () => {
+    const result = enforceDiamondRuntimeOutput(validReading);
+    expect(result.valid).toBe(true);
+    expect(result.content).toBe(validReading);
+    expect(result.violations).toEqual([]);
+  });
+
+  it("blocks a shallow trait dump before it reaches the user", () => {
+    const result = enforceDiamondRuntimeOutput("You are loyal, intense, and analytical.");
+    expect(result.valid).toBe(false);
+    expect(result.content).toBe(SAFE_DIAMOND_REFUSAL);
+    expect(result.violations).toContain("Missing Why");
+    expect(result.violations).toContain("Provides no concrete next step.");
+  });
+
+  it("blocks unsupported biography even when formatting looks complete", () => {
+    const unsafe = validReading.replace(
+      "Keeping the decision open makes revision feel safer than release.",
+      "You are this way because of your childhood."
+    );
+    const result = enforceDiamondRuntimeOutput(unsafe);
+    expect(result.valid).toBe(false);
+    expect(result.content).toContain("did not meet Soul Codex clarity standards");
+    expect(result.violations).toContain("Claims unsupported biography or interprets unresolved data.");
+  });
+
+  it("returns a complete safe refusal instead of an empty response", () => {
+    const result = enforceDiamondRuntimeOutput("");
+    expect(result.valid).toBe(false);
+    for (const section of ["Pattern", "Why", "Need", "Gift", "Cost", "Action", "Evidence"]) {
+      expect(result.content).toContain(`**${section}**`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Moves the Diamond standard from prompt guidance into the actual Soul Guide delivery path.

## Runtime behavior

- Buffers the generated Soul Guide response before sending it to the user
- Validates the full response against Pattern → Why → Need → Gift → Cost → Action → Evidence
- Rejects shallow trait dumps, unsupported biography, missing evidence, missing action, and unresolved-data interpretation
- Performs one low-temperature rewrite attempt when the first response fails
- Returns a complete safe refusal if the rewrite still fails
- Never sends a partially streamed unsafe answer before validation finishes

## Trade-off

Soul Guide responses now arrive as one validated SSE payload instead of token-by-token streaming. Trust takes priority over decorative streaming theater.

## Tests

Adds runtime firewall tests proving valid output passes unchanged and invalid output is replaced rather than leaked.

## Foundation boundary

This PR enforces maximum clarity through meaningful depth in the live response path. It does not begin visual design work.