### PR TITLE
docs(governance): lock Foundation backend receipt and uncertainty state

### DIFF
--- a/governance/ADRs/ADR-002-Uncertainty-Is-A-First-Class-State.md
+++ b/governance/ADRs/ADR-002-Uncertainty-Is-A-First-Class-State.md
@@ -1,0 +1,83 @@
+# ADR-002: Uncertainty Is a First-Class Product State
+
+- Status: Accepted
+- Date: 2026-08-02
+- Scope: Soul Codex Foundation and all later intelligence layers
+
+## Context
+
+Soul Codex combines deterministic calculations, time-sensitive astronomical placements, user-entered behavioral data, symbolic systems, and AI-generated interpretation. These inputs do not all carry the same level of certainty.
+
+Earlier implementations allowed approximation, legacy values, or form completeness to appear more authoritative than the underlying evidence justified. That creates a trust failure: the presentation layer can make an unknown or provisional value feel verified simply because it is displayed confidently.
+
+## Decision
+
+Missing, unresolved, provisional, inferred, and verified information are distinct product states. They must remain distinguishable throughout the full pipeline:
+
+```text
+Raw input
+→ Calculation
+→ Verification
+→ Interpretation
+→ Presentation
+```
+
+State may only be promoted by the calculation and verification layers. Interpretation and presentation may render state, but may not originate or upgrade it.
+
+## Required states
+
+At minimum, systems must support:
+
+- `unresolved`
+- `pending_independent_verification`
+- `partial`
+- `verified`
+
+Additional domain-specific states may be added, but none may silently collapse into `verified`.
+
+## Rules
+
+1. A populated field is not automatically verified.
+2. Birth time and location do not by themselves verify Moon, Ascendant, houses, or Human Design.
+3. A profile-level label cannot override weaker placement-level evidence.
+4. AI synthesis must skip unresolved inputs or state their uncertainty explicitly.
+5. UI components may display verification state but cannot manufacture it.
+6. Fallbacks must be labeled and must never impersonate calculated truth.
+7. Verification requires evidence appropriate to the domain, including source, engine or method, and calculation timestamp when applicable.
+8. Regression tests must fail when uncertainty is promoted without evidence.
+
+## Applies to
+
+- Unknown birth time
+- Incomplete names
+- Moon, Ascendant, houses, and planetary placements
+- Human Design
+- Compatibility confidence
+- Timeline confidence
+- Behavioral inference
+- AI-generated guidance
+- Predictions and future trajectory
+
+## Consequences
+
+### Positive
+
+- Users can see what the system knows, what it infers, and what remains unknown.
+- Future engines can improve calculations without rewriting the trust model.
+- AI cannot quietly convert missing data into confident biography.
+- Evidence and confidence become inspectable product features rather than decorative labels.
+
+### Trade-offs
+
+- Some readings will contain fewer claims.
+- The interface must communicate incomplete states clearly.
+- Runtime validation may add latency.
+- Developers must carry provenance metadata instead of passing naked values.
+
+These costs are accepted. Trust is more important than theatrical certainty.
+
+## Product principle
+
+> The system is allowed to say, “I do not know this yet.”
+
+That is not a failure state. It is an honest intelligence state.

--- a/governance/release-audits/FOUNDATION-BACKEND-RECEIPT-v2.md
+++ b/governance/release-audits/FOUNDATION-BACKEND-RECEIPT-v2.md
@@ -9,6 +9,8 @@
 
 The core local-first product now behaves as one integrated system across the saved reading, Timeline, and Compatibility. The runtime synthesis contract is enforced, profile storage is canonical, uncertainty cannot be promoted by presentation code, and the complete saved-profile journey is browser-validated across Chromium and WebKit.
 
+Chromium additionally validates the persistent offline restart path. WebKit validates persistent restart and service-worker control under the current Playwright Linux environment; it does not constitute a native iOS offline-device receipt.
+
 Foundation backend status is **integrated and browser-validated**, but not yet a public release candidate. Mobile packaging, final security/dependency review, and production calculation-engine verification remain separate gates.
 
 ## Evidence chain
@@ -87,8 +89,8 @@ Create profile
 
 Validated in:
 
-- Chromium desktop
-- WebKit iPhone profile
+- Chromium desktop: full lifecycle plus offline persistent restart
+- WebKit iPhone profile: full lifecycle, persistent restart, and service-worker control
 
 Assertions include:
 
@@ -99,30 +101,31 @@ Assertions include:
 - no redirect back to onboarding
 - no 404 route accepted
 - service-worker registration and control retained
-- offline route restoration supported
+- Chromium offline route restoration supported
 
 Classification:
 
 - Implemented: yes
 - Integrated: yes
