### PR TITLE
fix(profile): unify active profile storage and confidence truth

### DIFF
--- a/client/src/lib/profileStorage.ts
+++ b/client/src/lib/profileStorage.ts
@@ -1,69 +1,83 @@
-const STORAGE_KEY = "soulcodex.activeProfile.v1";
+import {
+  clearActiveProfile as clearCanonicalProfile,
+  loadActiveProfile as loadCanonicalProfile,
+  saveActiveProfile as saveCanonicalProfile,
+  type StoredProfile,
+} from "./ActiveProfileRepository";
 
-export interface StoredProfile {
-  birthDate?: string;
-  birthTime?: string;
-  birthLocation?: string;
-  sunSign?: string;
-  moonSign?: string;
-  risingSign?: string;
-  lifePathNumber?: number;
-  astrologyData?: any;
-  numerologyData?: any;
-  humanDesignData?: any;
-  synthesis?: any;
-  codename?: string;
-  archetype?: string;
+export type { StoredProfile } from "./ActiveProfileRepository";
+
+interface EvidenceLike {
+  source?: string | null;
+  engine?: string | null;
+  calculatedAt?: string | null;
 }
 
+interface PlacementLike {
+  verificationStatus?: string | null;
+  status?: string | null;
+  evidence?: EvidenceLike | null;
+  provenance?: EvidenceLike | null;
+}
+
+function isEvidenceComplete(value: PlacementLike | null | undefined): boolean {
+  const state = value?.verificationStatus ?? value?.status;
+  const evidence = value?.provenance ?? value?.evidence;
+  return state === "verified" && Boolean(evidence?.source && evidence?.engine && evidence?.calculatedAt);
+}
+
+function placement(profile: StoredProfile, key: "sun" | "moon" | "rising"): PlacementLike | undefined {
+  return (
+    profile?.astrologyData?.[key] ??
+    (profile as any)?.astrology?.[key] ??
+    (profile as any)?.natalChart?.[key] ??
+    (profile as any)?.chart?.[key]
+  );
+}
+
+/**
+ * Compatibility wrapper for older callers.
+ *
+ * The canonical repository owns migration, schema validation, timestamps,
+ * recovery status, and read-after-write verification. This wrapper exists only
+ * to keep older pages compiling while they migrate to the richer result API.
+ */
 export function loadActiveProfile(): StoredProfile | null {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw || raw === "undefined" || raw === "null") return null;
-    const parsed = JSON.parse(raw);
-    return parsed && typeof parsed === "object" ? parsed : null;
-  } catch {
-    return null;
-  }
+  return loadCanonicalProfile().profile;
 }
 
