### PR TITLE
feat(astrology): derive evidence-backed draft tolerance policy

### DIFF
--- a/governance/release-audits/ASTROLOGY-TOLERANCE-POLICY-PROPOSAL-v1.md
+++ b/governance/release-audits/ASTROLOGY-TOLERANCE-POLICY-PROPOSAL-v1.md
@@ -1,0 +1,47 @@
+# Astrology Longitude Tolerance Policy Proposal v1
+
+## Status
+
+**DRAFT. NOT APPROVED. NO PLACEMENT PROMOTION AUTHORIZED.**
+
+## Evidence basis
+
+Live workflow run: `30793529466`
+
+- Comparisons: 10
+- Sign disagreements: 0
+- Maximum Sun delta: `0.0002682866178815857°`
+- Maximum Moon delta: `0.0007351139863658318°`
+- Maximum overall delta: `0.0007351139863658318°`
+
+## Proposed tolerance
+
+`0.001°`
+
+The proposal applies a 1.25 safety multiplier to the observed maximum and rounds upward to the next `0.001°` increment.
+
+## Why this remains draft
+
+Ten successful comparisons prove the comparison pipeline works and show excellent agreement between Astronomy Engine and NASA/JPL Horizons. Ten rows are not broad enough to establish production confidence across the full supported date range, all timezone transitions, leap-day behavior, and sign-boundary proximity.
+
+The proposal therefore remains a governance input, not a verification key.
+
+## Approval gates still required
+
+1. Expand the evidence matrix substantially, including more sign-boundary, DST, historical, leap-day, and timezone fixtures.
+2. Re-run live evidence with zero sign disagreements.
+3. Confirm maximum deltas remain below the proposed tolerance.
+4. Review the coordinate-frame and timestamp assumptions for both engines.
+5. Record explicit human approval with approver, date, evidence receipt IDs, and policy version.
+6. Only then change policy status from `draft` to `approved`.
+
+## Enforcement
+
+The code-generated proposal always returns:
+
+```text
+status: draft
+promotionAllowed: false
+```
+
+The existing verification layer rejects draft policies with `policy_not_approved`. This prevents a measured tolerance from quietly becoming a user-facing fact because someone got impatient near the finish line, a beloved human tradition with consistently poor results.

--- a/server/services/astrology-tolerance-policy.ts
+++ b/server/services/astrology-tolerance-policy.ts
@@ -1,0 +1,85 @@
+import type { VerificationPolicy } from "./astrology-verification";
+
+export interface EphemerisEvidenceSummary {
+  totalRows: number;
+  signDisagreements: number;
+  maximumLongitudeDeltaDegrees: number;
+  sunMaximumDeltaDegrees: number;
+  moonMaximumDeltaDegrees: number;
+}
+
+export interface TolerancePolicyProposal {
+  policy: VerificationPolicy;
+  evidence: {
+    receiptRunId: string;
+    totalRows: number;
+    signDisagreements: number;
+    observedMaximumDeltaDegrees: number;
+    safetyMultiplier: number;
+  };
+  promotionAllowed: false;
+  rationale: string;
+}
+
+const MINIMUM_EVIDENCE_ROWS = 10;
+const SAFETY_MULTIPLIER = 1.25;
+const ROUNDING_INCREMENT_DEGREES = 0.001;
+
+function roundUpToIncrement(value: number, increment: number): number {
+  return Math.ceil(value / increment) * increment;
+}
+
+export function proposeLongitudeTolerancePolicy(
+  summary: EphemerisEvidenceSummary,
+  receiptRunId: string,
+): TolerancePolicyProposal {
+  if (!receiptRunId.trim()) {
+    throw new Error("evidence_receipt_id_required");
+  }
+
+  if (!Number.isInteger(summary.totalRows) || summary.totalRows < MINIMUM_EVIDENCE_ROWS) {
+    throw new Error("insufficient_evidence_rows");
+  }
+
+  if (summary.signDisagreements !== 0) {
+    throw new Error("sign_disagreement_present");
+  }
+
+  const deltas = [
+    summary.maximumLongitudeDeltaDegrees,
+    summary.sunMaximumDeltaDegrees,
+    summary.moonMaximumDeltaDegrees,
+  ];
+
+  if (deltas.some((value) => !Number.isFinite(value) || value < 0 || value > 1)) {
+    throw new Error("invalid_evidence_delta");
+  }
+
+  const measuredMaximum = Math.max(...deltas);
+  const proposedTolerance = roundUpToIncrement(
+    measuredMaximum * SAFETY_MULTIPLIER,
+    ROUNDING_INCREMENT_DEGREES,
+  );
+
+  if (proposedTolerance <= 0 || proposedTolerance > 1) {
+    throw new Error("invalid_proposed_tolerance");
+  }
+
+  return {
+    policy: {
+      status: "draft",
+      policyId: "ASTRO-LONGITUDE-v1-draft",
+      maximumLongitudeDeltaDegrees: proposedTolerance,
+    },
+    evidence: {
+      receiptRunId,
+      totalRows: summary.totalRows,
+      signDisagreements: summary.signDisagreements,
+      observedMaximumDeltaDegrees: measuredMaximum,
+      safetyMultiplier: SAFETY_MULTIPLIER,
+    },
+    promotionAllowed: false,
+    rationale:
+      "The live matrix supports a draft tolerance only. Human governance approval and a larger evidence set are still required before any placement can be promoted to verified.",
+  };
+}