-- Browser-validated: yes
-- Offline-validated: yes
+- Browser-validated: Chromium and WebKit
+- Offline-validated: Chromium browser environment
+- Native-device validated: no
 
 ## System classification
 
 | System | Classification | Current truth |
 |---|---|---|
-| Active Profile | Integrated, browser-validated | One canonical local identity survives refresh, restart, and offline use. |
+| Active Profile | Integrated, browser-validated | One canonical local identity survives refresh and persistent restart in Chromium and WebKit; Chromium also validates offline restart. |
 | Numerology | Implemented, regression-validated | Deterministic local calculations remain available. |
 | Reading Synthesis | Integrated, runtime-enforced | Diamond structure and clarity checks are enforced before delivery. |
 | Compatibility | Integrated, browser-validated | Reuses the saved profile and excludes unresolved evidence. |
 | Timeline | Integrated, browser-validated | Reuses the saved profile and survives lifecycle transitions. |
 | Persistence | Browser-validated | Canonical profile survives refresh and persistent browser restart. |
-| Offline/PWA | Browser-validated | Chromium and WebKit journeys pass supported offline behavior. |
+| Offline/PWA | Chromium browser-validated | Chromium passes the offline persistent journey; WebKit confirms persistence and service-worker control, not native iOS offline behavior. |
 | Uncertainty Handling | Integrated, regression-protected | Presentation cannot promote unresolved data. |
 | Astrology Engine | Partial | Trust boundary is established; production-grade independent ephemeris verification is not yet declared complete. |
 | Human Design Engine | Partial | Unverified values remain excluded; complete verified calculation lane is not declared complete. |
-| Native iOS Packaging | Blocked/separate lane | App Store archive and signing evidence remain outside this receipt. |
+| Native iOS Packaging | Blocked/separate lane | App Store archive, signing, installation, and native offline evidence remain outside this receipt. |
 | Android Packaging | Pending | Device/package receipt not included here. |
 
 ## Release blockers
@@ -131,7 +134,7 @@ Foundation must not be called a public release candidate until the following are
 
 1. Production-grade astrology verification receipt for every placement allowed into interpretation.
 2. Verified Human Design calculation receipt, or explicit Foundation exclusion.
-3. Native iOS archive/export/install receipt.
+3. Native iOS archive/export/install/offline receipt.
 4. Android package/install/offline receipt.
 5. Dependency and security audit disposition for production dependencies.
 6. Final release documentation, versioning, support, privacy, and store metadata.
@@ -151,7 +154,9 @@ Reading runtime contract:     PASS
 Compatibility reuse:          PASS
 Timeline lifecycle:           PASS
 Persistence lifecycle:        PASS
-Supported offline journey:    PASS
+Chromium offline journey:     PASS
+WebKit persistence/SW:        PASS
+Native mobile offline:        PENDING
 Uncertainty boundary:         PASS
 Astronomy verification:       PENDING
 Human Design verification:    PENDING OR EXCLUDE