-export function saveActiveProfile(profilePayload: any): void {
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(profilePayload));
-  } catch (e) {
-    console.warn("[profileStorage] Failed to save profile:", e);
+export function saveActiveProfile(profilePayload: StoredProfile): void {
+  const result = saveCanonicalProfile(profilePayload);
+  if (!result.success) {
+    console.warn("[profileStorage] Canonical profile save failed:", result.error);
   }
 }
 
 export function clearActiveProfile(): void {
-  try {
-    localStorage.removeItem(STORAGE_KEY);
-  } catch (e) {
-    console.warn("[profileStorage] Failed to clear profile:", e);
-  }
+  clearCanonicalProfile();
 }
 
+/**
+ * Confidence describes verified calculation evidence, not merely completed
+ * form fields. Birth time and location improve calculation capability, but
+ * their presence alone cannot promote a profile to verified.
+ */
 export function deriveConfidenceState(
-  profile: StoredProfile
+  profile: StoredProfile | null
 ): "verified" | "partial" | "unverified" {
-  if (!profile) return "unverified";
+  if (!profile?.birthDate) return "unverified";
 
-  // Verified: birthDate + birthTime + birthLocation present
-  if (profile.birthDate && profile.birthTime && profile.birthLocation) {
-    return "verified";
-  }
+  const explicit = (profile as any)?.confidence?.verificationStatus ?? (profile as any)?.confidence?.status;
+  if (explicit === "verified") return "verified";
 
-  // Partial: birthDate present but missing time or location
-  if (profile.birthDate) {
-    return "partial";
-  }
+  const verifiedPlacements = ["sun", "moon", "rising"].filter((key) =>
+    isEvidenceComplete(placement(profile, key as "sun" | "moon" | "rising"))
+  );
 
-  // Unverified: no birth data
-  return "unverified";
+  if (verifiedPlacements.length === 3) return "verified";
+  return "partial";
 }
 
 export function isProfileComplete(profile: StoredProfile | null): boolean {
-  if (!profile) return false;
-  // Profile is complete if it has a birth date (minimum requirement for onboarding)
-  return !!profile.birthDate;
+  return Boolean(profile?.birthDate);
 }

--- a/client/src/lib/profileStorage.ts
+++ b/client/src/lib/profileStorage.ts
@@ -59,19 +59,17 @@ export function clearActiveProfile(): void {
 
 /**
  * Confidence describes verified calculation evidence, not merely completed
- * form fields. Birth time and location improve calculation capability, but
- * their presence alone cannot promote a profile to verified.
+ * form fields or a copied verification label. Birth time and location improve
+ * calculation capability, but neither they nor profile-level status can
+ * promote placements without evidence-complete calculation records.
  */
 export function deriveConfidenceState(
   profile: StoredProfile | null
 ): "verified" | "partial" | "unverified" {
   if (!profile?.birthDate) return "unverified";
 
-  const explicit = (profile as any)?.confidence?.verificationStatus ?? (profile as any)?.confidence?.status;
-  if (explicit === "verified") return "verified";
-
-  const verifiedPlacements = ["sun", "moon", "rising"].filter((key) =>
-    isEvidenceComplete(placement(profile, key as "sun" | "moon" | "rising"))
+  const verifiedPlacements = (["sun", "moon", "rising"] as const).filter((key) =>
+    isEvidenceComplete(placement(profile, key))
   );
 
   if (verifiedPlacements.length === 3) return "verified";

--- a/tests/active-profile-contract.test.ts
+++ b/tests/active-profile-contract.test.ts
@@ -54,6 +54,18 @@ describe("canonical active Soul Profile contract", () => {
     })).toBe("partial");
   });
 
+  it("rejects a copied profile-level verified label without placement evidence", () => {
+    expect(deriveConfidenceState({
+      birthDate: "1990-09-17",
+      confidence: { verificationStatus: "verified" },
+      astrologyData: {
+        sun: { sign: "Virgo", verificationStatus: "pending_independent_verification" },
+        moon: { sign: "Virgo", verificationStatus: "pending_independent_verification" },
+        rising: { sign: "Scorpio", verificationStatus: "unresolved" },
+      },
+    })).toBe("partial");
+  });
+
   it("requires evidence-complete verified placements for verified confidence", () => {
     expect(deriveConfidenceState({
       birthDate: "1990-09-17",

--- a/tests/active-profile-contract.test.ts
+++ b/tests/active-profile-contract.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  clearActiveProfile,
+  deriveConfidenceState,
+  loadActiveProfile,
+  saveActiveProfile,
+} from "../client/src/lib/profileStorage";
+
+class MemoryStorage implements Storage {
+  private values = new Map<string, string>();
+  get length() { return this.values.size; }
+  clear() { this.values.clear(); }
+  getItem(key: string) { return this.values.get(key) ?? null; }
+  key(index: number) { return [...this.values.keys()][index] ?? null; }
+  removeItem(key: string) { this.values.delete(key); }
+  setItem(key: string, value: string) { this.values.set(key, value); }
+}
+
+const evidence = {
+  source: "independent ephemeris comparison",
+  engine: "engine-a+engine-b",
+  calculatedAt: "2026-08-02T20:15:00Z",
+};
+
+describe("canonical active Soul Profile contract", () => {
+  beforeEach(() => {
+    Object.defineProperty(globalThis, "localStorage", {
+      value: new MemoryStorage(),
+      configurable: true,
+    });
+  });
+
+  it("round-trips one profile through the legacy wrapper and canonical key", () => {
+    saveActiveProfile({
+      id: "bobby-foundation-fixture",
+      codename: "Bobby",
+      birthDate: "1990-09-17",
+      lifePathNumber: 9,
+    });
+
+    const restored = loadActiveProfile();
+    expect(restored?.id).toBe("bobby-foundation-fixture");
+    expect(restored?.birthDate).toBe("1990-09-17");
+    expect(restored?.lifePathNumber).toBe(9);
+    expect(restored?.schemaVersion).toBe(1);
+    expect(localStorage.getItem("soulcodex.activeProfile.v1")).toBeTruthy();
+  });
+
+  it("does not call a profile verified merely because time and location were entered", () => {
+    expect(deriveConfidenceState({
+      birthDate: "1990-09-17",
+      birthTime: "11:11",
+      birthLocation: "Bronx, NY",
+    })).toBe("partial");
+  });
+
+  it("requires evidence-complete verified placements for verified confidence", () => {
+    expect(deriveConfidenceState({
+      birthDate: "1990-09-17",
+      astrologyData: {
+        sun: { sign: "Virgo", verificationStatus: "verified", evidence },
+        moon: { sign: "Virgo", verificationStatus: "verified", evidence },
+        rising: { sign: "Scorpio", verificationStatus: "verified", evidence },
+      },
+    })).toBe("verified");
+  });
+
+  it("keeps pending populated placements partial", () => {
+    expect(deriveConfidenceState({
+      birthDate: "1990-09-17",
+      astrologyData: {
+        sun: { sign: "Virgo", verificationStatus: "pending_independent_verification", evidence },
+        moon: { sign: "Virgo", verificationStatus: "pending_independent_verification", evidence },
+        rising: { sign: "Scorpio", verificationStatus: "unresolved", evidence },
+      },
+    })).toBe("partial");
+  });
+
+  it("clears the shared profile for every consumer", () => {
+    saveActiveProfile({ birthDate: "1990-09-17" });
+    clearActiveProfile();
+    expect(loadActiveProfile()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Makes the legacy profile storage API delegate to the canonical ActiveProfileRepository so Reading, Timeline, Compatibility, Profile, and older pages stop maintaining two competing versions of the same human being. A stunning breakthrough for civilization.

## What changes

- One canonical localStorage key and repository owns save/load/clear behavior
- Legacy callers keep their simple API while receiving schema validation, migration, timestamps, and read-after-write verification
- Confidence can no longer become `verified` merely because birth time and location fields are populated
- Verified confidence now requires explicit verified state plus source, engine, and calculation timestamp for Sun, Moon, and Rising
- Pending populated placements remain partial rather than silently promoted

## Tests

Adds a five-test golden profile contract covering:

- save and restore through the canonical key
- schema version persistence
- rejection of form-completeness as verification
- acceptance of evidence-complete placements
- shared clear behavior across consumers

## Foundation outcome

One person creates one Soul Profile. Every core module reads the same identity and the same truth state.