### PR TITLE
feat(astrology): add NASA JPL Horizons independent reference adapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: npm test
 
       - name: Run Astrology Trust Tests
-        run: node --import tsx --test tests/astrology-candidate.test.ts tests/astrology-independent-verification.test.ts
+        run: node --import tsx --test tests/astrology-candidate.test.ts tests/astrology-independent-verification.test.ts tests/jpl-horizons-reference.test.ts
 
       - name: Build Application
         run: npm run build

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -37,7 +37,7 @@ jobs:
         run: npm test
 
       - name: Run astrology trust tests
-        run: node --import tsx --test tests/astrology-candidate.test.ts tests/astrology-independent-verification.test.ts
+        run: node --import tsx --test tests/astrology-candidate.test.ts tests/astrology-independent-verification.test.ts tests/jpl-horizons-reference.test.ts
 
       - name: Build project
         run: npm run build

--- a/server/services/jpl-horizons-reference.ts
+++ b/server/services/jpl-horizons-reference.ts
@@ -1,0 +1,154 @@
+import type { IndependentEphemerisReference } from "./astrology-verification";
+
+export type SupportedHorizonsBody = "Sun" | "Moon";
+
+type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+interface HorizonsPayload {
+  signature?: {
+    source?: string;
+    version?: string;
+  };
+  result?: string;
+  error?: string;
+}
+
+const HORIZONS_ENDPOINT = "https://ssd.jpl.nasa.gov/api/horizons.api";
+const HORIZONS_ENGINE = "nasa-jpl-horizons-api@1.3";
+const HORIZONS_SOURCE = "NASA/JPL Horizons observer quantity 31: geocentric apparent ecliptic-of-date longitude";
+const BODY_COMMAND: Record<SupportedHorizonsBody, string> = {
+  Sun: "10",
+  Moon: "301",
+};
+
+const ZODIAC_SIGNS = [
+  "Aries",
+  "Taurus",
+  "Gemini",
+  "Cancer",
+  "Leo",
+  "Virgo",
+  "Libra",
+  "Scorpio",
+  "Sagittarius",
+  "Capricorn",
+  "Aquarius",
+  "Pisces",
+] as const;
+
+function normalizeLongitude(value: number): number {
+  return ((value % 360) + 360) % 360;
+}
+
+function signFromLongitude(value: number): string {
+  return ZODIAC_SIGNS[Math.floor(normalizeLongitude(value) / 30)];
+}
+
+function addOneMinute(timestamp: string): string {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) throw new Error("invalid_input_timestamp");
+  return new Date(date.getTime() + 60_000).toISOString();
+}
+
+function horizonsTime(timestamp: string): string {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) throw new Error("invalid_input_timestamp");
+  return date.toISOString().replace("T", " ").replace(/\.\d{3}Z$/, "");
+}
+
+export function buildHorizonsReferenceUrl(body: SupportedHorizonsBody, inputTimestamp: string): string {
+  const start = horizonsTime(inputTimestamp);
+  const stop = horizonsTime(addOneMinute(inputTimestamp));
+  const params = new URLSearchParams({
+    format: "json",
+    COMMAND: `'${BODY_COMMAND[body]}'`,
+    OBJ_DATA: "'NO'",
+    MAKE_EPHEM: "'YES'",
+    EPHEM_TYPE: "'OBSERVER'",
+    CENTER: "'500@399'",
+    START_TIME: `'${start}'`,
+    STOP_TIME: `'${stop}'`,
+    STEP_SIZE: "'1 m'",
+    QUANTITIES: "'31'",
+    CSV_FORMAT: "'YES'",
+    CAL_FORMAT: "'CAL'",
+    TIME_DIGITS: "'SECONDS'",
+    ANG_FORMAT: "'DEG'",
+    APPARENT: "'AIRLESS'",
+  });
+  return `${HORIZONS_ENDPOINT}?${params.toString()}`;
+}
+
+function splitCsv(line: string): string[] {
+  return line.split(",").map((value) => value.trim());
+}
+
+export function parseHorizonsLongitude(result: string): number {
+  const lines = result.split(/\r?\n/);
+  const startIndex = lines.findIndex((line) => line.trim() === "$$SOE");
+  const endIndex = lines.findIndex((line, index) => index > startIndex && line.trim() === "$$EOE");
+  if (startIndex < 0 || endIndex < 0 || endIndex <= startIndex + 1) {
+    throw new Error("horizons_ephemeris_block_missing");
+  }
+
+  const headerIndex = lines
+    .slice(0, startIndex)
+    .map((line, index) => ({ line, index }))
+    .reverse()
+    .find(({ line }) => /ObsEcLon|App_Lon_Sun/i.test(line))?.index;
+  if (headerIndex === undefined) throw new Error("horizons_longitude_header_missing");
+
+  const headers = splitCsv(lines[headerIndex]);
+  const longitudeIndex = headers.findIndex((header) => /ObsEcLon|App_Lon_Sun/i.test(header));
+  if (longitudeIndex < 0) throw new Error("horizons_longitude_column_missing");
+
+  const dataLine = lines.slice(startIndex + 1, endIndex).find((line) => line.trim().length > 0);
+  if (!dataLine) throw new Error("horizons_data_row_missing");
+  const values = splitCsv(dataLine);
+  const longitude = Number.parseFloat(values[longitudeIndex]);
+  if (!Number.isFinite(longitude) || longitude < 0 || longitude >= 360) {
+    throw new Error("horizons_invalid_longitude");
+  }
+  return longitude;
+}
+
+export async function fetchHorizonsReference(
+  body: SupportedHorizonsBody,
+  inputTimestamp: string,
+  options: {
+    fetchImpl?: FetchLike;
+    timeoutMs?: number;
+  } = {},
+): Promise<IndependentEphemerisReference> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? 8_000);
+
+  try {
+    const response = await fetchImpl(buildHorizonsReferenceUrl(body, inputTimestamp), {
+      signal: controller.signal,
+      headers: { Accept: "application/json" },
+    });
+    if (!response.ok) throw new Error(`horizons_http_${response.status}`);
+
+    const payload = await response.json() as HorizonsPayload;
+    if (payload.error) throw new Error("horizons_api_error");
+    if (!payload.signature?.source?.toLowerCase().includes("jpl")) {
+      throw new Error("horizons_signature_invalid");
+    }
+    if (!payload.result) throw new Error("horizons_result_missing");
+
+    const longitude = parseHorizonsLongitude(payload.result);
+    return {
+      body,
+      sign: signFromLongitude(longitude),
+      longitude,
+      source: HORIZONS_SOURCE,
+      engine: HORIZONS_ENGINE,
+      calculatedAt: new Date().toISOString(),
+      inputTimestamp: new Date(inputTimestamp).toISOString(),
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/tests/jpl-horizons-reference.test.ts
+++ b/tests/jpl-horizons-reference.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildHorizonsReferenceUrl,
+  fetchHorizonsReference,
+  parseHorizonsLongitude,
+} from "../server/services/jpl-horizons-reference";
+
+const sampleResult = `
+*******************************************************************************
+ Date__(UT)__HR:MN:SC.fff, ObsEcLon, ObsEcLat,
+*******************************************************************************
+$$SOE
+1990-Sep-17 15:11:00.000, 174.2700000, 0.0001000,
+$$EOE
+*******************************************************************************
+`;
+
+test("builds an official geocentric quantity-31 request for the same UTC instant", () => {
+  const url = new URL(buildHorizonsReferenceUrl("Sun", "1990-09-17T15:11:00.000Z"));
+
+  assert.equal(url.origin, "https://ssd.jpl.nasa.gov");
+  assert.equal(url.pathname, "/api/horizons.api");
+  assert.equal(url.searchParams.get("COMMAND"), "'10'");
+  assert.equal(url.searchParams.get("CENTER"), "'500@399'");
+  assert.equal(url.searchParams.get("EPHEM_TYPE"), "'OBSERVER'");
+  assert.equal(url.searchParams.get("QUANTITIES"), "'31'");
+  assert.equal(url.searchParams.get("START_TIME"), "'1990-09-17 15:11:00'");
+  assert.equal(url.searchParams.get("STOP_TIME"), "'1990-09-17 15:12:00'");
+});
+
+test("parses the named Horizons ecliptic-longitude column instead of guessing a numeric position", () => {
+  assert.equal(parseHorizonsLongitude(sampleResult), 174.27);
+});
+
+test("creates an independent Sun reference with provenance but does not promote it", async () => {
+  const fetchImpl = async () => new Response(JSON.stringify({
+    signature: { source: "NASA/JPL Horizons API", version: "1.3" },
+    result: sampleResult,
+  }), { status: 200, headers: { "Content-Type": "application/json" } });
+
+  const reference = await fetchHorizonsReference("Sun", "1990-09-17T15:11:00.000Z", { fetchImpl });
+
+  assert.equal(reference.body, "Sun");
+  assert.equal(reference.sign, "Virgo");
+  assert.equal(reference.longitude, 174.27);
+  assert.equal(reference.engine, "nasa-jpl-horizons-api@1.3");
+  assert.match(reference.source, /NASA\/JPL Horizons/i);
+  assert.equal(reference.inputTimestamp, "1990-09-17T15:11:00.000Z");
+  assert.equal("status" in reference, false);
+});
+
+test("uses the Moon major-body command for Moon references", () => {
+  const url = new URL(buildHorizonsReferenceUrl("Moon", "1990-09-17T15:11:00.000Z"));
+  assert.equal(url.searchParams.get("COMMAND"), "'301'");
+});
+
+test("rejects unsigned, malformed, or incomplete Horizons responses", async () => {
+  const unsignedFetch = async () => new Response(JSON.stringify({ result: sampleResult }), { status: 200 });
+  await assert.rejects(
+    fetchHorizonsReference("Sun", "1990-09-17T15:11:00.000Z", { fetchImpl: unsignedFetch }),
+    /horizons_signature_invalid/,
+  );
+
+  const malformedFetch = async () => new Response(JSON.stringify({
+    signature: { source: "NASA/JPL Horizons API", version: "1.3" },
+    result: "no ephemeris block",
+  }), { status: 200 });
+  await assert.rejects(
+    fetchHorizonsReference("Sun", "1990-09-17T15:11:00.000Z", { fetchImpl: malformedFetch }),
+    /horizons_ephemeris_block_missing/,
+  );
+});


### PR DESCRIPTION
## Summary

Adds a real second-source adapter for NASA/JPL Horizons without yet promoting any placement into user-facing truth.

## What this PR does

- Queries the official JPL Horizons API
- Uses geocentric observer ephemerides
- Requests quantity 31 for apparent ecliptic-of-date longitude
- Supports Sun and Moon major-body IDs
- Preserves the exact UTC input timestamp
- Requires a valid NASA/JPL response signature
- Parses the named longitude column rather than guessing a numeric field
- Returns an `IndependentEphemerisReference` compatible with the promotion contract merged in #148
- Fails closed on HTTP, signature, parsing, timeout, and malformed-response errors

## Trust boundary

This PR provides the second source. It does **not** approve a longitude tolerance, automatically call the network during normal profile creation, or promote Robert's Sun, Moon, or Rising. A JPL reference must still pass the approved policy gate before it can become authoritative.

## Regression protection

Tests verify:

- exact official endpoint and query configuration
- Sun and Moon command separation
- named-column parsing
- provenance and timestamp preservation
- unsigned and malformed payload rejection

The tests mock the network. CI remains deterministic and does not quietly depend on NASA availability at build time.

## Next lane

Run a versioned live-reference evidence suite across boundary, DST, historical, and golden-profile fixtures, then approve a release tolerance only from measured deltas.