### PR TITLE
ci(astrology): capture live ephemeris evidence receipt

### DIFF
--- a/.github/workflows/live-ephemeris-evidence.yml
+++ b/.github/workflows/live-ephemeris-evidence.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - chore/live-ephemeris-evidence-receipt
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/live-ephemeris-evidence.yml
+++ b/.github/workflows/live-ephemeris-evidence.yml
@@ -1,0 +1,43 @@
+name: Live Ephemeris Evidence
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - chore/live-ephemeris-evidence-receipt
+
+permissions:
+  contents: read
+
+jobs:
+  generate-live-receipt:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate live NASA/JPL evidence receipt
+        run: |
+          mkdir -p evidence
+          node --import tsx scripts/run-live-ephemeris-evidence.ts evidence/ephemeris-live-receipt.json
+
+      - name: Display receipt summary
+        run: node -e "const r=require('./evidence/ephemeris-live-receipt.json'); console.log(JSON.stringify(r.summary,null,2));"
+
+      - name: Upload evidence receipt
+        uses: actions/upload-artifact@v4
+        with:
+          name: ephemeris-live-evidence-receipt
+          path: evidence/ephemeris-live-receipt.json
+          if-no-files-found: error
+          retention-days: 90


### PR DESCRIPTION
Adds a dedicated live-evidence workflow for the already-merged ephemeris matrix.

The workflow:
- runs the real NASA/JPL Horizons comparison outside ordinary deterministic CI
- writes the machine-readable receipt
- prints the measured summary
- uploads the receipt as a 90-day artifact
- does not approve a tolerance or promote any placement

This remains one coherent evidence lane. The purpose is execution and capture, not another decorative PR ritual.