### PR TITLE
feat(human-design): enforce unverified candidate boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Run Workspace Tests
         run: npm test
 
-      - name: Run Astrology Trust Tests
+      - name: Run Trust Boundary Tests
         run: >-
           node --import tsx --test
           tests/astrology-candidate.test.ts
@@ -44,6 +44,7 @@ jobs:
           tests/astrology-evidence-matrix.test.ts
           tests/astrology-tolerance-policy.test.ts
           tests/astrology-production-verification.test.ts
+          tests/human-design-trust.test.ts
 
       - name: Build Application
         run: npm run build

--- a/server/services/human-design-trust.ts
+++ b/server/services/human-design-trust.ts
@@ -1,0 +1,109 @@
+export type HumanDesignVerificationStatus =
+  | "unresolved"
+  | "calculated_unverified"
+  | "verified";
+
+export type HumanDesignCoreField = "type" | "strategy" | "authority" | "profile";
+
+export interface HumanDesignCandidateEvidence {
+  status: "calculated_unverified";
+  engine: "soulcodex-hd-candidate-v0";
+  source: "Soul Codex deterministic Human Design candidate engine";
+  calculatedAt: string;
+  inputTimestampUtc: string;
+  birthTimeKnown: true;
+  candidate: Partial<Record<HumanDesignCoreField, string>>;
+  limitations: readonly string[];
+}
+
+export interface HumanDesignUnresolvedEvidence {
+  status: "unresolved";
+  engine: null;
+  source: null;
+  calculatedAt: null;
+  inputTimestampUtc: null;
+  birthTimeKnown: false;
+  candidate: Record<string, never>;
+  limitations: readonly string[];
+}
+
+export type HumanDesignTrustRecord =
+  | HumanDesignCandidateEvidence
+  | HumanDesignUnresolvedEvidence;
+
+const UNVERIFIED_LIMITATIONS = Object.freeze([
+  "Human Design output has not passed an independent reference comparison.",
+  "Advanced values such as variables and incarnation cross are not authoritative.",
+  "Candidate fields must not drive compatibility scores or interpretation as verified facts.",
+]);
+
+function isValidIsoTimestamp(value: string): boolean {
+  return Boolean(value.trim()) && !Number.isNaN(new Date(value).getTime());
+}
+
+export function createHumanDesignTrustRecord(input: {
+  birthTimeKnown: boolean;
+  inputTimestampUtc?: string | null;
+  calculatedAt?: string;
+  candidate?: Partial<Record<HumanDesignCoreField, string>> | null;
+}): HumanDesignTrustRecord {
+  if (!input.birthTimeKnown || !input.inputTimestampUtc) {
+    return {
+      status: "unresolved",
+      engine: null,
+      source: null,
+      calculatedAt: null,
+      inputTimestampUtc: null,
+      birthTimeKnown: false,
+      candidate: {},
+      limitations: Object.freeze([
+        "Exact birth time and timezone are required for Human Design calculation.",
+        ...UNVERIFIED_LIMITATIONS,
+      ]),
+    };
+  }
+
+  if (!isValidIsoTimestamp(input.inputTimestampUtc)) {
+    throw new Error("human_design_input_timestamp_invalid");
+  }
+
+  const calculatedAt = input.calculatedAt ?? new Date().toISOString();
+  if (!isValidIsoTimestamp(calculatedAt)) {
+    throw new Error("human_design_calculation_timestamp_invalid");
+  }
+
+  const candidate = Object.fromEntries(
+    Object.entries(input.candidate ?? {}).filter(
+      ([, value]) => typeof value === "string" && value.trim().length > 0,
+    ),
+  ) as Partial<Record<HumanDesignCoreField, string>>;
+
+  return {
+    status: "calculated_unverified",
+    engine: "soulcodex-hd-candidate-v0",
+    source: "Soul Codex deterministic Human Design candidate engine",
+    calculatedAt,
+    inputTimestampUtc: input.inputTimestampUtc,
+    birthTimeKnown: true,
+    candidate,
+    limitations: UNVERIFIED_LIMITATIONS,
+  };
+}
+
+export function getVerifiedHumanDesignField(
+  record: HumanDesignTrustRecord,
+  field: HumanDesignCoreField,
+): string | null {
+  if (record.status !== "verified") {
+    return null;
+  }
+
+  const value = (record as HumanDesignCandidateEvidence).candidate[field];
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+export function mayUseHumanDesignForCompatibility(
+  record: HumanDesignTrustRecord,
+): boolean {
+  return record.status === "verified";
+}

--- a/server/services/human-design-trust.ts
+++ b/server/services/human-design-trust.ts
@@ -5,18 +5,36 @@ export type HumanDesignVerificationStatus =
 
 export type HumanDesignCoreField = "type" | "strategy" | "authority" | "profile";
 
-export interface HumanDesignCandidateEvidence {
+type HumanDesignCandidateFields = Partial<Record<HumanDesignCoreField, string>>;
+
+interface HumanDesignEvidenceBase {
+  limitations: readonly string[];
+}
+
+export interface HumanDesignCandidateEvidence extends HumanDesignEvidenceBase {
   status: "calculated_unverified";
   engine: "soulcodex-hd-candidate-v0";
   source: "Soul Codex deterministic Human Design candidate engine";
   calculatedAt: string;
   inputTimestampUtc: string;
   birthTimeKnown: true;
-  candidate: Partial<Record<HumanDesignCoreField, string>>;
-  limitations: readonly string[];
+  candidate: HumanDesignCandidateFields;
 }
 
-export interface HumanDesignUnresolvedEvidence {
+export interface HumanDesignVerifiedEvidence extends HumanDesignEvidenceBase {
+  status: "verified";
+  engine: string;
+  source: string;
+  calculatedAt: string;
+  inputTimestampUtc: string;
+  birthTimeKnown: true;
+  candidate: HumanDesignCandidateFields;
+  verificationReceiptId: string;
+  independentSource: string;
+  verifiedAt: string;
+}
+
+export interface HumanDesignUnresolvedEvidence extends HumanDesignEvidenceBase {
   status: "unresolved";
   engine: null;
   source: null;
@@ -24,11 +42,11 @@ export interface HumanDesignUnresolvedEvidence {
   inputTimestampUtc: null;
   birthTimeKnown: false;
   candidate: Record<string, never>;
-  limitations: readonly string[];
 }
 
 export type HumanDesignTrustRecord =
   | HumanDesignCandidateEvidence
+  | HumanDesignVerifiedEvidence
   | HumanDesignUnresolvedEvidence;
 
 const UNVERIFIED_LIMITATIONS = Object.freeze([
@@ -45,7 +63,7 @@ export function createHumanDesignTrustRecord(input: {
   birthTimeKnown: boolean;
   inputTimestampUtc?: string | null;
   calculatedAt?: string;
-  candidate?: Partial<Record<HumanDesignCoreField, string>> | null;
+  candidate?: HumanDesignCandidateFields | null;
 }): HumanDesignTrustRecord {
   if (!input.birthTimeKnown || !input.inputTimestampUtc) {
     return {
@@ -76,7 +94,7 @@ export function createHumanDesignTrustRecord(input: {
     Object.entries(input.candidate ?? {}).filter(
       ([, value]) => typeof value === "string" && value.trim().length > 0,
     ),
-  ) as Partial<Record<HumanDesignCoreField, string>>;
+  ) as HumanDesignCandidateFields;
 
   return {
     status: "calculated_unverified",
@@ -98,7 +116,7 @@ export function getVerifiedHumanDesignField(
     return null;
   }
 
-  const value = (record as HumanDesignCandidateEvidence).candidate[field];
+  const value = record.candidate[field];
   return typeof value === "string" && value.trim() ? value : null;
 }
 

--- a/tests/human-design-trust.test.ts
+++ b/tests/human-design-trust.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createHumanDesignTrustRecord,
+  getVerifiedHumanDesignField,
+  mayUseHumanDesignForCompatibility,
+} from "../server/services/human-design-trust";
+
+test("unknown birth time keeps Human Design unresolved", () => {
+  const record = createHumanDesignTrustRecord({ birthTimeKnown: false });
+
+  assert.equal(record.status, "unresolved");
+  assert.equal(record.engine, null);
+  assert.equal(getVerifiedHumanDesignField(record, "type"), null);
+  assert.equal(mayUseHumanDesignForCompatibility(record), false);
+});
+
+test("calculated values remain candidates rather than authoritative facts", () => {
+  const record = createHumanDesignTrustRecord({
+    birthTimeKnown: true,
+    inputTimestampUtc: "1990-09-17T15:11:00.000Z",
+    calculatedAt: "2026-08-03T16:00:00.000Z",
+    candidate: {
+      type: "Reflector",
+      strategy: "Wait a lunar cycle",
+      authority: "Lunar Authority",
+      profile: "2/5",
+    },
+  });
+
+  assert.equal(record.status, "calculated_unverified");
+  assert.equal(record.candidate.type, "Reflector");
+  assert.equal(getVerifiedHumanDesignField(record, "type"), null);
+  assert.equal(getVerifiedHumanDesignField(record, "authority"), null);
+  assert.equal(mayUseHumanDesignForCompatibility(record), false);
+  assert.match(record.limitations.join(" "), /independent reference comparison/i);
+});
+
+test("invalid timestamps fail closed", () => {
+  assert.throws(
+    () =>
+      createHumanDesignTrustRecord({
+        birthTimeKnown: true,
+        inputTimestampUtc: "not-a-date",
+        candidate: { type: "Generator" },
+      }),
+    /human_design_input_timestamp_invalid/,
+  );
+});
+
+test("blank candidate strings are discarded", () => {
+  const record = createHumanDesignTrustRecord({
+    birthTimeKnown: true,
+    inputTimestampUtc: "1990-09-17T15:11:00.000Z",
+    calculatedAt: "2026-08-03T16:00:00.000Z",
+    candidate: { type: "   ", profile: "2/5" },
+  });
+
+  assert.equal(record.status, "calculated_unverified");
+  assert.equal(record.candidate.type, undefined);
+  assert.equal(record.candidate.profile, "2/5");
+});


### PR DESCRIPTION
## Objective

Stop Human Design calculations from being treated as verified identity facts before an independent reference lane exists.

## What this adds

- explicit `unresolved`, `calculated_unverified`, and `verified` trust states
- exact birth-time requirement for calculation eligibility
- source, engine, calculation timestamp, and UTC input provenance
- candidate-only storage for Type, Strategy, Authority, and Profile
- verified-field accessor that returns `null` for every unverified state
- compatibility gate that excludes Human Design until verification is explicit
- visible limitations covering independent comparison, advanced values, and interpretation use
- CI regression tests for unknown time, candidate refusal, timestamp validation, blank data, and compatibility exclusion

## Important boundary

This does not claim Human Design is scientifically validated, and it does not claim the current calculation engine agrees with an independent implementation. It prevents the existing engine from being promoted merely because it produced familiar-looking output.

## Diamond line

Clarity over volume. Useful depth without confidence theater. The system is allowed to say the Human Design result is not verified yet instead of handing the user a polished guess wearing ceremonial robes.