### PR TITLE
fix(profile): migrate saved profiles to verified Ascendant

### DIFF
--- a/client/src/lib/profileVerificationReconciliation.ts
+++ b/client/src/lib/profileVerificationReconciliation.ts
@@ -6,6 +6,8 @@ type PlacementRecord = {
   sign?: string | null;
 };
 
+export const CURRENT_ASTROLOGY_VERIFICATION_VERSION = 2;
+
 export type RemoteProfileSnapshot = {
   id?: string;
   name?: string;
@@ -41,6 +43,7 @@ export type ReconciledOfflineProfile = OfflineCodexProfile & {
     remoteId: string;
     syncedAt: string;
     status: "verified-online";
+    verificationVersion?: number;
   };
 };
 
@@ -61,6 +64,26 @@ export function hasVerifiedSunAndMoon(
   return Boolean(
     getVerifiedAstrologySign(astrology, "sun") &&
       getVerifiedAstrologySign(astrology, "moon"),
+  );
+}
+
+export function hasVerifiedBigThree(
+  astrology: RemoteProfileSnapshot["astrologyData"] | undefined,
+): boolean {
+  return Boolean(
+    hasVerifiedSunAndMoon(astrology) &&
+      getVerifiedAstrologySign(astrology, "rising"),
+  );
+}
+
+function hasExactAscendantInputs(profile: ReconciledOfflineProfile): boolean {
+  return Boolean(
+    profile.birthTime &&
+      profile.timezone &&
+      profile.latitude !== null &&
+      profile.latitude !== undefined &&
+      profile.longitude !== null &&
+      profile.longitude !== undefined,
   );
 }
 
@@ -105,6 +128,7 @@ export function reconcileActiveProfile(
         ? local.confidence
         : {}),
       astrologyVerification: astrology?.verification ?? null,
+      astrologyVerificationVersion: CURRENT_ASTROLOGY_VERIFICATION_VERSION,
       remoteSyncedAt: syncedAt,
     },
     updatedAt: syncedAt,
@@ -133,6 +157,7 @@ export function reconcileOfflineProfile(
       remoteId,
       syncedAt,
       status: "verified-online",
+      verificationVersion: CURRENT_ASTROLOGY_VERIFICATION_VERSION,
     },
     updatedAt: syncedAt,
   };
