### PR TITLE
feat(astrology): add live ephemeris evidence matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: npm test
 
       - name: Run Astrology Trust Tests
-        run: node --import tsx --test tests/astrology-candidate.test.ts tests/astrology-independent-verification.test.ts tests/jpl-horizons-reference.test.ts
+        run: node --import tsx --test tests/astrology-candidate.test.ts tests/astrology-independent-verification.test.ts tests/jpl-horizons-reference.test.ts tests/astrology-evidence-matrix.test.ts
 
       - name: Build Application
         run: npm run build

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -37,7 +37,7 @@ jobs:
         run: npm test
 
       - name: Run astrology trust tests
-        run: node --import tsx --test tests/astrology-candidate.test.ts tests/astrology-independent-verification.test.ts tests/jpl-horizons-reference.test.ts
+        run: node --import tsx --test tests/astrology-candidate.test.ts tests/astrology-independent-verification.test.ts tests/jpl-horizons-reference.test.ts tests/astrology-evidence-matrix.test.ts
 
       - name: Build project
         run: npm run build

--- a/scripts/run-live-ephemeris-evidence.ts
+++ b/scripts/run-live-ephemeris-evidence.ts
@@ -1,0 +1,27 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { runLiveEphemerisEvidenceMatrix } from "../server/services/astrology-evidence-matrix";
+
+const outputPath = resolve(
+  process.argv[2] ?? "artifacts/astrology/ephemeris-evidence-receipt.json",
+);
+
+async function main(): Promise<void> {
+  const receipt = await runLiveEphemerisEvidenceMatrix();
+  await mkdir(dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf8");
+
+  console.log(`Ephemeris evidence receipt written to ${outputPath}`);
+  console.log(JSON.stringify(receipt.summary, null, 2));
+
+  if (receipt.summary.signDisagreements > 0) {
+    process.exitCode = 2;
+    console.error("Sign disagreement detected. No tolerance policy may be approved from this receipt.");
+  }
+}
+
+main().catch((error: unknown) => {
+  process.exitCode = 1;
+  console.error("Live ephemeris evidence run failed closed.");
+  console.error(error instanceof Error ? error.message : String(error));
+});

--- a/server/services/astrology-evidence-matrix.ts
+++ b/server/services/astrology-evidence-matrix.ts
@@ -1,0 +1,173 @@
+import { calculateAstrology } from "./astrology";
+import { fetchHorizonsReference, type SupportedHorizonsBody } from "./jpl-horizons-reference";
+
+export type EvidenceFixtureCategory =
+  | "golden_profile"
+  | "zodiac_boundary"
+  | "dst_transition"
+  | "historical";
+
+export interface EphemerisEvidenceFixture {
+  id: string;
+  category: EvidenceFixtureCategory;
+  birthDate: string;
+  birthTime: string;
+  timezone: string;
+  latitude: number;
+  longitude: number;
+  bodies: SupportedHorizonsBody[];
+  note: string;
+}
+
+export interface EphemerisEvidenceRow {
+  fixtureId: string;
+  category: EvidenceFixtureCategory;
+  body: SupportedHorizonsBody;
+  inputTimestamp: string;
+  candidateEngine: string;
+  candidateLongitude: number;
+  candidateSign: string;
+  referenceEngine: string;
+  referenceLongitude: number;
+  referenceSign: string;
+  longitudeDeltaDegrees: number;
+  signAgreement: boolean;
+}
+
+export interface EphemerisEvidenceReceipt {
+  schemaVersion: "1.0.0";
+  generatedAt: string;
+  policyStatus: "evidence_only_no_tolerance_approved";
+  fixtures: EphemerisEvidenceFixture[];
+  rows: EphemerisEvidenceRow[];
+  summary: {
+    totalRows: number;
+    signDisagreements: number;
+    maximumLongitudeDeltaDegrees: number | null;
+    sunMaximumDeltaDegrees: number | null;
+    moonMaximumDeltaDegrees: number | null;
+  };
+}
+
+export const EPHEMERIS_EVIDENCE_FIXTURES: EphemerisEvidenceFixture[] = [
+  {
+    id: "bobby-bronx-1990",
+    category: "golden_profile",
+    birthDate: "1990-09-17",
+    birthTime: "11:11",
+    timezone: "America/New_York",
+    latitude: 40.8448,
+    longitude: -73.8648,
+    bodies: ["Sun", "Moon"],
+    note: "Golden profile fixture; no expected sign is hardcoded.",
+  },
+  {
+    id: "spring-equinox-boundary-2000",
+    category: "zodiac_boundary",
+    birthDate: "2000-03-20",
+    birthTime: "07:35",
+    timezone: "UTC",
+    latitude: 0,
+    longitude: 0,
+    bodies: ["Sun", "Moon"],
+    note: "Near a tropical zodiac boundary; agreement must be measured, not assumed.",
+  },
+  {
+    id: "new-york-dst-spring-2024",
+    category: "dst_transition",
+    birthDate: "2024-03-10",
+    birthTime: "03:05",
+    timezone: "America/New_York",
+    latitude: 40.7128,
+    longitude: -74.006,
+    bodies: ["Sun", "Moon"],
+    note: "Post-spring-forward local time checks UTC conversion consistency.",
+  },
+  {
+    id: "new-york-dst-fall-2024",
+    category: "dst_transition",
+    birthDate: "2024-11-03",
+    birthTime: "02:05",
+    timezone: "America/New_York",
+    latitude: 40.7128,
+    longitude: -74.006,
+    bodies: ["Sun", "Moon"],
+    note: "Post-fall-back local time avoids ambiguous 01:xx while testing offset transition handling.",
+  },
+  {
+    id: "historical-greenwich-1900",
+    category: "historical",
+    birthDate: "1900-01-01",
+    birthTime: "12:00",
+    timezone: "UTC",
+    latitude: 51.4769,
+    longitude: 0,
+    bodies: ["Sun", "Moon"],
+    note: "Historical-range comparison fixture.",
+  },
+];
+
+function circularDelta(left: number, right: number): number {
+  const raw = Math.abs(left - right) % 360;
+  return Math.min(raw, 360 - raw);
+}
+
+function maximum(values: number[]): number | null {
+  return values.length > 0 ? Math.max(...values) : null;
+}
+
+export async function runLiveEphemerisEvidenceMatrix(
+  fixtures: EphemerisEvidenceFixture[] = EPHEMERIS_EVIDENCE_FIXTURES,
+): Promise<EphemerisEvidenceReceipt> {
+  const rows: EphemerisEvidenceRow[] = [];
+
+  for (const fixture of fixtures) {
+    const astrology = calculateAstrology(fixture);
+
+    for (const body of fixture.bodies) {
+      const placement = body === "Sun" ? astrology.sun : astrology.moon;
+      const candidate = placement.candidate;
+      if (!candidate) {
+        throw new Error(`candidate_missing:${fixture.id}:${body}`);
+      }
+
+      const reference = await fetchHorizonsReference(body, candidate.inputTimestamp);
+      if (reference.inputTimestamp !== candidate.inputTimestamp) {
+        throw new Error(`timestamp_mismatch:${fixture.id}:${body}`);
+      }
+
+      rows.push({
+        fixtureId: fixture.id,
+        category: fixture.category,
+        body,
+        inputTimestamp: candidate.inputTimestamp,
+        candidateEngine: candidate.engine,
+        candidateLongitude: candidate.longitude,
+        candidateSign: candidate.sign,
+        referenceEngine: reference.engine,
+        referenceLongitude: reference.longitude,
+        referenceSign: reference.sign,
+        longitudeDeltaDegrees: circularDelta(candidate.longitude, reference.longitude),
+        signAgreement: candidate.sign === reference.sign,
+      });
+    }
+  }
+
+  const sunRows = rows.filter((row) => row.body === "Sun");
+  const moonRows = rows.filter((row) => row.body === "Moon");
+
+  return {
+    schemaVersion: "1.0.0",
+    generatedAt: new Date().toISOString(),
+    policyStatus: "evidence_only_no_tolerance_approved",
+    fixtures,
+    rows,
+    summary: {
+      totalRows: rows.length,
+      signDisagreements: rows.filter((row) => !row.signAgreement).length,
+      maximumLongitudeDeltaDegrees: maximum(rows.map((row) => row.longitudeDeltaDegrees)),
+      sunMaximumDeltaDegrees: maximum(sunRows.map((row) => row.longitudeDeltaDegrees)),
+      moonMaximumDeltaDegrees: maximum(moonRows.map((row) => row.longitudeDeltaDegrees)),
+    },
+  };
+}

--- a/tests/astrology-evidence-matrix.test.ts
+++ b/tests/astrology-evidence-matrix.test.ts
@@ -50,7 +50,10 @@ test("a live-style receipt measures deltas but never approves a tolerance", asyn
     assert.equal(receipt.policyStatus, "evidence_only_no_tolerance_approved");
     assert.equal(receipt.summary.totalRows, 2);
     assert.equal(receipt.summary.signDisagreements, 0);
-    assert.equal(receipt.summary.maximumLongitudeDeltaDegrees, 0);
+    assert.ok(
+      receipt.summary.maximumLongitudeDeltaDegrees < 1e-8,
+      `expected a rounding-only delta below 1e-8°, got ${receipt.summary.maximumLongitudeDeltaDegrees}`,
+    );
     assert.equal("approvedTolerance" in receipt, false);
     assert.equal("verified" in receipt, false);
   } finally {

--- a/tests/astrology-evidence-matrix.test.ts
+++ b/tests/astrology-evidence-matrix.test.ts
@@ -8,11 +8,11 @@ import {
 
 function horizonsPayload(longitude: number): Response {
   const result = `
-+ Date__(UT)__HR:MN:SC.fff, ObsEcLon, ObsEcLat,
-+$$SOE
-+2000-Jan-01 00:00:00.000, ${longitude.toFixed(8)}, 0.00000000,
-+$$EOE
-+`;
+ Date__(UT)__HR:MN:SC.fff, ObsEcLon, ObsEcLat,
+$$SOE
+2000-Jan-01 00:00:00.000, ${longitude.toFixed(8)}, 0.00000000,
+$$EOE
+`;
   return new Response(JSON.stringify({
     signature: { source: "NASA/JPL Horizons API", version: "1.3" },
     result,

--- a/tests/astrology-evidence-matrix.test.ts
+++ b/tests/astrology-evidence-matrix.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { calculateAstrology } from "../server/services/astrology";
+import {
+  EPHEMERIS_EVIDENCE_FIXTURES,
+  runLiveEphemerisEvidenceMatrix,
+} from "../server/services/astrology-evidence-matrix";
+
+function horizonsPayload(longitude: number): Response {
+  const result = `
++ Date__(UT)__HR:MN:SC.fff, ObsEcLon, ObsEcLat,
++$$SOE
++2000-Jan-01 00:00:00.000, ${longitude.toFixed(8)}, 0.00000000,
++$$EOE
++`;
+  return new Response(JSON.stringify({
+    signature: { source: "NASA/JPL Horizons API", version: "1.3" },
+    result,
+  }), { status: 200, headers: { "Content-Type": "application/json" } });
+}
+
+test("the versioned matrix covers golden, boundary, DST, and historical evidence categories", () => {
+  const categories = new Set(EPHEMERIS_EVIDENCE_FIXTURES.map((fixture) => fixture.category));
+  assert.deepEqual(categories, new Set([
+    "golden_profile",
+    "zodiac_boundary",
+    "dst_transition",
+    "historical",
+  ]));
+  assert.ok(EPHEMERIS_EVIDENCE_FIXTURES.every((fixture) => fixture.bodies.includes("Sun")));
+  assert.ok(EPHEMERIS_EVIDENCE_FIXTURES.every((fixture) => fixture.bodies.includes("Moon")));
+});
+
+test("a live-style receipt measures deltas but never approves a tolerance", async () => {
+  const fixture = EPHEMERIS_EVIDENCE_FIXTURES[0];
+  const astrology = calculateAstrology(fixture);
+  const longitudes = [
+    astrology.sun.candidate?.longitude,
+    astrology.moon.candidate?.longitude,
+  ];
+  assert.ok(longitudes.every((value) => typeof value === "number"));
+
+  const originalFetch = globalThis.fetch;
+  let callIndex = 0;
+  globalThis.fetch = async () => horizonsPayload(longitudes[callIndex++] as number);
+
+  try {
+    const receipt = await runLiveEphemerisEvidenceMatrix([fixture]);
+    assert.equal(receipt.schemaVersion, "1.0.0");
+    assert.equal(receipt.policyStatus, "evidence_only_no_tolerance_approved");
+    assert.equal(receipt.summary.totalRows, 2);
+    assert.equal(receipt.summary.signDisagreements, 0);
+    assert.equal(receipt.summary.maximumLongitudeDeltaDegrees, 0);
+    assert.equal("approvedTolerance" in receipt, false);
+    assert.equal("verified" in receipt, false);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("the evidence runner fails closed when a candidate cannot be produced", async () => {
+  const invalidFixture = {
+    ...EPHEMERIS_EVIDENCE_FIXTURES[0],
+    id: "invalid-date-fixture",
+    birthDate: "not-a-date",
+  };
+
+  await assert.rejects(
+    runLiveEphemerisEvidenceMatrix([invalidFixture]),
+    /candidate_missing:invalid-date-fixture:Sun/,
+  );
+});


### PR DESCRIPTION
## Summary

Adds the evidence-gathering lane required before any longitude tolerance can be approved.

## What this PR does

- Defines a versioned fixture matrix covering golden-profile, zodiac-boundary, DST-transition, and historical cases
- Calculates Astronomy Engine Sun and Moon candidates for each fixture
- Fetches matching NASA/JPL Horizons references using the exact UTC timestamp
- Measures circular longitude deltas and sign agreement
- Writes a machine-readable evidence receipt
- Fails closed when a candidate is missing, timestamps drift, the live source fails, or signs disagree
- Keeps the receipt status explicitly `evidence_only_no_tolerance_approved`

## What this PR does not do

- It does not approve a tolerance
- It does not promote any placement into the active profile
- It does not claim Robert's Moon or Rising
- It does not run live NASA requests in ordinary CI

## Regression protection

Deterministic tests verify matrix category coverage, receipt generation, zero silent promotion fields, and fail-closed behavior. Network responses are mocked in CI.

## Manual evidence command

`node --import tsx scripts/run-live-ephemeris-evidence.ts [optional-output-path]`

The output receipt is the input to a separate policy-review PR. Measurement first, approval second. Apparently even astronomy benefits when paperwork stops pretending to be evidence.