### PR TITLE
feat(astrology): require expanded live evidence before tolerance proposal

### DIFF
--- a/server/services/astrology-tolerance-policy.ts
+++ b/server/services/astrology-tolerance-policy.ts
@@ -21,7 +21,7 @@ export interface TolerancePolicyProposal {
   rationale: string;
 }
 
-const MINIMUM_EVIDENCE_ROWS = 10;
+const MINIMUM_EVIDENCE_ROWS = 40;
 const SAFETY_MULTIPLIER = 1.25;
 const ROUNDING_INCREMENT_DEGREES = 0.001;
 
@@ -80,6 +80,6 @@ export function proposeLongitudeTolerancePolicy(
     },
     promotionAllowed: false,
     rationale:
-      "The live matrix supports a draft tolerance only. Human governance approval and a larger evidence set are still required before any placement can be promoted to verified.",
+      "The expanded live matrix supports a draft tolerance only. Explicit governance approval is still required before any placement can be promoted to verified.",
   };
 }

--- a/tests/astrology-tolerance-policy.test.ts
+++ b/tests/astrology-tolerance-policy.test.ts
@@ -4,25 +4,25 @@ import { proposeLongitudeTolerancePolicy } from "../server/services/astrology-to
 import { verifyAgainstIndependentReference } from "../server/services/astrology-verification";
 
 const liveSummary = {
-  totalRows: 10,
+  totalRows: 40,
   signDisagreements: 0,
   maximumLongitudeDeltaDegrees: 0.0007351139863658318,
   sunMaximumDeltaDegrees: 0.0002682866178815857,
   moonMaximumDeltaDegrees: 0.0007351139863658318,
 };
 
-test("live evidence produces a conservative draft tolerance without enabling promotion", () => {
-  const proposal = proposeLongitudeTolerancePolicy(liveSummary, "actions-run-30793529466");
+test("expanded live evidence produces a conservative draft tolerance without enabling promotion", () => {
+  const proposal = proposeLongitudeTolerancePolicy(liveSummary, "expanded-live-receipt");
 
   assert.equal(proposal.policy.status, "draft");
   assert.equal(proposal.policy.maximumLongitudeDeltaDegrees, 0.001);
   assert.equal(proposal.promotionAllowed, false);
-  assert.equal(proposal.evidence.totalRows, 10);
+  assert.equal(proposal.evidence.totalRows, 40);
   assert.equal(proposal.evidence.signDisagreements, 0);
 });
 
 test("the draft proposal cannot verify a placement", () => {
-  const proposal = proposeLongitudeTolerancePolicy(liveSummary, "actions-run-30793529466");
+  const proposal = proposeLongitudeTolerancePolicy(liveSummary, "expanded-live-receipt");
   const result = verifyAgainstIndependentReference({
     body: "Sun",
     sign: "Virgo",
@@ -52,9 +52,16 @@ test("sign disagreements block even a draft proposal", () => {
   );
 });
 
-test("too little evidence cannot produce a proposal", () => {
+test("the old 10-row matrix no longer satisfies the evidence floor", () => {
   assert.throws(
-    () => proposeLongitudeTolerancePolicy({ ...liveSummary, totalRows: 9 }, "run"),
+    () => proposeLongitudeTolerancePolicy({ ...liveSummary, totalRows: 10 }, "run"),
+    /insufficient_evidence_rows/,
+  );
+});
+
+test("39 rows still cannot produce a proposal", () => {
+  assert.throws(
+    () => proposeLongitudeTolerancePolicy({ ...liveSummary, totalRows: 39 }, "run"),
     /insufficient_evidence_rows/,
   );
 });


### PR DESCRIPTION
## Summary

Raises the tolerance-proposal evidence floor from the original 10 comparisons to the expanded 40-comparison matrix now on main.

## Changes

- requires at least 40 live comparison rows
- makes the original 10-row receipt insufficient by contract
- preserves zero-sign-disagreement requirement
- preserves draft-only status and `promotionAllowed: false`
- triggers a fresh live NASA/JPL run against the expanded fixture set

## Boundary

This lane measures and tightens governance. It does not approve the tolerance, promote Sun or Moon, or unlock interpretation. Diamond's line stays intact: evidence first, claims second.