@@ -141,5 +166,15 @@ export function reconcileOfflineProfile(
 export function profileNeedsOnlineVerification(
   profile: ReconciledOfflineProfile,
 ): boolean {
-  return !hasVerifiedSunAndMoon(profile.verifiedAstrologyData);
+  if (!hasVerifiedSunAndMoon(profile.verifiedAstrologyData)) {
+    return true;
+  }
+
+  const syncedVersion = profile.remoteSync?.verificationVersion ?? 1;
+  const needsAscendantMigration =
+    hasExactAscendantInputs(profile) &&
+    syncedVersion < CURRENT_ASTROLOGY_VERIFICATION_VERSION &&
+    !getVerifiedAstrologySign(profile.verifiedAstrologyData, "rising");
+
+  return needsAscendantMigration;
 }

--- a/tests/profile-verification-reconciliation.test.ts
+++ b/tests/profile-verification-reconciliation.test.ts
@@ -2,11 +2,14 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { generateOfflineCodexProfile } from "../packages/core/offline-codex/index.ts";
 import {
+  CURRENT_ASTROLOGY_VERIFICATION_VERSION,
   getVerifiedAstrologySign,
+  hasVerifiedBigThree,
   hasVerifiedSunAndMoon,
   profileNeedsOnlineVerification,
   reconcileActiveProfile,
   reconcileOfflineProfile,
+  type ReconciledOfflineProfile,
 } from "../client/src/lib/profileVerificationReconciliation.ts";
 
 const local = generateOfflineCodexProfile(
@@ -32,20 +35,32 @@ const verifiedRemote = {
   astrologyData: {
     sun: { status: "verified", sign: "Virgo" },
     moon: { status: "verified", sign: "Scorpio" },
-    rising: { status: "pending_ephemeris", sign: null },
+    rising: { status: "verified", sign: "Scorpio" },
     // Legacy aliases cannot bypass the nested verification state.
     sunSign: "Aries",
     moonSign: "Gemini",
     risingSign: "Capricorn",
     verification: {
-      verifiedBodies: ["Sun", "Moon"],
-      policyId: "ASTRO-LONGITUDE-v1",
+      verifiedBodies: ["Sun", "Moon", "Ascendant"],
+      policyId: "ASTRO-LONGITUDE-v1 + ASTRO-ASCENDANT-v1",
     },
   },
   numerologyData: local.numerologyData,
   archetypeData: {
     ...local.archetypeData,
     title: "Evidence-Cleared Guardian",
+  },
+};
+
+const preAscendantRemote = {
+  ...verifiedRemote,
+  astrologyData: {
+    ...verifiedRemote.astrologyData,
+    rising: { status: "pending_ephemeris", sign: null },
+    verification: {
+      verifiedBodies: ["Sun", "Moon"],
+      policyId: "ASTRO-LONGITUDE-v1",
+    },
   },
 };
 
@@ -67,16 +82,20 @@ test("verified remote placements replace legacy active aliases without changing 
       archetype: local.archetypeData.title,
     },
     verifiedRemote,
-    "2026-08-03T23:00:00.000Z",
+    "2026-08-04T04:30:00.000Z",
   );
 
   assert.equal(active.id, "local-robert");
   assert.equal(active.remoteId, "remote-robert");
   assert.equal(active.sunSign, "Virgo");
   assert.equal(active.moonSign, "Scorpio");
-  assert.equal(active.risingSign, null);
+  assert.equal(active.risingSign, "Scorpio");
   assert.equal(active.timezone, "America/New_York");
   assert.equal(active.archetype, "Evidence-Cleared Guardian");
+  assert.equal(
+    (active.confidence as Record<string, unknown>).astrologyVerificationVersion,
+    CURRENT_ASTROLOGY_VERIFICATION_VERSION,
+  );
 });
 
 test("unverified nested placements never inherit populated legacy aliases", () => {
@@ -91,21 +110,75 @@ test("unverified nested placements never inherit populated legacy aliases", () =
 
   assert.equal(getVerifiedAstrologySign(astrology, "sun"), null);
   assert.equal(getVerifiedAstrologySign(astrology, "moon"), null);
+  assert.equal(getVerifiedAstrologySign(astrology, "rising"), null);
   assert.equal(hasVerifiedSunAndMoon(astrology), false);
+  assert.equal(hasVerifiedBigThree(astrology), false);
 });
 
-test("offline profile keeps its local chart while carrying a separate verified overlay", () => {
+test("offline profile keeps its local chart while carrying a separate verified Big Three overlay", () => {
   const hydrated = reconcileOfflineProfile(
     local,
     verifiedRemote,
-    "2026-08-03T23:00:00.000Z",
+    "2026-08-04T04:30:00.000Z",
   );
 
   assert.equal(hydrated.astrologyData.sunSign, local.astrologyData.sunSign);
   assert.equal(hydrated.verifiedAstrologyData?.sun?.status, "verified");
   assert.equal(hydrated.verifiedAstrologyData?.moon?.status, "verified");
+  assert.equal(hydrated.verifiedAstrologyData?.rising?.status, "verified");
   assert.equal(hydrated.remoteSync?.remoteId, "remote-robert");
   assert.equal(hydrated.remoteSync?.status, "verified-online");
+  assert.equal(
+    hydrated.remoteSync?.verificationVersion,
+    CURRENT_ASTROLOGY_VERIFICATION_VERSION,
+  );
   assert.equal(hydrated.archetypeData.title, "Evidence-Cleared Guardian");
+  assert.equal(hasVerifiedBigThree(hydrated.verifiedAstrologyData), true);
   assert.equal(profileNeedsOnlineVerification(hydrated), false);
+});
+
+test("a profile synchronized before Ascendant support refreshes exactly once when raw inputs exist", () => {
+  const legacyHydrated = {
+    ...local,
+    verifiedAstrologyData: preAscendantRemote.astrologyData,
+    remoteSync: {
+      remoteId: "remote-robert",
+      syncedAt: "2026-08-03T23:00:00.000Z",
+      status: "verified-online" as const,
+    },
+  } satisfies ReconciledOfflineProfile;
+
+  assert.equal(hasVerifiedSunAndMoon(legacyHydrated.verifiedAstrologyData), true);
+  assert.equal(hasVerifiedBigThree(legacyHydrated.verifiedAstrologyData), false);
+  assert.equal(profileNeedsOnlineVerification(legacyHydrated), true);
+
+  const migrated = reconcileOfflineProfile(
+    legacyHydrated,
+    verifiedRemote,
+    "2026-08-04T04:30:00.000Z",
+  );
+
+  assert.equal(migrated.verifiedAstrologyData?.rising?.sign, "Scorpio");
+  assert.equal(
+    migrated.remoteSync?.verificationVersion,
+    CURRENT_ASTROLOGY_VERIFICATION_VERSION,
+  );
+  assert.equal(profileNeedsOnlineVerification(migrated), false);
+});
+
+test("missing exact Ascendant inputs do not create an endless migration loop", () => {
+  const legacyWithoutCoordinates = {
+    ...local,
+    latitude: null,
+    longitude: null,
+    verifiedAstrologyData: preAscendantRemote.astrologyData,
+    remoteSync: {
+      remoteId: "remote-robert",
+      syncedAt: "2026-08-03T23:00:00.000Z",
+      status: "verified-online" as const,
+    },
+  } satisfies ReconciledOfflineProfile;
+
+  assert.equal(hasVerifiedSunAndMoon(legacyWithoutCoordinates.verifiedAstrologyData), true);
+  assert.equal(profileNeedsOnlineVerification(legacyWithoutCoordinates), false);
 });


### PR DESCRIPTION
## Root cause after the Ascendant engine merged

PR #159 made the server capable of returning a verified Rising sign, but profiles already synchronized under PR #158 had a subtle migration trap: the client considered Sun + Moon sufficient and would not request verification again. So an existing user could remain stuck on `Rising unresolved` forever while every newly created profile worked correctly. Software loves leaving one chair missing after announcing the dining room is finished.

## Fix

- adds an explicit astrology verification schema version
- marks newly reconciled profiles as verification version 2
- detects pre-Ascendant synchronized profiles
- requests one migration refresh when exact birth time, timezone, latitude, and longitude exist
- merges the verified Rising result into the same local and active profile
- preserves local IDs and offline data
- avoids endless refresh loops when exact Ascendant inputs are unavailable
- adds Big Three verification helpers and regression coverage

## Acceptance target

Existing saved profile with verified Sun/Moon + exact raw birth inputs:

`open Identity → detect old verification version → refresh production profile → merge verified Rising → stop retrying`

No profile recreation and no hardcoded sign.