### PR TITLE
test(astrology): lock Bobby's correct verified Big Three

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
           tests/astrology-tolerance-policy.test.ts
           tests/astrology-production-verification.test.ts
           tests/ascendant-verification.test.ts
+          tests/bobby-big-three-golden.test.ts
           tests/human-design-trust.test.ts
           tests/profile-verification-reconciliation.test.ts
 

--- a/tests/bobby-big-three-golden.test.ts
+++ b/tests/bobby-big-three-golden.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  calculateVerifiedAstrology,
+  type BirthData,
+} from "../server/services/astrology-production";
+import type { IndependentReferenceFetcher } from "../server/services/astrology";
+import type {
+  IndependentEphemerisReference,
+  VerifiableBody,
+} from "../server/services/astrology-verification";
+
+const BOBBY_RAW_BIRTH_INPUT: BirthData = {
+  birthDate: "1990-09-17",
+  birthTime: "11:11",
+  timezone: "America/New_York",
+  latitude: 40.8448,
+  longitude: -73.8648,
+};
+
+const SWISS_EPHEMERIS_REFERENCE: Record<
+  VerifiableBody,
+  { sign: "Virgo"; longitude: number }
+> = {
+  Sun: {
+    sign: "Virgo",
+    longitude: 174.4712502800783,
+  },
+  Moon: {
+    sign: "Virgo",
+    longitude: 157.6363960284451,
+  },
+};
+
+const referenceFetcher: IndependentReferenceFetcher = async (
+  body,
+  inputTimestamp,
+): Promise<IndependentEphemerisReference> => ({
+  body,
+  sign: SWISS_EPHEMERIS_REFERENCE[body].sign,
+  longitude: SWISS_EPHEMERIS_REFERENCE[body].longitude,
+  source:
+    "Swiss Ephemeris 2.10.03 geocentric tropical longitude golden fixture",
+  engine: "swisseph@2.10.03",
+  calculatedAt: "2026-08-04T04:35:00.000Z",
+  inputTimestamp,
+});
+
+test("Bobby's raw birth inputs verify as Virgo Sun, Virgo Moon, and Scorpio Rising", async () => {
+  const result = await calculateVerifiedAstrology(BOBBY_RAW_BIRTH_INPUT, {
+    referenceFetcher,
+  });
+
+  assert.equal(result.sun.status, "verified");
+  assert.equal(result.sun.sign, "Virgo");
+  assert.equal(result.sun.candidate?.inputTimestamp, "1990-09-17T15:11:00.000Z");
+  assert.ok(result.sun.provenance);
+  assert.ok(result.sun.provenance.longitudeDeltaDegrees <= 0.001);
+
+  assert.equal(result.moon.status, "verified");
+  assert.equal(result.moon.sign, "Virgo");
+  assert.equal(result.moon.candidate?.inputTimestamp, "1990-09-17T15:11:00.000Z");
+  assert.ok(result.moon.provenance);
+  assert.ok(result.moon.provenance.longitudeDeltaDegrees <= 0.001);
+
+  assert.equal(result.rising.status, "verified");
+  assert.equal(result.rising.sign, "Scorpio");
+  assert.equal(result.rising.candidate?.inputTimestamp, "1990-09-17T15:11:00.000Z");
+  assert.ok(result.rising.candidate);
+  assert.ok(result.rising.candidate.longitude > 227.3);
+  assert.ok(result.rising.candidate.longitude < 227.33);
+  assert.ok(result.rising.provenance);
+  assert.equal(result.rising.provenance.policyId, "ASTRO-ASCENDANT-v1");
+  assert.ok(result.rising.provenance.longitudeDeltaDegrees <= 0.01);
+
+  assert.equal(result.verification.complete, true);
+  assert.deepEqual(result.verification.unresolvedBodies, []);
+});

--- a/tests/profile-verification-reconciliation.test.ts
+++ b/tests/profile-verification-reconciliation.test.ts
@@ -34,7 +34,7 @@ const verifiedRemote = {
   name: "Robert Example",
   astrologyData: {
     sun: { status: "verified", sign: "Virgo" },
-    moon: { status: "verified", sign: "Scorpio" },
+    moon: { status: "verified", sign: "Virgo" },
     rising: { status: "verified", sign: "Scorpio" },
     // Legacy aliases cannot bypass the nested verification state.
     sunSign: "Aries",
@@ -88,7 +88,7 @@ test("verified remote placements replace legacy active aliases without changing 
   assert.equal(active.id, "local-robert");
   assert.equal(active.remoteId, "remote-robert");
   assert.equal(active.sunSign, "Virgo");
-  assert.equal(active.moonSign, "Scorpio");
+  assert.equal(active.moonSign, "Virgo");
   assert.equal(active.risingSign, "Scorpio");
   assert.equal(active.timezone, "America/New_York");
   assert.equal(active.archetype, "Evidence-Cleared Guardian");
@@ -125,7 +125,9 @@ test("offline profile keeps its local chart while carrying a separate verified B
   assert.equal(hydrated.astrologyData.sunSign, local.astrologyData.sunSign);
   assert.equal(hydrated.verifiedAstrologyData?.sun?.status, "verified");
   assert.equal(hydrated.verifiedAstrologyData?.moon?.status, "verified");
+  assert.equal(hydrated.verifiedAstrologyData?.moon?.sign, "Virgo");
   assert.equal(hydrated.verifiedAstrologyData?.rising?.status, "verified");
+  assert.equal(hydrated.verifiedAstrologyData?.rising?.sign, "Scorpio");
   assert.equal(hydrated.remoteSync?.remoteId, "remote-robert");
   assert.equal(hydrated.remoteSync?.status, "verified-online");
   assert.equal(
@@ -158,6 +160,7 @@ test("a profile synchronized before Ascendant support refreshes exactly once whe
     "2026-08-04T04:30:00.000Z",
   );
 
+  assert.equal(migrated.verifiedAstrologyData?.moon?.sign, "Virgo");
   assert.equal(migrated.verifiedAstrologyData?.rising?.sign, "Scorpio");
   assert.equal(
     migrated.remoteSync?.verificationVersion,


### PR DESCRIPTION
## Why this exists

The production engines were fixed, but one reconciliation test fixture still carried the old incorrect Scorpio Moon value for Bobby's raw Bronx birth inputs. Test data is supposed to stop regressions, not preserve them in amber like a tiny software mosquito.

## Correct golden result

For `1990-09-17 11:11 America/New_York`, Bronx coordinates:

- Sun: Virgo
- Moon: Virgo
- Rising: Scorpio

## What changes

- corrects the reconciliation fixture from Scorpio Moon to Virgo Moon
- adds a dedicated production golden test using fixed Swiss Ephemeris 2.10.03 Sun/Moon longitudes
- requires the production verifier to expose Virgo Sun, Virgo Moon, and Scorpio Rising
- checks the exact UTC conversion `1990-09-17T15:11:00.000Z`
- checks the approved Sun/Moon and Ascendant tolerances and provenance
- runs the golden fixture in the permanent trust-boundary CI lane

No production result is hardcoded. The expected values are independent regression references used to catch future calculation, timezone, or profile-reconciliation drift.