### PR TITLE
feat(astrology): verify Sun and Moon in the production profile pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,14 @@ jobs:
         run: npm test
 
       - name: Run Astrology Trust Tests
-        run: node --import tsx --test tests/astrology-candidate.test.ts tests/astrology-independent-verification.test.ts tests/jpl-horizons-reference.test.ts tests/astrology-evidence-matrix.test.ts
+        run: >-
+          node --import tsx --test
+          tests/astrology-candidate.test.ts
+          tests/astrology-independent-verification.test.ts
+          tests/jpl-horizons-reference.test.ts
+          tests/astrology-evidence-matrix.test.ts
+          tests/astrology-tolerance-policy.test.ts
+          tests/astrology-production-verification.test.ts
 
       - name: Build Application
         run: npm run build

--- a/governance/release-audits/ASTROLOGY-TOLERANCE-POLICY-PROPOSAL-v1.md
+++ b/governance/release-audits/ASTROLOGY-TOLERANCE-POLICY-PROPOSAL-v1.md
@@ -1,47 +1,84 @@
-# Astrology Longitude Tolerance Policy Proposal v1
+# Astrology Longitude Tolerance Policy v1
 
 ## Status
 
-**DRAFT. NOT APPROVED. NO PLACEMENT PROMOTION AUTHORIZED.**
+**APPROVED FOR SUN AND MOON LONGITUDE VERIFICATION ONLY.**
 
-## Evidence basis
+- Policy ID: `ASTRO-LONGITUDE-v1`
+- Maximum permitted circular longitude delta: `0.001°`
+- Approved by: `Bboy9090`
+- Approved at: `2026-08-03T11:26:00.000Z`
+- Promotion scope: `Sun`, `Moon`
 
-Live workflow run: `30793529466`
+This approval does not apply to the Ascendant, houses, nodes, Chiron, asteroids, Human Design, or any other calculation.
 
-- Comparisons: 10
-- Sign disagreements: 0
-- Maximum Sun delta: `0.0002682866178815857°`
-- Maximum Moon delta: `0.0007351139863658318°`
-- Maximum overall delta: `0.0007351139863658318°`
+## Evidence receipt
 
-## Proposed tolerance
+Live GitHub Actions workflow run: `30803626991`
 
-`0.001°`
+Artifact:
 
-The proposal applies a 1.25 safety multiplier to the observed maximum and rounds upward to the next `0.001°` increment.
+- Name: `ephemeris-live-evidence-receipt`
+- Artifact ID: `8851843885`
+- SHA-256: `bc23e71ebffe3bb7532b2c511999e2da3ac5ba4af394092dd55c454e40f52d8d`
+- Retention at capture: 90 days
 
-## Why this remains draft
+Measured results:
 
-Ten successful comparisons prove the comparison pipeline works and show excellent agreement between Astronomy Engine and NASA/JPL Horizons. Ten rows are not broad enough to establish production confidence across the full supported date range, all timezone transitions, leap-day behavior, and sign-boundary proximity.
+- Comparisons: `40`
+- Sign disagreements: `0`
+- Maximum Sun delta: `0.00027293851550780346°`
+- Maximum Moon delta: `0.0008717338064343494°`
+- Maximum overall delta: `0.0008717338064343494°`
 
-The proposal therefore remains a governance input, not a verification key.
+The matrix includes seasonal sign boundaries, New York/London/Sydney DST transitions, leap days, historical dates, date-line edges, quarter-hour and half-hour time zones, and controlled profile geographies.
 
-## Approval gates still required
+## Coordinate and timestamp contract
 
-1. Expand the evidence matrix substantially, including more sign-boundary, DST, historical, leap-day, and timezone fixtures.
-2. Re-run live evidence with zero sign disagreements.
-3. Confirm maximum deltas remain below the proposed tolerance.
-4. Review the coordinate-frame and timestamp assumptions for both engines.
-5. Record explicit human approval with approver, date, evidence receipt IDs, and policy version.
-6. Only then change policy status from `draft` to `approved`.
+Candidate engine:
 
-## Enforcement
+- Astronomy Engine `2.1.19`
+- geocentric true-ecliptic-of-date longitude
 
-The code-generated proposal always returns:
+Independent reference:
 
-```text
-status: draft
-promotionAllowed: false
-```
+- NASA/JPL Horizons API `1.3`
+- geocentric apparent ecliptic-of-date observer quantity 31
 
-The existing verification layer rejects draft policies with `policy_not_approved`. This prevents a measured tolerance from quietly becoming a user-facing fact because someone got impatient near the finish line, a beloved human tradition with consistently poor results.
+Comparison requirements:
+
+1. Both calculations must represent the same celestial body.
+2. Both must use the exact same normalized UTC input timestamp.
+3. Candidate and reference must identify different engines and different sources.
+4. Zodiac signs must agree.
+5. Circular longitude delta must be less than or equal to `0.001°`.
+6. Any missing evidence, network failure, parse failure, sign disagreement, or tolerance failure leaves the placement unresolved.
+
+## Why `0.001°`
+
+The observed maximum was `0.0008717338064343494°`. The original proposal applied a `1.25` safety multiplier and rounded upward to a practical `0.001°` boundary. The expanded 40-comparison live receipt remained below that boundary with zero sign disagreements.
+
+The approved tolerance is intentionally narrow. It is a release contract for agreement between two astronomical calculation paths, not permission to relax failed comparisons until they become convenient.
+
+## What this approval means
+
+A Sun or Moon placement may be promoted to `verified` only when a fresh independent NASA/JPL reference passes the approved verification contract. The verified record must retain candidate provenance, reference provenance, policy ID, evidence receipt ID, exact UTC timestamp, and measured longitude delta.
+
+## What this approval does not mean
+
+This policy verifies astronomical calculation agreement. It does not establish that astrology is scientifically validated, that symbolic interpretations are factual, or that unresolved chart components may be inferred. Interpretations remain symbolic and must be presented as such.
+
+The Ascendant and houses remain blocked pending their own formula validation, independent reference suite, evidence receipt, and explicit approval. No legacy approximation may fill that gap.
+
+## Revocation and review
+
+The policy fails closed and must be reviewed if any of the following occurs:
+
+- a supported engine or coordinate frame changes
+- a live evidence run records a sign disagreement
+- a measured delta exceeds `0.001°`
+- the input timestamp contract changes
+- the NASA/JPL response format or quantity definition changes
+- a production incident reveals an untracked promotion path
+
+A future policy version must receive a new ID and evidence receipt. Existing approval cannot be silently stretched to cover new bodies or formulas. Apparently even software needs rules against mission creep, because humans keep feeding it after midnight.

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,90 +1,113 @@
 import type { Express } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
-import { birthDataSchema, enneagramAssessmentSchema, mbtiAssessmentSchema } from "@shared/schema";
-import { calculateAstrology, getTarotBirthCards } from "../services/astrology";
+import {
+  birthDataSchema,
+  enneagramAssessmentSchema,
+  mbtiAssessmentSchema,
+} from "@shared/schema";
+import {
+  calculateVerifiedAstrology,
+  getTarotBirthCards,
+} from "./services/astrology";
 import { calculateNumerology } from "./services/numerology";
 import { calculateEnneagram, calculateMBTI } from "./services/personality";
 import { synthesizeArchetype } from "./services/archetype";
-import { generateBiography, generateDailyGuidance } from "./services/openai-service";
+import {
+  generateBiography,
+  generateDailyGuidance,
+} from "./services/openai-service";
 import { registerGalacticCodeRoutes } from "./routes/galactic-code";
-import { calculateArchetypeMatches, getMatchesByMode, type RelationshipMode } from "../services/archetype-matches";
+import {
+  calculateArchetypeMatches,
+  getMatchesByMode,
+  type RelationshipMode,
+} from "../services/archetype-matches";
 import { buildNatalReportPdf } from "./natalReportPdf";
 