--- a/governance/release-audits/FOUNDATION-BACKEND-RECEIPT-v2.md
+++ b/governance/release-audits/FOUNDATION-BACKEND-RECEIPT-v2.md
@@ -1,0 +1,160 @@
+# Soul Codex Foundation Backend Receipt v2
+
+- Receipt date: 2026-08-02
+- Repository: `Bboy9090/Ultimate-SoulCodex`
+- Baseline: `main` after PR #145
+- Purpose: Record what is proven, what remains blocked, and what may not be claimed yet.
+
+## Executive result
+
+The core local-first product now behaves as one integrated system across the saved reading, Timeline, and Compatibility. The runtime synthesis contract is enforced, profile storage is canonical, uncertainty cannot be promoted by presentation code, and the complete saved-profile journey is browser-validated across Chromium and WebKit.
+
+Foundation backend status is **integrated and browser-validated**, but not yet a public release candidate. Mobile packaging, final security/dependency review, and production calculation-engine verification remain separate gates.
+
+## Evidence chain
+
+### PR #141: Compatibility profile reuse
+
+Established one saved Soul Profile as the source for Compatibility. Removed naked Sun-sign input and required evidence-complete verified placements before astrology contributes to match rankings.
+
+Classification:
+
+- Implemented: yes
+- Integrated: yes
+- Browser-validated: covered by PR #145
+
+### PR #142: Diamond synthesis contract
+
+Established the required reading structure:
+
+```text
+Pattern
+Why
+Need
+Gift
+Cost
+Action
+Evidence
+```
+
+Added regression checks for shallow trait dumps, unsupported biography, unresolved-data interpretation, missing action, missing evidence, and excessive depth without clarity.
+
+Classification:
+
+- Implemented: yes
+- Integrated: yes
+
+### PR #143: Runtime synthesis enforcement
+
+Moved the contract from prompt guidance into runtime enforcement. Complete output is buffered, validated, rewritten once when invalid, and replaced with an evidence-honest fallback if the rewrite still fails.
+
+Classification:
+
+- Implemented: yes
+- Integrated: yes
+- Runtime-validated: CI validated
+
+### PR #144: Canonical active profile storage
+
+Unified legacy and current callers behind one canonical active-profile repository. Removed the shortcut where form completeness or a copied profile-level label could mark a profile verified.
+
+Verified placement evidence requires:
+
+- `verificationStatus: verified`
+- source
+- engine or calculation method
+- calculation timestamp
+
+Classification:
+
+- Implemented: yes
+- Integrated: yes
+- Regression-protected: yes
+
+### PR #145: Full saved-profile lifecycle
+
+Browser journey now proves:
+
+```text
+Create profile
+→ saved Reading
+→ Timeline
+→ Compatibility
+→ refresh
+→ browser restart
+→ supported offline use
+```
+
+Validated in:
+
+- Chromium desktop
+- WebKit iPhone profile
+
+Assertions include:
+
+- same profile ID across every route
+- same birth date across every route
+- one canonical storage key
+- no duplicate profile creation
+- no redirect back to onboarding
+- no 404 route accepted
+- service-worker registration and control retained
+- offline route restoration supported
+
+Classification:
+
+- Implemented: yes
+- Integrated: yes
+- Browser-validated: yes
+- Offline-validated: yes
+
+## System classification
+
+| System | Classification | Current truth |
+|---|---|---|
+| Active Profile | Integrated, browser-validated | One canonical local identity survives refresh, restart, and offline use. |
+| Numerology | Implemented, regression-validated | Deterministic local calculations remain available. |
+| Reading Synthesis | Integrated, runtime-enforced | Diamond structure and clarity checks are enforced before delivery. |
+| Compatibility | Integrated, browser-validated | Reuses the saved profile and excludes unresolved evidence. |
+| Timeline | Integrated, browser-validated | Reuses the saved profile and survives lifecycle transitions. |
+| Persistence | Browser-validated | Canonical profile survives refresh and persistent browser restart. |
+| Offline/PWA | Browser-validated | Chromium and WebKit journeys pass supported offline behavior. |
+| Uncertainty Handling | Integrated, regression-protected | Presentation cannot promote unresolved data. |
+| Astrology Engine | Partial | Trust boundary is established; production-grade independent ephemeris verification is not yet declared complete. |
+| Human Design Engine | Partial | Unverified values remain excluded; complete verified calculation lane is not declared complete. |
+| Native iOS Packaging | Blocked/separate lane | App Store archive and signing evidence remain outside this receipt. |
+| Android Packaging | Pending | Device/package receipt not included here. |
+
+## Release blockers
+
+Foundation must not be called a public release candidate until the following are complete:
+
+1. Production-grade astrology verification receipt for every placement allowed into interpretation.
+2. Verified Human Design calculation receipt, or explicit Foundation exclusion.
+3. Native iOS archive/export/install receipt.
+4. Android package/install/offline receipt.
+5. Dependency and security audit disposition for production dependencies.
+6. Final release documentation, versioning, support, privacy, and store metadata.
+
+## Locked product rule
+
+> Depth must create clarity, not volume.
+
+The backend may produce fewer claims when evidence is incomplete. It may not fill the silence with approximation disguised as insight.
+
+## Receipt verdict
+
+```text
+Core web foundation:          PASS
+Canonical identity:           PASS
+Reading runtime contract:     PASS
+Compatibility reuse:          PASS
+Timeline lifecycle:           PASS
+Persistence lifecycle:        PASS
+Supported offline journey:    PASS
+Uncertainty boundary:         PASS
+Astronomy verification:       PENDING
+Human Design verification:    PENDING OR EXCLUDE
+Native mobile release:        PENDING
+Public release candidate:     NOT YET
+```


### PR DESCRIPTION
## Summary

Records the current Foundation backend truth after PRs #141–#145 and codifies uncertainty as a first-class product state.

## Included

- ADR-002: Uncertainty Is a First-Class Product State
- Foundation Backend Receipt v2
- Explicit system classifications
- Browser lifecycle evidence for one canonical profile
- Clear separation between proven web Foundation behavior and still-pending astrology, Human Design, security, and native mobile release gates

## Why

The repository now has enough integrated proof to state what works without pretending the remaining calculation and packaging lanes are finished. This PR turns that evidence into a durable release contract.

## Locked rule

Depth must create clarity, not volume. Unknown data remains unknown until the verification layer promotes it with evidence.