--- a/tests/astrology-tolerance-policy.test.ts
+++ b/tests/astrology-tolerance-policy.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { proposeLongitudeTolerancePolicy } from "../server/services/astrology-tolerance-policy";
+import { verifyAgainstIndependentReference } from "../server/services/astrology-verification";
+
+const liveSummary = {
+  totalRows: 10,
+  signDisagreements: 0,
+  maximumLongitudeDeltaDegrees: 0.0007351139863658318,
+  sunMaximumDeltaDegrees: 0.0002682866178815857,
+  moonMaximumDeltaDegrees: 0.0007351139863658318,
+};
+
+test("live evidence produces a conservative draft tolerance without enabling promotion", () => {
+  const proposal = proposeLongitudeTolerancePolicy(liveSummary, "actions-run-30793529466");
+
+  assert.equal(proposal.policy.status, "draft");
+  assert.equal(proposal.policy.maximumLongitudeDeltaDegrees, 0.001);
+  assert.equal(proposal.promotionAllowed, false);
+  assert.equal(proposal.evidence.totalRows, 10);
+  assert.equal(proposal.evidence.signDisagreements, 0);
+});
+
+test("the draft proposal cannot verify a placement", () => {
+  const proposal = proposeLongitudeTolerancePolicy(liveSummary, "actions-run-30793529466");
+  const result = verifyAgainstIndependentReference({
+    body: "Sun",
+    sign: "Virgo",
+    longitude: 174.25,
+    source: "Astronomy Engine geocentric true-ecliptic-of-date calculation",
+    engine: "astronomy-engine@2.1.19",
+    calculatedAt: "2026-08-03T07:25:00.000Z",
+    inputTimestamp: "1990-09-17T15:11:00.000Z",
+  }, {
+    body: "Sun",
+    sign: "Virgo",
+    longitude: 174.2502,
+    source: "NASA/JPL Horizons API",
+    engine: "NASA/JPL Horizons",
+    calculatedAt: "2026-08-03T07:25:01.000Z",
+    inputTimestamp: "1990-09-17T15:11:00.000Z",
+  }, proposal.policy);
+
+  assert.equal(result.status, "rejected");
+  if (result.status === "rejected") assert.equal(result.reason, "policy_not_approved");
+});
+
+test("sign disagreements block even a draft proposal", () => {
+  assert.throws(
+    () => proposeLongitudeTolerancePolicy({ ...liveSummary, signDisagreements: 1 }, "run"),
+    /sign_disagreement_present/,
+  );
+});
+
+test("too little evidence cannot produce a proposal", () => {
+  assert.throws(
+    () => proposeLongitudeTolerancePolicy({ ...liveSummary, totalRows: 9 }, "run"),
+    /insufficient_evidence_rows/,
+  );
+});
+
+test("an evidence receipt identifier is mandatory", () => {
+  assert.throws(
+    () => proposeLongitudeTolerancePolicy(liveSummary, "  "),
+    /evidence_receipt_id_required/,
+  );
+});


### PR DESCRIPTION
## Summary

Turns the live NASA/JPL evidence receipt into a conservative, explicitly draft longitude tolerance proposal.

## What this lane does

- derives a proposed `0.001°` tolerance from the observed maximum delta
- applies a 1.25 safety multiplier and rounds upward
- requires at least 10 evidence rows and zero sign disagreements
- records the exact live workflow run as evidence
- adds regression tests for missing evidence, disagreements, and insufficient samples
- keeps `promotionAllowed: false`
- keeps the policy status `draft`

## What this lane does not do

- does not approve the tolerance
- does not promote Sun or Moon
- does not unlock interpretation
- does not claim the current 10-row matrix is broad enough for production verification

Measurement has now become a governed proposal. Approval remains a separate human decision, because apparently even good numbers should not be allowed to crown themselves.