### PR TITLE
feat(astrology): enforce independent verification before promotion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Run Workspace Tests
         run: npm test
 
-      - name: Run Astrology Candidate Trust Tests
-        run: node --import tsx --test tests/astrology-candidate.test.ts
+      - name: Run Astrology Trust Tests
+        run: node --import tsx --test tests/astrology-candidate.test.ts tests/astrology-independent-verification.test.ts
 
       - name: Build Application
         run: npm run build

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -36,8 +36,8 @@ jobs:
       - name: Run workspace tests
         run: npm test
 
-      - name: Run astrology candidate trust tests
-        run: node --import tsx --test tests/astrology-candidate.test.ts
+      - name: Run astrology trust tests
+        run: node --import tsx --test tests/astrology-candidate.test.ts tests/astrology-independent-verification.test.ts
 
       - name: Build project
         run: npm run build

--- a/server/services/astrology-verification.ts
+++ b/server/services/astrology-verification.ts
@@ -1,4 +1,7 @@
+export type VerifiableBody = "Sun" | "Moon";
+
 export interface EphemerisCandidate {
+  body: VerifiableBody;
   sign: string;
   longitude: number;
   source: string;
@@ -8,7 +11,7 @@ export interface EphemerisCandidate {
 }
 
 export interface IndependentEphemerisReference {
-  body: "Sun" | "Moon";
+  body: VerifiableBody;
   sign: string;
   longitude: number;
   source: string;
@@ -27,6 +30,7 @@ export interface VerificationPolicy {
 export type IndependentVerificationResult =
   | {
       status: "verified";
+      body: VerifiableBody;
       sign: string;
       longitudeDeltaDegrees: number;
       candidate: EphemerisCandidate;
@@ -40,7 +44,9 @@ export type IndependentVerificationResult =
       reason:
         | "policy_not_approved"
         | "invalid_policy_tolerance"
+        | "body_mismatch"
         | "same_engine_not_independent"
+        | "same_source_not_independent"
         | "timestamp_mismatch"
         | "sign_disagreement"
         | "longitude_outside_tolerance"
@@ -59,6 +65,10 @@ function isValidLongitude(value: number): boolean {
 function circularLongitudeDelta(left: number, right: number): number {
   const raw = Math.abs(normalizeLongitude(left) - normalizeLongitude(right));
   return Math.min(raw, 360 - raw);
+}
+
+function normalizedIdentity(value: string): string {
+  return value.trim().toLowerCase();
 }
 
 export function verifyAgainstIndependentReference(
@@ -80,8 +90,16 @@ export function verifyAgainstIndependentReference(
     return { status: "rejected", sign: null, reason: "invalid_longitude", longitudeDeltaDegrees: null };
   }
 
-  if (candidate.engine.trim().toLowerCase() === reference.engine.trim().toLowerCase()) {
+  if (candidate.body !== reference.body) {
+    return { status: "rejected", sign: null, reason: "body_mismatch", longitudeDeltaDegrees: null };
+  }
+
+  if (normalizedIdentity(candidate.engine) === normalizedIdentity(reference.engine)) {
     return { status: "rejected", sign: null, reason: "same_engine_not_independent", longitudeDeltaDegrees: null };
+  }
+
+  if (normalizedIdentity(candidate.source) === normalizedIdentity(reference.source)) {
+    return { status: "rejected", sign: null, reason: "same_source_not_independent", longitudeDeltaDegrees: null };
   }
 
   if (candidate.inputTimestamp !== reference.inputTimestamp) {
@@ -100,6 +118,7 @@ export function verifyAgainstIndependentReference(
 
   return {
     status: "verified",
+    body: candidate.body,
     sign: candidate.sign,
     longitudeDeltaDegrees,
     candidate,

--- a/server/services/astrology-verification.ts
+++ b/server/services/astrology-verification.ts
@@ -1,0 +1,110 @@
+export interface EphemerisCandidate {
+  sign: string;
+  longitude: number;
+  source: string;
+  engine: string;
+  calculatedAt: string;
+  inputTimestamp: string;
+}
+
+export interface IndependentEphemerisReference {
+  body: "Sun" | "Moon";
+  sign: string;
+  longitude: number;
+  source: string;
+  engine: string;
+  calculatedAt: string;
+  inputTimestamp: string;
+}
+
+export interface VerificationPolicy {
+  status: "draft" | "approved";
+  policyId: string;
+  maximumLongitudeDeltaDegrees: number;
+  approvedAt?: string;
+}
+
+export type IndependentVerificationResult =
+  | {
+      status: "verified";
+      sign: string;
+      longitudeDeltaDegrees: number;
+      candidate: EphemerisCandidate;
+      reference: IndependentEphemerisReference;
+      policyId: string;
+      verifiedAt: string;
+    }
+  | {
+      status: "rejected";
+      sign: null;
+      reason:
+        | "policy_not_approved"
+        | "invalid_policy_tolerance"
+        | "same_engine_not_independent"
+        | "timestamp_mismatch"
+        | "sign_disagreement"
+        | "longitude_outside_tolerance"
+        | "invalid_longitude";
+      longitudeDeltaDegrees: number | null;
+    };
+
+function normalizeLongitude(value: number): number {
+  return ((value % 360) + 360) % 360;
+}
+
+function isValidLongitude(value: number): boolean {
+  return Number.isFinite(value) && value >= 0 && value < 360;
+}
+
+function circularLongitudeDelta(left: number, right: number): number {
+  const raw = Math.abs(normalizeLongitude(left) - normalizeLongitude(right));
+  return Math.min(raw, 360 - raw);
+}
+
+export function verifyAgainstIndependentReference(
+  candidate: EphemerisCandidate,
+  reference: IndependentEphemerisReference,
+  policy: VerificationPolicy,
+): IndependentVerificationResult {
+  if (policy.status !== "approved" || !policy.approvedAt) {
+    return { status: "rejected", sign: null, reason: "policy_not_approved", longitudeDeltaDegrees: null };
+  }
+
+  if (!Number.isFinite(policy.maximumLongitudeDeltaDegrees)
+    || policy.maximumLongitudeDeltaDegrees <= 0
+    || policy.maximumLongitudeDeltaDegrees > 1) {
+    return { status: "rejected", sign: null, reason: "invalid_policy_tolerance", longitudeDeltaDegrees: null };
+  }
+
+  if (!isValidLongitude(candidate.longitude) || !isValidLongitude(reference.longitude)) {
+    return { status: "rejected", sign: null, reason: "invalid_longitude", longitudeDeltaDegrees: null };
+  }
+
+  if (candidate.engine.trim().toLowerCase() === reference.engine.trim().toLowerCase()) {
+    return { status: "rejected", sign: null, reason: "same_engine_not_independent", longitudeDeltaDegrees: null };
+  }
+
+  if (candidate.inputTimestamp !== reference.inputTimestamp) {
+    return { status: "rejected", sign: null, reason: "timestamp_mismatch", longitudeDeltaDegrees: null };
+  }
+
+  const longitudeDeltaDegrees = circularLongitudeDelta(candidate.longitude, reference.longitude);
+
+  if (candidate.sign !== reference.sign) {
+    return { status: "rejected", sign: null, reason: "sign_disagreement", longitudeDeltaDegrees };
+  }
+
+  if (longitudeDeltaDegrees > policy.maximumLongitudeDeltaDegrees) {
+    return { status: "rejected", sign: null, reason: "longitude_outside_tolerance", longitudeDeltaDegrees };
+  }
+
+  return {
+    status: "verified",
+    sign: candidate.sign,
+    longitudeDeltaDegrees,
+    candidate,
+    reference,
+    policyId: policy.policyId,
+    verifiedAt: new Date().toISOString(),
+  };
+}

--- a/tests/astrology-independent-verification.test.ts
+++ b/tests/astrology-independent-verification.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  verifyAgainstIndependentReference,
+  type EphemerisCandidate,
+  type IndependentEphemerisReference,
+  type VerificationPolicy,
+} from "../server/services/astrology-verification";
+
+const candidate: EphemerisCandidate = {
+  sign: "Virgo",
+  longitude: 174.25,
+  source: "Astronomy Engine geocentric true-ecliptic-of-date calculation",
+  engine: "astronomy-engine@2.1.19",
+  calculatedAt: "2026-08-02T23:00:00.000Z",
+  inputTimestamp: "1990-09-17T15:11:00.000Z",
+};
+
+const reference: IndependentEphemerisReference = {
+  body: "Sun",
+  sign: "Virgo",
+  longitude: 174.27,
+  source: "Independent checked reference fixture",
+  engine: "independent-engine@1.0.0",
+  calculatedAt: "2026-08-02T23:01:00.000Z",
+  inputTimestamp: "1990-09-17T15:11:00.000Z",
+};
+
+const approvedPolicy: VerificationPolicy = {
+  status: "approved",
+  policyId: "ASTRO-LONGITUDE-v1",
+  maximumLongitudeDeltaDegrees: 0.1,
+  approvedAt: "2026-08-02T23:02:00.000Z",
+};
+
+test("approved independent agreement can produce a verified result", () => {
+  const result = verifyAgainstIndependentReference(candidate, reference, approvedPolicy);
+
+  assert.equal(result.status, "verified");
+  if (result.status !== "verified") return;
+  assert.equal(result.sign, "Virgo");
+  assert.equal(result.policyId, "ASTRO-LONGITUDE-v1");
+  assert.ok(result.longitudeDeltaDegrees <= 0.1);
+  assert.equal(result.candidate.engine, "astronomy-engine@2.1.19");
+  assert.equal(result.reference.engine, "independent-engine@1.0.0");
+});
+
+test("draft policy cannot promote a candidate", () => {
+  const result = verifyAgainstIndependentReference(candidate, reference, {
+    ...approvedPolicy,
+    status: "draft",
+    approvedAt: undefined,
+  });
+
+  assert.deepEqual(result, {
+    status: "rejected",
+    sign: null,
+    reason: "policy_not_approved",
+    longitudeDeltaDegrees: null,
+  });
+});
+
+test("the same engine cannot verify itself", () => {
+  const result = verifyAgainstIndependentReference(candidate, {
+    ...reference,
+    engine: candidate.engine,
+  }, approvedPolicy);
+
+  assert.equal(result.status, "rejected");
+  if (result.status === "rejected") assert.equal(result.reason, "same_engine_not_independent");
+});
+
+test("timestamp mismatch blocks promotion", () => {
+  const result = verifyAgainstIndependentReference(candidate, {
+    ...reference,
+    inputTimestamp: "1990-09-17T15:12:00.000Z",
+  }, approvedPolicy);
+
+  assert.equal(result.status, "rejected");
+  if (result.status === "rejected") assert.equal(result.reason, "timestamp_mismatch");
+});
+
+test("sign disagreement blocks promotion even when longitude values are near a boundary", () => {
+  const result = verifyAgainstIndependentReference({
+    ...candidate,
+    sign: "Virgo",
+    longitude: 179.99,
+  }, {
+    ...reference,
+    sign: "Libra",
+    longitude: 180.01,
+  }, approvedPolicy);
+
+  assert.equal(result.status, "rejected");
+  if (result.status === "rejected") assert.equal(result.reason, "sign_disagreement");
+});
+
+test("longitude outside the approved tolerance blocks promotion", () => {
+  const result = verifyAgainstIndependentReference(candidate, {
+    ...reference,
+    longitude: 174.5,
+  }, approvedPolicy);
+
+  assert.equal(result.status, "rejected");
+  if (result.status === "rejected") assert.equal(result.reason, "longitude_outside_tolerance");
+});

--- a/tests/astrology-independent-verification.test.ts
+++ b/tests/astrology-independent-verification.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../server/services/astrology-verification";
 
 const candidate: EphemerisCandidate = {
+  body: "Sun",
   sign: "Virgo",
   longitude: 174.25,
   source: "Astronomy Engine geocentric true-ecliptic-of-date calculation",
@@ -38,6 +39,7 @@ test("approved independent agreement can produce a verified result", () => {
 
   assert.equal(result.status, "verified");
   if (result.status !== "verified") return;
+  assert.equal(result.body, "Sun");
   assert.equal(result.sign, "Virgo");
   assert.equal(result.policyId, "ASTRO-LONGITUDE-v1");
   assert.ok(result.longitudeDeltaDegrees <= 0.1);
@@ -60,6 +62,16 @@ test("draft policy cannot promote a candidate", () => {
   });
 });
 
+test("a Moon reference cannot verify a Sun candidate", () => {
+  const result = verifyAgainstIndependentReference(candidate, {
+    ...reference,
+    body: "Moon",
+  }, approvedPolicy);
+
+  assert.equal(result.status, "rejected");
+  if (result.status === "rejected") assert.equal(result.reason, "body_mismatch");
+});
+
 test("the same engine cannot verify itself", () => {
   const result = verifyAgainstIndependentReference(candidate, {
     ...reference,
@@ -68,6 +80,16 @@ test("the same engine cannot verify itself", () => {
 
   assert.equal(result.status, "rejected");
   if (result.status === "rejected") assert.equal(result.reason, "same_engine_not_independent");
+});
+
+test("the same source cannot be relabeled as independent", () => {
+  const result = verifyAgainstIndependentReference(candidate, {
+    ...reference,
+    source: candidate.source,
+  }, approvedPolicy);
+
+  assert.equal(result.status, "rejected");
+  if (result.status === "rejected") assert.equal(result.reason, "same_source_not_independent");
 });
 
 test("timestamp mismatch blocks promotion", () => {


### PR DESCRIPTION
## Summary

Adds the promotion contract that sits between an Astronomy Engine candidate and any future authoritative placement.

## What this PR does

- Requires an explicitly approved verification policy
- Requires a genuinely different engine/reference source
- Requires an identical UTC input timestamp
- Requires sign agreement
- Requires longitude agreement within an approved tolerance
- Rejects invalid longitudes and unsafe tolerance values
- Produces a verification receipt containing both evidence sources and the policy ID

## What this PR does not do

- It does not ship a second ephemeris engine
- It does not approve a release tolerance
- It does not wire candidate promotion into the active profile
- It does not claim Robert's Moon or Ascendant

## Regression protection

Tests prove that draft policy, same-engine self-verification, timestamp mismatch, sign disagreement, and out-of-tolerance longitude all fail closed.

## Trust principle

One calculator cannot notarize its own answer. The second source and tolerance policy remain separate release gates.