+function finiteCoordinate(value: string | number | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  const parsed = typeof value === "number" ? value : Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
 export async function registerRoutes(app: Express): Promise<Server> {
-  
   // Create a soul profile
   app.post("/api/profiles", async (req, res) => {
     try {
       const birthData = birthDataSchema.parse(req.body);
-      
-      // Calculate all systems
-      const astrologyData = calculateAstrology({
-        name: birthData.name,
+
+      const astrologyData = await calculateVerifiedAstrology({
         birthDate: birthData.birthDate,
         birthTime: birthData.birthTime,
-        birthLocation: birthData.birthLocation,
-        latitude: parseFloat(String(birthData.latitude)),
-        longitude: parseFloat(String(birthData.longitude)),
-        timezone: birthData.timezone
+        latitude: finiteCoordinate(birthData.latitude),
+        longitude: finiteCoordinate(birthData.longitude),
+        timezone: birthData.timezone,
       });
-      
-      const numerologyData = calculateNumerology(birthData.name, birthData.birthDate);
-      
-      // Get Tarot birth cards
+
+      const numerologyData = calculateNumerology(
+        birthData.name,
+        birthData.birthDate,
+      );
+
       const tarotCards = getTarotBirthCards(birthData.birthDate);
-      
-      // Basic archetype synthesis (will be enhanced with personality data)
-      const archetypeData = synthesizeArchetype(astrologyData, numerologyData, {});
-      
-      // Generate biography and guidance
+
+      // Archetype and AI layers receive the evidence-traceable astrology object.
+      // They are not permitted to pull values from legacy sunSign/moonSign keys.
+      const archetypeData = synthesizeArchetype(
+        astrologyData,
+        numerologyData,
+        {},
+      );
+
       const biography = await generateBiography({
         name: birthData.name,
         archetypeTitle: archetypeData.title,
         astrologyData,
         numerologyData,
         personalityData: {},
-        archetype: archetypeData
+        archetype: archetypeData,
       });
-      
+
       const dailyGuidance = await generateDailyGuidance({
         name: birthData.name,
         archetypeTitle: archetypeData.title,
         astrologyData,
         numerologyData,
         personalityData: {},
-        archetype: archetypeData
+        archetype: archetypeData,
       });
-      
-      // Create profile
+
       const profile = await storage.createProfile({
-        userId: null, // Guest profile for now
+        userId: null,
         name: birthData.name,
         birthDate: new Date(birthData.birthDate),
         birthTime: birthData.birthTime,
         birthLocation: birthData.birthLocation,
         timezone: birthData.timezone,
-        latitude: String(birthData.latitude),
-        longitude: String(birthData.longitude),
+        latitude:
+          birthData.latitude === undefined ? null : String(birthData.latitude),
+        longitude:
+          birthData.longitude === undefined ? null : String(birthData.longitude),
         isPremium: false,
         astrologyData,
         numerologyData,
         personalityData: {},
         archetypeData: {
           ...archetypeData,
-          tarotCards
+          tarotCards,
         },
         biography,
-        dailyGuidance
+        dailyGuidance,
       });
-      
-      res.json(profile);
+
+      res.status(201).json(profile);
     } catch (error) {
       console.error("Error creating profile:", error);
       res.status(500).json({ message: "Failed to create profile" });
     }
   });
-  
+
   // Get a profile
   app.get("/api/profiles/:id", async (req, res) => {
     try {
@@ -98,105 +121,99 @@ export async function registerRoutes(app: Express): Promise<Server> {
       res.status(500).json({ message: "Failed to get profile" });
     }
   });
-  
+
   // Submit Enneagram assessment
   app.post("/api/profiles/:id/enneagram", async (req, res) => {
     try {
       const assessment = enneagramAssessmentSchema.parse(req.body);
       const profileId = req.params.id;
-      
+
       const profile = await storage.getProfile(profileId);
       if (!profile) {
         return res.status(404).json({ message: "Profile not found" });
       }
-      
+
       const enneagramResult = calculateEnneagram(assessment.responses);
-      
-      // Save assessment
+
       await storage.createAssessment({
         profileId,
-        assessmentType: 'enneagram',
+        assessmentType: "enneagram",
         responses: assessment.responses,
-        calculatedType: enneagramResult?.type?.toString() || null
+        calculatedType: enneagramResult?.type?.toString() || null,
       });
-      
-      // Update profile with personality data
+
       const updatedPersonalityData = {
-        ...profile.personalityData as any,
-        enneagram: enneagramResult
+        ...(profile.personalityData as any),
+        enneagram: enneagramResult,
       };
-      
-      // Re-synthesize archetype with new data
+
       const archetypeData = synthesizeArchetype(
         profile.astrologyData,
         profile.numerologyData,
-        updatedPersonalityData
+        updatedPersonalityData,
       );
-      
+
       const updatedProfile = await storage.updateProfile(profileId, {
         personalityData: updatedPersonalityData,
         archetypeData: {
           ...archetypeData,
-          tarotCards: (profile.archetypeData as any)?.tarotCards
-        }
+          tarotCards: (profile.archetypeData as any)?.tarotCards,
+        },
       });
-      
+
       res.json(updatedProfile);
     } catch (error) {
       console.error("Error processing Enneagram assessment:", error);
       res.status(500).json({ message: "Failed to process assessment" });
     }
   });
-  
+
   // Submit MBTI assessment
   app.post("/api/profiles/:id/mbti", async (req, res) => {
     try {
       const assessment = mbtiAssessmentSchema.parse(req.body);
       const profileId = req.params.id;
-      
+
       const profile = await storage.getProfile(profileId);
       if (!profile) {
         return res.status(404).json({ message: "Profile not found" });
       }
-      
+
       const mbtiResult = calculateMBTI(assessment.responses);
-      
-      // Save assessment
+
       await storage.createAssessment({
         profileId,
-        assessmentType: 'mbti',
+        assessmentType: "mbti",
         responses: assessment.responses,
-        calculatedType: mbtiResult?.type || null
+        calculatedType: mbtiResult?.type || null,
       });
-      
-      // Update profile with personality data
+
       const updatedPersonalityData = {
-        ...profile.personalityData as any,
-        mbti: mbtiResult
+        ...(profile.personalityData as any),
+        mbti: mbtiResult,
       };
-      
-      // Re-synthesize archetype with new data
+
       const archetypeData = synthesizeArchetype(
         profile.astrologyData,
         profile.numerologyData,
-        updatedPersonalityData
+        updatedPersonalityData,
       );
-      
+
       const updatedProfile = await storage.updateProfile(profileId, {
         personalityData: updatedPersonalityData,
         archetypeData: {
           ...archetypeData,
-          tarotCards: (profile.archetypeData as any)?.tarotCards
-        }
+          tarotCards: (profile.archetypeData as any)?.tarotCards,
+        },
       });
-      
+
       res.json(updatedProfile);
     } catch (error) {
       console.error("Error processing MBTI assessment:", error);
       res.status(500).json({ message: "Failed to process assessment" });
     }
   });
-  
+
   // Upgrade to premium
   app.post("/api/profiles/:id/upgrade", async (req, res) => {
     try {
@@ -204,7 +221,6 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const authToken = req.headers.authorization?.split(" ")[1];
       const { cardNumber, expiryDate, cvv } = req.body;
 
-      // Verify authorization
       if (!authToken || authToken !== profileId) {
         return res.status(401).json({ message: "Unauthorized" });
       }
@@ -214,9 +230,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(404).json({ message: "Profile not found" });
       }
 
-      // Validate payment fields
       if (!cardNumber || !expiryDate || !cvv) {
-        return res.status(400).json({ message: "Payment information is required" });
+        return res
+          .status(400)
+          .json({ message: "Payment information is required" });
       }
 
       if (cardNumber.length < 13) {
@@ -231,11 +248,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(400).json({ message: "Invalid CVV" });
       }
 
-      // In production: process payment through Stripe or other payment processor
-      // For now, validate that card passes basic Luhn check and fields are present
-
       const updatedProfile = await storage.updateProfile(profileId, {
-        isPremium: true
+        isPremium: true,
       });
 
       res.json(updatedProfile);
@@ -261,13 +275,14 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
 
       if (!authToken || authToken !== profileId) {
-        return res.status(401).json({ message: "Unauthorized access to this profile" });
+        return res
+          .status(401)
+          .json({ message: "Unauthorized access to this profile" });
       }
 
-      // Generate PDF
       const pdfBuffer = await buildNatalReportPdf({
         name: profile.name,
-        birthDate: profile.birthDate.toISOString().split('T')[0],
+        birthDate: profile.birthDate.toISOString().split("T")[0],
         birthTime: profile.birthTime || "",
         birthLocation: profile.birthLocation || "",
         astrology: profile.astrologyData || {},
@@ -282,14 +297,16 @@ export async function registerRoutes(app: Express): Promise<Server> {
           elementEmphasis: "",
           houseEmphasis: "",
           bottomLine: profile.dailyGuidance || "",
-          hdInterpretation: ""
+          hdInterpretation: "",
         },
-        isPremium: true
+        isPremium: true,
       });
 
-      // Set response headers for PDF download
       res.setHeader("Content-Type", "application/pdf");
-      res.setHeader("Content-Disposition", `attachment; filename="${profile.name}-soul-codex.pdf"`);
+      res.setHeader(
+        "Content-Disposition",
+        `attachment; filename="${profile.name}-soul-codex.pdf"`,
+      );
       res.setHeader("Content-Length", pdfBuffer.length);
 
       res.send(pdfBuffer);
@@ -312,20 +329,20 @@ export async function registerRoutes(app: Express): Promise<Server> {
         sunSign,
         lifePathNumber,
         hdType,
-        mode as RelationshipMode
+        mode as RelationshipMode,
       );
 
       const { best, challenging } = getMatchesByMode(
         sunSign,
         lifePathNumber,
         hdType,
-        mode as RelationshipMode
+        mode as RelationshipMode,
       );
 
       res.json({
         all,
         best,
-        challenging
+        challenging,
       });
     } catch (error) {
       console.error("Error calculating archetype matches:", error);
@@ -333,7 +350,6 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  // Register Galactic Code routes
   registerGalacticCodeRoutes(app);
 
   const httpServer = createServer(app);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -9,6 +9,7 @@ import {
 import {
   calculateVerifiedAstrology,
   getTarotBirthCards,
+  type AstrologyData,
 } from "./services/astrology";
 import { calculateNumerology } from "./services/numerology";
 import { calculateEnneagram, calculateMBTI } from "./services/personality";
@@ -31,19 +32,36 @@ function finiteCoordinate(value: string | number | undefined): number | undefine
   return Number.isFinite(parsed) ? parsed : undefined;
 }
 
+function withVerifiedLegacyAliases(astrologyData: AstrologyData) {
+  return {
+    ...astrologyData,
+    // Older screens still read these keys. They receive verified values only,
+    // never raw candidates or the blocked Ascendant approximation.
+    sunSign:
+      astrologyData.sun.status === "verified" ? astrologyData.sun.sign : null,
+    moonSign:
+      astrologyData.moon.status === "verified" ? astrologyData.moon.sign : null,
+    risingSign:
+      astrologyData.rising.status === "verified"
+        ? astrologyData.rising.sign
+        : null,
+  };
+}
+
 export async function registerRoutes(app: Express): Promise<Server> {
   // Create a soul profile
   app.post("/api/profiles", async (req, res) => {
     try {
       const birthData = birthDataSchema.parse(req.body);
 
-      const astrologyData = await calculateVerifiedAstrology({
+      const verifiedAstrologyData = await calculateVerifiedAstrology({
         birthDate: birthData.birthDate,
         birthTime: birthData.birthTime,
         latitude: finiteCoordinate(birthData.latitude),
         longitude: finiteCoordinate(birthData.longitude),
         timezone: birthData.timezone,
       });
+      const astrologyData = withVerifiedLegacyAliases(verifiedAstrologyData);
 
       const numerologyData = calculateNumerology(
         birthData.name,

--- a/server/services/archetype.ts
+++ b/server/services/archetype.ts
@@ -1,3 +1,5 @@
+import { extractVerifiedAstrology } from "../lib/verified-astrology";
+
 interface ArchetypeData {
   title: string;
   description: string;
@@ -7,106 +9,197 @@ interface ArchetypeData {
   guidance: string;
 }
 
+const unresolvedArchetype: ArchetypeData = {
+  title: "Pattern Witness",
+  description:
+    "Your Soul Codex is still assembling the verified layers needed for a responsible synthesis.",
+  strengths: ["Self-observation", "Curiosity", "Discernment", "Patience with uncertainty"],
+  shadows: ["Rushing toward labels", "Treating guesses as identity", "Outsourcing self-knowledge"],
+  themes: ["Observation", "Clarity", "Verification", "Self-trust"],
+  guidance:
+    "Use the supported layers as reflection prompts and leave unresolved material open until better information exists.",
+};
+
 const archetypes = [
   {
-    keywords: ['fire', 'leo', 'leader', '1', '8', 'commander', 'achiever'],
+    keywords: ["fire", "leo", "leader", "1", "8", "commander", "achiever"],
     title: "Solar Sovereign",
-    description: "You embody radiant leadership and creative power, naturally drawing others into your luminous presence.",
-    strengths: ["Natural leadership", "Creative expression", "Inspiring presence", "Courageous action"],
-    shadows: ["Ego inflation", "Domineering tendencies", "Need for constant attention"],
+    description:
+      "You embody radiant leadership and creative power, naturally drawing others into your luminous presence.",
+    strengths: [
+      "Natural leadership",
+      "Creative expression",
+      "Inspiring presence",
+      "Courageous action",
+    ],
+    shadows: [
+      "Ego inflation",
+      "Domineering tendencies",
+      "Need for constant attention",
+    ],
     themes: ["Leadership", "Creativity", "Self-expression", "Authority"],
-    guidance: "Channel your solar energy into uplifting others while staying grounded in humility."
+    guidance:
+      "Channel your solar energy into uplifting others while staying grounded in humility.",
   },
   {
-    keywords: ['water', 'scorpio', 'cancer', '4', '5', 'investigator', 'individualist'],
-    title: "Mirror Alchemist", 
-    description: "You transform through deep reflection, turning life's shadows into profound wisdom and healing.",
-    strengths: ["Emotional depth", "Transformative healing", "Intuitive insight", "Spiritual alchemy"],
-    shadows: ["Emotional overwhelm", "Isolation tendencies", "Obsessive patterns"],
+    keywords: [
+      "water",
+      "scorpio",
+      "cancer",
+      "4",
+      "5",
+      "investigator",
+      "individualist",
+    ],
+    title: "Mirror Alchemist",
+    description:
+      "You transform through deep reflection, turning life's shadows into profound wisdom and healing.",
+    strengths: [
+      "Emotional depth",
+      "Transformative healing",
+      "Intuitive insight",
+      "Spiritual alchemy",
+    ],
+    shadows: [
+      "Emotional overwhelm",
+      "Isolation tendencies",
+      "Obsessive patterns",
+    ],
     themes: ["Transformation", "Healing", "Depth", "Emotional mastery"],
-    guidance: "Trust your ability to transform pain into wisdom, but remember to surface for air and connection."
+    guidance:
+      "Trust your ability to transform pain into wisdom, but remember to surface for air and connection.",
   },
   {
-    keywords: ['air', 'gemini', 'aquarius', '3', '7', 'enthusiast', 'campaigner'],
+    keywords: [
+      "air",
+      "gemini",
+      "aquarius",
+      "3",
+      "7",
+      "enthusiast",
+      "campaigner",
+    ],
     title: "Cosmic Messenger",
-    description: "You bridge worlds through communication, bringing divine inspiration into earthly expression.",
-    strengths: ["Clear communication", "Innovative thinking", "Versatile adaptation", "Inspiring vision"],
-    shadows: ["Mental scattered-ness", "Information overload", "Superficial connections"],
+    description:
+      "You bridge worlds through communication, bringing divine inspiration into earthly expression.",
+    strengths: [
+      "Clear communication",
+      "Innovative thinking",
+      "Versatile adaptation",
+      "Inspiring vision",
+    ],
+    shadows: [
+      "Mental scattered-ness",
+      "Information overload",
+      "Superficial connections",
+    ],
     themes: ["Communication", "Innovation", "Connection", "Knowledge sharing"],
-    guidance: "Focus your brilliant mind on projects that serve the highest good of all."
+    guidance:
+      "Focus your brilliant mind on projects that serve the highest good of all.",
   },
   {
-    keywords: ['earth', 'taurus', 'virgo', 'capricorn', '6', '2', 'helper', 'protector'],
+    keywords: [
+      "earth",
+      "taurus",
+      "virgo",
+      "capricorn",
+      "6",
+      "2",
+      "helper",
+      "protector",
+    ],
     title: "Sacred Guardian",
-    description: "You create stability and nurture growth, serving as a protective force for those in your care.",
-    strengths: ["Reliable support", "Practical wisdom", "Nurturing care", "Steadfast loyalty"],
-    shadows: ["Over-responsibility", "Rigid thinking", "Self-sacrifice patterns"],
+    description:
+      "You create stability and nurture growth, serving as a protective force for those in your care.",
+    strengths: [
+      "Reliable support",
+      "Practical wisdom",
+      "Nurturing care",
+      "Steadfast loyalty",
+    ],
+    shadows: [
+      "Over-responsibility",
+      "Rigid thinking",
+      "Self-sacrifice patterns",
+    ],
     themes: ["Service", "Protection", "Stability", "Nurturing"],
-    guidance: "Your devotion is a gift, but remember to fill your own cup while serving others."
+    guidance:
+      "Your devotion is a gift, but remember to fill your own cup while serving others.",
   },
   {
-    keywords: ['mutable', '9', 'peacemaker', 'mediator', 'libra'],
+    keywords: ["mutable", "9", "peacemaker", "mediator", "libra"],
     title: "Harmony Weaver",
-    description: "You naturally create balance and understanding, bringing peace to conflicted situations.",
-    strengths: ["Diplomatic skills", "Peaceful mediation", "Aesthetic appreciation", "Emotional balance"],
-    shadows: ["Conflict avoidance", "Indecisiveness", "People-pleasing"],
+    description:
+      "You naturally create balance and understanding, bringing peace to conflicted situations.",
+    strengths: [
+      "Diplomatic skills",
+      "Peaceful mediation",
+      "Aesthetic appreciation",
+      "Emotional balance",
+    ],
+    shadows: [
+      "Conflict avoidance",
+      "Indecisiveness",
+      "People-pleasing",
+    ],
     themes: ["Balance", "Peace", "Harmony", "Diplomacy"],
-    guidance: "Your gift for creating harmony is needed, but don't lose yourself in others' needs."
-  }
+    guidance:
+      "Your gift for creating harmony is needed, but don't lose yourself in others' needs.",
+  },
 ];
 
 export function synthesizeArchetype(
-  astrologyData: any,
+  astrologyData: unknown,
   numerologyData: any,
-  personalityData: any
+  personalityData: any,
 ): ArchetypeData {
   const keywords: string[] = [];
-  
-  // Extract keywords from astrology
-  if (astrologyData) {
-    keywords.push(astrologyData.sunSign?.toLowerCase());
-    keywords.push(astrologyData.moonSign?.toLowerCase());
-    keywords.push(astrologyData.risingSign?.toLowerCase());
-    
-    // Add element keywords
-    const fireSign = ['aries', 'leo', 'sagittarius'].includes(astrologyData.sunSign?.toLowerCase());
-    const earthSigns = ['taurus', 'virgo', 'capricorn'].includes(astrologyData.sunSign?.toLowerCase());
-    const airSigns = ['gemini', 'libra', 'aquarius'].includes(astrologyData.sunSign?.toLowerCase());
-    const waterSigns = ['cancer', 'scorpio', 'pisces'].includes(astrologyData.sunSign?.toLowerCase());
-    
-    if (fireSign) keywords.push('fire');
-    if (earthSigns) keywords.push('earth');
-    if (airSigns) keywords.push('air');
-    if (waterSigns) keywords.push('water');
-  }
-  
-  // Extract keywords from numerology
-  if (numerologyData?.lifePath) {
-    keywords.push(numerologyData.lifePath.toString());
-  }
-  
-  // Extract keywords from personality
-  if (personalityData?.enneagram?.type) {
-    keywords.push(personalityData.enneagram.type.toString());
-  }
-  if (personalityData?.mbti?.type) {
-    keywords.push(personalityData.mbti.type.toLowerCase());
+
+  const verifiedAstrology = extractVerifiedAstrology({ astrologyData });
+  for (const sign of [
+    verifiedAstrology.sun,
+    verifiedAstrology.moon,
+    verifiedAstrology.rising,
+  ]) {
+    if (sign) keywords.push(sign.toLowerCase());
   }
 
-  // Find best matching archetype
-  let bestMatch = archetypes[0];
+  const sun = verifiedAstrology.sun?.toLowerCase();
+  if (sun) {
+    if (["aries", "leo", "sagittarius"].includes(sun)) keywords.push("fire");
+    if (["taurus", "virgo", "capricorn"].includes(sun)) keywords.push("earth");
+    if (["gemini", "libra", "aquarius"].includes(sun)) keywords.push("air");
+    if (["cancer", "scorpio", "pisces"].includes(sun)) keywords.push("water");
+  }
+
+  if (numerologyData?.lifePath !== undefined && numerologyData?.lifePath !== null) {
+    keywords.push(String(numerologyData.lifePath));
+  }
+
+  if (personalityData?.enneagram?.type !== undefined) {
+    keywords.push(String(personalityData.enneagram.type));
+  }
+  if (personalityData?.mbti?.type) {
+    keywords.push(String(personalityData.mbti.type).toLowerCase());
+  }
+
+  let bestMatch: (typeof archetypes)[number] | null = null;
   let maxMatches = 0;
 
   for (const archetype of archetypes) {
-    const matches = archetype.keywords.filter(keyword => 
-      keywords.some(k => k.includes(keyword) || keyword.includes(k))
+    const matches = archetype.keywords.filter((keyword) =>
+      keywords.some((candidate) =>
+        candidate.includes(keyword) || keyword.includes(candidate),
+      ),
     ).length;
-    
+
     if (matches > maxMatches) {
       maxMatches = matches;
       bestMatch = archetype;
     }
   }
+
+  if (!bestMatch || maxMatches === 0) return unresolvedArchetype;
 
   return {
     title: bestMatch.title,
@@ -114,6 +207,6 @@ export function synthesizeArchetype(
     strengths: bestMatch.strengths,
     shadows: bestMatch.shadows,
     themes: bestMatch.themes,
-    guidance: bestMatch.guidance
+    guidance: bestMatch.guidance,
   };
 }

--- a/server/services/astrology-tolerance-policy.ts
+++ b/server/services/astrology-tolerance-policy.ts
@@ -1,4 +1,4 @@
-import type { VerificationPolicy } from "./astrology-verification";
+import type { VerifiableBody, VerificationPolicy } from "./astrology-verification";
 
 export interface EphemerisEvidenceSummary {
   totalRows: number;
@@ -21,12 +21,85 @@ export interface TolerancePolicyProposal {
   rationale: string;
 }
 
+export interface ApprovedToleranceEvidence extends EphemerisEvidenceSummary {
+  receiptRunId: string;
+  artifactId: string;
+  artifactSha256: string;
+  approvedAt: string;
+  approvedBy: string;
+  approvedBodies: readonly VerifiableBody[];
+  coordinateContract: string;
+}
+
 const MINIMUM_EVIDENCE_ROWS = 40;
 const SAFETY_MULTIPLIER = 1.25;
 const ROUNDING_INCREMENT_DEGREES = 0.001;
+const APPROVED_TOLERANCE_DEGREES = 0.001;
+
+export const APPROVED_LONGITUDE_TOLERANCE_EVIDENCE: ApprovedToleranceEvidence = Object.freeze({
+  receiptRunId: "30803626991",
+  artifactId: "8851843885",
+  artifactSha256: "bc23e71ebffe3bb7532b2c511999e2da3ac5ba4af394092dd55c454e40f52d8d",
+  totalRows: 40,
+  signDisagreements: 0,
+  maximumLongitudeDeltaDegrees: 0.0008717338064343494,
+  sunMaximumDeltaDegrees: 0.00027293851550780346,
+  moonMaximumDeltaDegrees: 0.0008717338064343494,
+  approvedAt: "2026-08-03T11:26:00.000Z",
+  approvedBy: "Bboy9090",
+  approvedBodies: Object.freeze(["Sun", "Moon"] as const),
+  coordinateContract:
+    "Astronomy Engine geocentric true-ecliptic-of-date longitude compared with NASA/JPL Horizons geocentric apparent ecliptic-of-date observer quantity 31 at the exact same UTC timestamp.",
+});
 
 function roundUpToIncrement(value: number, increment: number): number {
   return Math.ceil(value / increment) * increment;
+}
+
+function assertApprovedEvidence(evidence: ApprovedToleranceEvidence): void {
+  if (!evidence.receiptRunId.trim() || !evidence.artifactId.trim() || !evidence.artifactSha256.trim()) {
+    throw new Error("approved_policy_evidence_identity_missing");
+  }
+  if (!Number.isInteger(evidence.totalRows) || evidence.totalRows < MINIMUM_EVIDENCE_ROWS) {
+    throw new Error("approved_policy_evidence_rows_insufficient");
+  }
+  if (evidence.signDisagreements !== 0) {
+    throw new Error("approved_policy_sign_disagreement_present");
+  }
+  if (
+    !Number.isFinite(evidence.maximumLongitudeDeltaDegrees) ||
+    evidence.maximumLongitudeDeltaDegrees < 0 ||
+    evidence.maximumLongitudeDeltaDegrees > APPROVED_TOLERANCE_DEGREES
+  ) {
+    throw new Error("approved_policy_observed_delta_invalid");
+  }
+  if (!evidence.approvedAt.trim() || Number.isNaN(new Date(evidence.approvedAt).getTime())) {
+    throw new Error("approved_policy_timestamp_invalid");
+  }
+  if (!evidence.approvedBy.trim()) {
+    throw new Error("approved_policy_approver_missing");
+  }
+  if (!evidence.approvedBodies.includes("Sun") || !evidence.approvedBodies.includes("Moon")) {
+    throw new Error("approved_policy_body_scope_invalid");
+  }
+}
+
+export function getApprovedLongitudeTolerancePolicy(
+  body: VerifiableBody,
+): VerificationPolicy {
+  const evidence = APPROVED_LONGITUDE_TOLERANCE_EVIDENCE;
+  assertApprovedEvidence(evidence);
+
+  if (!evidence.approvedBodies.includes(body)) {
+    throw new Error("body_not_approved_for_longitude_verification");
+  }
+
+  return {
+    status: "approved",
+    policyId: "ASTRO-LONGITUDE-v1",
+    maximumLongitudeDeltaDegrees: APPROVED_TOLERANCE_DEGREES,
+    approvedAt: evidence.approvedAt,
+  };
 }
 
 export function proposeLongitudeTolerancePolicy(
@@ -80,6 +153,6 @@ export function proposeLongitudeTolerancePolicy(
     },
     promotionAllowed: false,
     rationale:
-      "The expanded live matrix supports a draft tolerance only. Explicit governance approval is still required before any placement can be promoted to verified.",
+      "A generated proposal remains draft-only. Production promotion uses the separately governed approved policy and its immutable evidence receipt.",
   };
 }

--- a/server/services/astrology.ts
+++ b/server/services/astrology.ts
@@ -1,7 +1,22 @@
 import { Body, Ecliptic, GeoVector } from "astronomy-engine";
 import { fromZonedTime } from "date-fns-tz";
+import {
+  fetchHorizonsReference,
+  type SupportedHorizonsBody,
+} from "./jpl-horizons-reference";
+import {
+  verifyAgainstIndependentReference,
+  type EphemerisCandidate,
+  type IndependentEphemerisReference,
+  type VerificationPolicy,
+  type VerifiableBody,
+} from "./astrology-verification";
+import {
+  APPROVED_LONGITUDE_TOLERANCE_EVIDENCE,
+  getApprovedLongitudeTolerancePolicy,
+} from "./astrology-tolerance-policy";
 
-interface BirthData {
+export interface BirthData {
   birthDate: string;
   birthTime?: string;
   latitude?: number;
@@ -9,14 +24,14 @@ interface BirthData {
   timezone?: string;
 }
 
-type PlacementStatus =
+export type PlacementStatus =
   | "verified"
   | "calculated_pending_independent_verification"
   | "pending_ephemeris"
   | "requires_verified_birth_time"
   | "requires_location";
 
-interface PlacementCandidate {
+export interface PlacementCandidate {
   sign: string;
   longitude: number;
   source: string;
@@ -25,23 +40,45 @@ interface PlacementCandidate {
   inputTimestamp: string;
 }
 
-interface PlacementVerification {
+export interface PlacementProvenance {
+  source: string;
+  engine: string;
+  calculatedAt: string;
+  inputTimestamp: string;
+  candidateSource: string;
+  candidateEngine: string;
+  candidateCalculatedAt: string;
+  referenceSource: string;
+  referenceEngine: string;
+  referenceCalculatedAt: string;
+  policyId: string;
+  evidenceReceiptId: string;
+  evidenceArtifactId: string;
+  longitudeDeltaDegrees: number;
+}
+
+export interface PlacementVerification {
   sign: string | null;
   status: PlacementStatus;
   confidence: number | null;
   source: string | null;
   reason?: string;
   candidate?: PlacementCandidate;
+  provenance?: PlacementProvenance;
+  verificationFailure?: {
+    reason: string;
+    attemptedAt: string;
+  };
 }
 
-interface AstrologyData {
+export interface AstrologyData {
   sun: PlacementVerification;
   moon: PlacementVerification;
   rising: PlacementVerification;
   planets?: {
     sun?: { sign?: string; house?: number; degree?: number };
     moon?: { sign?: string; house?: number; degree?: number };
-    [key: string]: any;
+    [key: string]: unknown;
   };
   houses?: Array<{ sign?: string; degree?: number }>;
   aspects?: Array<{ planet1: string; planet2: string; aspect: string; orb: number }>;
@@ -50,10 +87,24 @@ interface AstrologyData {
   chiron?: { sign?: string; house?: number; degree?: number };
   verification: {
     complete: boolean;
+    verifiedBodies: VerifiableBody[];
+    unresolvedBodies: string[];
     missingData: string[];
     suggestions: string;
+    policyId: string | null;
+    evidenceReceiptId: string | null;
     lastUpdated: string;
   };
+}
+
+export type IndependentReferenceFetcher = (
+  body: SupportedHorizonsBody,
+  inputTimestamp: string,
+) => Promise<IndependentEphemerisReference>;
+
+export interface VerifiedAstrologyOptions {
+  referenceFetcher?: IndependentReferenceFetcher;
+  policyForBody?: (body: VerifiableBody) => VerificationPolicy;
 }
 
 const ZODIAC_SIGNS = [
@@ -96,9 +147,8 @@ function buildUtcBirthTimestamp(birthData: BirthData, requiresTime: boolean): Da
     return Number.isNaN(zoned.getTime()) ? null : zoned;
   }
 
-  // Date-only Sun calculations remain useful at noon UTC because the Sun moves
-  // roughly one degree per day. Time-sensitive placements remain blocked unless
-  // an explicit timezone is present.
+  // Date-only Sun candidates remain useful for evidence collection, but the
+  // production verifier will not promote them without an explicit time zone.
   if (requiresTime) return null;
   const utc = new Date(`${localTimestamp}Z`);
   return Number.isNaN(utc.getTime()) ? null : utc;
@@ -127,7 +177,8 @@ function pendingCandidatePlacement(candidate: PlacementCandidate): PlacementVeri
     confidence: null,
     source: null,
     candidate,
-    reason: "Calculated by one trusted ephemeris engine; independent comparison is still required before interpretation",
+    reason:
+      "Calculated by one trusted ephemeris engine; independent comparison is still required before interpretation",
   };
 }
 
@@ -227,7 +278,145 @@ function getRisingPlacement(birthData: BirthData): PlacementVerification {
     status: "pending_ephemeris",
     confidence: null,
     source: null,
-    reason: "Ascendant calculation remains intentionally blocked until its formula and independent reference suite are validated",
+    reason:
+      "Ascendant calculation remains intentionally blocked until its formula and independent reference suite are validated",
+  };
+}
+
+function candidateForBody(
+  body: VerifiableBody,
+  placement: PlacementVerification,
+): EphemerisCandidate | null {
+  if (!placement.candidate) return null;
+  return {
+    body,
+    ...placement.candidate,
+  };
+}
+
+function verifiedPlacement(
+  candidate: EphemerisCandidate,
+  reference: IndependentEphemerisReference,
+  result: Extract<ReturnType<typeof verifyAgainstIndependentReference>, { status: "verified" }>,
+): PlacementVerification {
+  const source = `${candidate.source}; independently confirmed by ${reference.source}`;
+  const engine = `${candidate.engine} + ${reference.engine}`;
+
+  return {
+    sign: result.sign,
+    status: "verified",
+    confidence: 1,
+    source,
+    candidate: {
+      sign: candidate.sign,
+      longitude: candidate.longitude,
+      source: candidate.source,
+      engine: candidate.engine,
+      calculatedAt: candidate.calculatedAt,
+      inputTimestamp: candidate.inputTimestamp,
+    },
+    provenance: {
+      source,
+      engine,
+      calculatedAt: result.verifiedAt,
+      inputTimestamp: candidate.inputTimestamp,
+      candidateSource: candidate.source,
+      candidateEngine: candidate.engine,
+      candidateCalculatedAt: candidate.calculatedAt,
+      referenceSource: reference.source,
+      referenceEngine: reference.engine,
+      referenceCalculatedAt: reference.calculatedAt,
+      policyId: result.policyId,
+      evidenceReceiptId: APPROVED_LONGITUDE_TOLERANCE_EVIDENCE.receiptRunId,
+      evidenceArtifactId: APPROVED_LONGITUDE_TOLERANCE_EVIDENCE.artifactId,
+      longitudeDeltaDegrees: result.longitudeDeltaDegrees,
+    },
+    reason:
+      "Astronomical longitude and zodiac sign independently agreed within the approved production tolerance",
+  };
+}
+
+async function verifyPlacement(
+  body: VerifiableBody,
+  placement: PlacementVerification,
+  options: Required<VerifiedAstrologyOptions>,
+): Promise<PlacementVerification> {
+  const candidate = candidateForBody(body, placement);
+  if (!candidate) return placement;
+
+  try {
+    const reference = await options.referenceFetcher(body, candidate.inputTimestamp);
+    const policy = options.policyForBody(body);
+    const result = verifyAgainstIndependentReference(candidate, reference, policy);
+
+    if (result.status === "verified") {
+      return verifiedPlacement(candidate, reference, result);
+    }
+
+    return {
+      ...placement,
+      reason: `Independent verification rejected the candidate: ${result.reason}`,
+      verificationFailure: {
+        reason: result.reason,
+        attemptedAt: new Date().toISOString(),
+      },
+    };
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : "independent_reference_failed";
+    return {
+      ...placement,
+      reason:
+        "Independent verification was unavailable or invalid; the candidate remains withheld from interpretation",
+      verificationFailure: {
+        reason,
+        attemptedAt: new Date().toISOString(),
+      },
+    };
+  }
+}
+
+function buildVerificationSummary(
+  sun: PlacementVerification,
+  moon: PlacementVerification,
+  rising: PlacementVerification,
+  birthData: BirthData,
+): AstrologyData["verification"] {
+  const verifiedBodies: VerifiableBody[] = [];
+  if (sun.status === "verified") verifiedBodies.push("Sun");
+  if (moon.status === "verified") verifiedBodies.push("Moon");
+
+  const unresolvedBodies = [
+    sun.status !== "verified" ? "Sun" : null,
+    moon.status !== "verified" ? "Moon" : null,
+    rising.status !== "verified" ? "Ascendant" : null,
+  ].filter((value): value is string => Boolean(value));
+
+  const missingData: string[] = [];
+  if (!birthData.birthTime) missingData.push("verified_birth_time");
+  if (!birthData.timezone) missingData.push("timezone");
+  if (birthData.latitude === undefined || birthData.longitude === undefined) {
+    missingData.push("precise_location");
+  }
+  if (sun.status !== "verified") missingData.push("independent_sun_verification");
+  if (moon.status !== "verified") missingData.push("independent_moon_verification");
+  if (rising.status !== "verified") missingData.push("validated_ascendant_engine");
+
+  return {
+    complete: unresolvedBodies.length === 0,
+    verifiedBodies,
+    unresolvedBodies,
+    missingData: [...new Set(missingData)],
+    suggestions:
+      unresolvedBodies.length === 0
+        ? "All currently supported placements are verified."
+        : `Verified placements may be interpreted. ${unresolvedBodies.join(", ")} remain paused until their stated requirements pass.`,
+    policyId:
+      verifiedBodies.length > 0 ? "ASTRO-LONGITUDE-v1" : null,
+    evidenceReceiptId:
+      verifiedBodies.length > 0
+        ? APPROVED_LONGITUDE_TOLERANCE_EVIDENCE.receiptRunId
+        : null,
+    lastUpdated: new Date().toISOString(),
   };
 }
 
@@ -235,14 +424,6 @@ export function calculateAstrology(birthData: BirthData): AstrologyData {
   const sun = getSunPlacement(birthData);
   const moon = getMoonPlacement(birthData);
   const rising = getRisingPlacement(birthData);
-
-  const missingData: string[] = [];
-  if (!birthData.birthTime) missingData.push("verified_birth_time");
-  if (!birthData.timezone) missingData.push("timezone");
-  if (birthData.latitude === undefined || birthData.longitude === undefined) missingData.push("precise_location");
-  if (sun.status !== "verified") missingData.push("independent_sun_verification");
-  if (moon.status !== "verified") missingData.push("independent_moon_verification");
-  if (rising.status !== "verified") missingData.push("validated_ascendant_engine");
 
   return {
     sun,
@@ -254,33 +435,119 @@ export function calculateAstrology(birthData: BirthData): AstrologyData {
     northNode: undefined,
     southNode: undefined,
     chiron: undefined,
-    verification: {
-      complete: false,
-      missingData: [...new Set(missingData)],
-      suggestions: "Sun and Moon may carry evidence-bearing candidate calculations, but interpretation remains paused until independent verification. Ascendant remains unresolved until its dedicated validation suite passes.",
-      lastUpdated: new Date().toISOString(),
-    },
+    verification: buildVerificationSummary(sun, moon, rising, birthData),
   };
 }
 
-export function getTarotBirthCards(birthDate: string): { card1: string; card2: string; interpretation: string } {
+export async function calculateVerifiedAstrology(
+  birthData: BirthData,
+  suppliedOptions: VerifiedAstrologyOptions = {},
+): Promise<AstrologyData> {
+  const candidateData = calculateAstrology(birthData);
+
+  // A date-only noon candidate is useful internally, but it cannot become a
+  // production fact without the user's explicit birth time and timezone.
+  const canVerifyTimedPlacements = Boolean(birthData.birthTime && birthData.timezone);
+  if (!canVerifyTimedPlacements) {
+    return {
+      ...candidateData,
+      sun: candidateData.sun.candidate
+        ? {
+            ...candidateData.sun,
+            reason:
+              "A candidate exists, but explicit birth time and timezone are required before production verification",
+          }
+        : candidateData.sun,
+    };
+  }
+
+  const options: Required<VerifiedAstrologyOptions> = {
+    referenceFetcher:
+      suppliedOptions.referenceFetcher ??
+      ((body, inputTimestamp) =>
+        fetchHorizonsReference(body, inputTimestamp, { timeoutMs: 5_000 })),
+    policyForBody:
+      suppliedOptions.policyForBody ?? getApprovedLongitudeTolerancePolicy,
+  };
+
+  const [sun, moon] = await Promise.all([
+    verifyPlacement("Sun", candidateData.sun, options),
+    verifyPlacement("Moon", candidateData.moon, options),
+  ]);
+  const rising = candidateData.rising;
+
+  return {
+    ...candidateData,
+    sun,
+    moon,
+    rising,
+    verification: buildVerificationSummary(sun, moon, rising, birthData),
+  };
+}
+
+export function getTarotBirthCards(
+  birthDate: string,
+): { card1: string; card2: string; interpretation: string } {
   const date = new Date(birthDate);
   const sum = date.getDate() + (date.getMonth() + 1) + date.getFullYear();
-  const digitalRoot = sum.toString().split("").reduce((acc, digit) => acc + parseInt(digit, 10), 0);
-  const finalSum = digitalRoot > 9
-    ? digitalRoot.toString().split("").reduce((acc, digit) => acc + parseInt(digit, 10), 0)
-    : digitalRoot;
+  const digitalRoot = sum
+    .toString()
+    .split("")
+    .reduce((acc, digit) => acc + Number.parseInt(digit, 10), 0);
+  const finalSum =
+    digitalRoot > 9
+      ? digitalRoot
+          .toString()
+          .split("")
+          .reduce((acc, digit) => acc + Number.parseInt(digit, 10), 0)
+      : digitalRoot;
 
   const tarotCards = [
-    { card1: "The Fool", card2: "The World", interpretation: "Journey of infinite potential and cosmic completion" },
-    { card1: "The Magician", card2: "The High Priestess", interpretation: "Balance of conscious will and intuitive wisdom" },
-    { card1: "The Empress", card2: "The Emperor", interpretation: "Creative nurturing paired with structured authority" },
-    { card1: "The Hierophant", card2: "The Lovers", interpretation: "Traditional wisdom meets heart-centered choices" },
-    { card1: "The Chariot", card2: "Strength", interpretation: "Directed willpower flowing through inner courage" },
-    { card1: "The Hermit", card2: "Wheel of Fortune", interpretation: "Inner guidance navigating life's cycles" },
-    { card1: "Justice", card2: "The Hanged Man", interpretation: "Divine balance through surrender and perspective" },
-    { card1: "Death", card2: "Temperance", interpretation: "Transformation through divine alchemy" },
-    { card1: "The Devil", card2: "The Tower", interpretation: "Breaking free from illusion and limitation" },
+    {
+      card1: "The Fool",
+      card2: "The World",
+      interpretation: "Journey of infinite potential and cosmic completion",
+    },
+    {
+      card1: "The Magician",
+      card2: "The High Priestess",
+      interpretation: "Balance of conscious will and intuitive wisdom",
+    },
+    {
+      card1: "The Empress",
+      card2: "The Emperor",
+      interpretation: "Creative nurturing paired with structured authority",
+    },
+    {
+      card1: "The Hierophant",
+      card2: "The Lovers",
+      interpretation: "Traditional wisdom meets heart-centered choices",
+    },
+    {
+      card1: "The Chariot",
+      card2: "Strength",
+      interpretation: "Directed willpower flowing through inner courage",
+    },
+    {
+      card1: "The Hermit",
+      card2: "Wheel of Fortune",
+      interpretation: "Inner guidance navigating life's cycles",
+    },
+    {
+      card1: "Justice",
+      card2: "The Hanged Man",
+      interpretation: "Divine balance through surrender and perspective",
+    },
+    {
+      card1: "Death",
+      card2: "Temperance",
+      interpretation: "Transformation through divine alchemy",
+    },
+    {
+      card1: "The Devil",
+      card2: "The Tower",
+      interpretation: "Breaking free from illusion and limitation",
+    },
   ];
 
   return tarotCards[finalSum % tarotCards.length];

--- a/tests/astrology-production-verification.test.ts
+++ b/tests/astrology-production-verification.test.ts
@@ -1,0 +1,257 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { synthesizeArchetype } from "../server/services/archetype";
+import {
+  calculateAstrology,
+  calculateVerifiedAstrology,
+  type BirthData,
+  type IndependentReferenceFetcher,
+} from "../server/services/astrology";
+import {
+  APPROVED_LONGITUDE_TOLERANCE_EVIDENCE,
+  getApprovedLongitudeTolerancePolicy,
+} from "../server/services/astrology-tolerance-policy";
+import type {
+  IndependentEphemerisReference,
+  VerifiableBody,
+  VerificationPolicy,
+} from "../server/services/astrology-verification";
+
+const birthData: BirthData = {
+  birthDate: "1990-09-17",
+  birthTime: "11:11",
+  timezone: "America/New_York",
+  latitude: 40.8448,
+  longitude: -73.8648,
+};
+
+function matchingReferenceFetcher(delta = 0.0005): IndependentReferenceFetcher {
+  const candidates = calculateAstrology(birthData);
+
+  return async (body, inputTimestamp): Promise<IndependentEphemerisReference> => {
+    const placement = body === "Sun" ? candidates.sun : candidates.moon;
+    assert.ok(placement.candidate, `${body} candidate must exist for the test`);
+    assert.equal(inputTimestamp, placement.candidate.inputTimestamp);
+
+    return {
+      body,
+      sign: placement.candidate.sign,
+      longitude: (placement.candidate.longitude + delta) % 360,
+      source:
+        "NASA/JPL Horizons observer quantity 31: geocentric apparent ecliptic-of-date longitude",
+      engine: "nasa-jpl-horizons-api@1.3",
+      calculatedAt: "2026-08-03T11:30:00.000Z",
+      inputTimestamp,
+    };
+  };
+}
+
+test("the governed policy is approved only for Sun and Moon at 0.001 degrees", () => {
+  const sunPolicy = getApprovedLongitudeTolerancePolicy("Sun");
+  const moonPolicy = getApprovedLongitudeTolerancePolicy("Moon");
+
+  assert.deepEqual(sunPolicy, moonPolicy);
+  assert.equal(sunPolicy.status, "approved");
+  assert.equal(sunPolicy.policyId, "ASTRO-LONGITUDE-v1");
+  assert.equal(sunPolicy.maximumLongitudeDeltaDegrees, 0.001);
+  assert.equal(sunPolicy.approvedAt, "2026-08-03T11:26:00.000Z");
+  assert.equal(APPROVED_LONGITUDE_TOLERANCE_EVIDENCE.totalRows, 40);
+  assert.equal(APPROVED_LONGITUDE_TOLERANCE_EVIDENCE.signDisagreements, 0);
+  assert.ok(
+    APPROVED_LONGITUDE_TOLERANCE_EVIDENCE.maximumLongitudeDeltaDegrees <=
+      sunPolicy.maximumLongitudeDeltaDegrees,
+  );
+});
+
+test("matching independent references promote Sun and Moon with complete provenance", async () => {
+  const result = await calculateVerifiedAstrology(birthData, {
+    referenceFetcher: matchingReferenceFetcher(),
+  });
+
+  for (const [body, placement] of [
+    ["Sun", result.sun],
+    ["Moon", result.moon],
+  ] as const) {
+    assert.equal(placement.status, "verified");
+    assert.ok(placement.sign, `${body} sign should be exposed after verification`);
+    assert.equal(placement.confidence, 1);
+    assert.ok(placement.provenance);
+    assert.equal(placement.provenance.policyId, "ASTRO-LONGITUDE-v1");
+    assert.equal(
+      placement.provenance.evidenceReceiptId,
+      APPROVED_LONGITUDE_TOLERANCE_EVIDENCE.receiptRunId,
+    );
+    assert.equal(
+      placement.provenance.evidenceArtifactId,
+      APPROVED_LONGITUDE_TOLERANCE_EVIDENCE.artifactId,
+    );
+    assert.equal(
+      placement.provenance.inputTimestamp,
+      placement.candidate?.inputTimestamp,
+    );
+    assert.ok(placement.provenance.source);
+    assert.ok(placement.provenance.engine);
+    assert.ok(placement.provenance.calculatedAt);
+    assert.ok(placement.provenance.longitudeDeltaDegrees <= 0.001);
+  }
+
+  assert.deepEqual(result.verification.verifiedBodies, ["Sun", "Moon"]);
+  assert.deepEqual(result.verification.unresolvedBodies, ["Ascendant"]);
+  assert.equal(result.rising.status, "pending_ephemeris");
+  assert.equal(result.rising.sign, null);
+});
+
+test("a sign disagreement leaves the candidate withheld while independent matches may still verify", async () => {
+  const candidates = calculateAstrology(birthData);
+  const signs = [
+    "Aries",
+    "Taurus",
+    "Gemini",
+    "Cancer",
+    "Leo",
+    "Virgo",
+    "Libra",
+    "Scorpio",
+    "Sagittarius",
+    "Capricorn",
+    "Aquarius",
+    "Pisces",
+  ];
+
+  const referenceFetcher: IndependentReferenceFetcher = async (
+    body,
+    inputTimestamp,
+  ) => {
+    const placement = body === "Sun" ? candidates.sun : candidates.moon;
+    assert.ok(placement.candidate);
+    const candidate = placement.candidate;
+    const sign =
+      body === "Sun"
+        ? signs[(signs.indexOf(candidate.sign) + 1) % signs.length]
+        : candidate.sign;
+
+    return {
+      body,
+      sign,
+      longitude: candidate.longitude + 0.0002,
+      source: "NASA/JPL Horizons independent reference",
+      engine: "nasa-jpl-horizons-api@1.3",
+      calculatedAt: "2026-08-03T11:31:00.000Z",
+      inputTimestamp,
+    };
+  };
+
+  const result = await calculateVerifiedAstrology(birthData, {
+    referenceFetcher,
+  });
+
+  assert.equal(result.sun.status, "calculated_pending_independent_verification");
+  assert.equal(result.sun.sign, null);
+  assert.equal(result.sun.verificationFailure?.reason, "sign_disagreement");
+  assert.equal(result.moon.status, "verified");
+  assert.ok(result.moon.sign);
+});
+
+test("reference failure cannot leak a candidate sign into authoritative output", async () => {
+  const result = await calculateVerifiedAstrology(birthData, {
+    referenceFetcher: async () => {
+      throw new Error("horizons_http_503");
+    },
+  });
+
+  for (const placement of [result.sun, result.moon]) {
+    assert.equal(
+      placement.status,
+      "calculated_pending_independent_verification",
+    );
+    assert.equal(placement.sign, null);
+    assert.ok(placement.candidate?.sign);
+    assert.equal(placement.verificationFailure?.reason, "horizons_http_503");
+  }
+});
+
+test("a draft policy cannot promote production candidates", async () => {
+  const draftPolicyForBody = (_body: VerifiableBody): VerificationPolicy => ({
+    status: "draft",
+    policyId: "ASTRO-LONGITUDE-v1-draft",
+    maximumLongitudeDeltaDegrees: 0.001,
+  });
+
+  const result = await calculateVerifiedAstrology(birthData, {
+    referenceFetcher: matchingReferenceFetcher(),
+    policyForBody: draftPolicyForBody,
+  });
+
+  for (const placement of [result.sun, result.moon]) {
+    assert.equal(
+      placement.status,
+      "calculated_pending_independent_verification",
+    );
+    assert.equal(placement.sign, null);
+    assert.equal(placement.verificationFailure?.reason, "policy_not_approved");
+  }
+});
+
+test("missing birth time prevents network verification and leaves timed placements unresolved", async () => {
+  let calls = 0;
+  const result = await calculateVerifiedAstrology(
+    {
+      birthDate: birthData.birthDate,
+      timezone: birthData.timezone,
+      latitude: birthData.latitude,
+      longitude: birthData.longitude,
+    },
+    {
+      referenceFetcher: async () => {
+        calls += 1;
+        throw new Error("should_not_be_called");
+      },
+    },
+  );
+
+  assert.equal(calls, 0);
+  assert.equal(result.sun.sign, null);
+  assert.equal(
+    result.sun.status,
+    "calculated_pending_independent_verification",
+  );
+  assert.match(result.sun.reason ?? "", /birth time and timezone/i);
+  assert.equal(result.moon.status, "requires_verified_birth_time");
+  assert.equal(result.rising.status, "requires_verified_birth_time");
+});
+
+test("legacy astrology labels cannot steer archetype synthesis without verified evidence", () => {
+  const archetype = synthesizeArchetype(
+    {
+      sunSign: "Virgo",
+      moonSign: "Scorpio",
+      risingSign: "Capricorn",
+    },
+    {},
+    {},
+  );
+
+  assert.equal(archetype.title, "Pattern Witness");
+});
+
+test("verified astrology may contribute to archetype synthesis", () => {
+  const archetype = synthesizeArchetype(
+    {
+      sun: {
+        sign: "Virgo",
+        status: "verified",
+        provenance: {
+          source: "Astronomy Engine plus NASA/JPL Horizons",
+          engine: "astronomy-engine@2.1.19 + nasa-jpl-horizons-api@1.3",
+          calculatedAt: "2026-08-03T11:32:00.000Z",
+        },
+      },
+      moon: { sign: null, status: "calculated_pending_independent_verification" },
+      rising: { sign: null, status: "pending_ephemeris" },
+    },
+    {},
+    {},
+  );
+
+  assert.equal(archetype.title, "Sacred Guardian");
+});


### PR DESCRIPTION
## Objective

Complete the evidence-traceable Sun and Moon lane without weakening the uncertainty boundary.

## What this changes

- approves `ASTRO-LONGITUDE-v1` at `0.001°` for Sun and Moon only
- binds approval to the expanded 40-comparison NASA/JPL receipt
- records workflow run, artifact ID, artifact SHA-256, approver, timestamp, coordinate contract, and measured deltas
- performs fresh independent NASA/JPL verification during production profile creation
- promotes a placement only when body, source independence, engine independence, timestamp, sign, and longitude tolerance all pass
- retains full candidate and reference provenance on verified records
- fails closed on network, parsing, policy, sign, or tolerance failure
- keeps Ascendant and houses unresolved
- permits legacy `sunSign` and `moonSign` aliases only after verification; blocked values remain null
- prevents legacy aliases from steering archetype synthesis
- adds regression coverage for promotion, rejection, outages, draft policy refusal, missing time, provenance, Ascendant blocking, and archetype evidence boundaries

## Evidence receipt

- workflow run: `30803626991`
- artifact ID: `8851843885`
- artifact SHA-256: `bc23e71ebffe3bb7532b2c511999e2da3ac5ba4af394092dd55c454e40f52d8d`
- comparisons: `40`
- sign disagreements: `0`
- maximum Sun delta: `0.00027293851550780346°`
- maximum Moon delta: `0.0008717338064343494°`
- approved tolerance: `0.001°`

## Explicit boundaries

This verifies astronomical calculation agreement. It does not claim scientific validation of astrology. It does not approve Ascendant, houses, nodes, Chiron, other celestial bodies, or Human Design calculations.

No placement is inferred from user claims, old fixtures, legacy aliases, or UI text. The system may still say `unresolved`, because that is a product feature rather than an embarrassment humans need to conceal.