### PR TITLE
governance: establish the Foundation web release candidate gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,9 @@
 # DEMO MODE NOTE:
 #   Omitting DATABASE_URL runs the active Foundation server with MemStorage.
 #   Server-side profiles will be lost on restart. Local-first browser profiles
-#   remain on the user's device.
+#   remain on the user's device. Billing stays disabled in this mode because a
+#   paid entitlement must survive a process restart. Humanity has invented
+#   enough ways to lose receipts already.
 #
 
 # Server Configuration
@@ -27,13 +29,14 @@ PUBLIC_APP_URL=http://localhost:5000
 # stack is deliberately reconciled with the active server.
 # SESSION_SECRET=generate_a_strong_random_value
 
-# Database (PostgreSQL - recommended for persistent server storage)
+# Database (PostgreSQL - required before secure billing can be enabled)
 # DATABASE_URL=postgresql://user:password@host:port/database
 
 # ------------------------------------------------------------------
 # Secure billing through hosted Stripe Checkout
 # Soul Codex must never collect card numbers, CVC/CVV, or expiry dates.
-# All four values are required before /api/billing/status reports enabled=true.
+# DATABASE_URL plus all four values below are required before
+# /api/billing/status reports enabled=true.
 # ------------------------------------------------------------------
 # STRIPE_SECRET_KEY=sk_test_...
 # STRIPE_PRICE_ID=price_...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
           tests/profile-verification-reconciliation.test.ts
           tests/billing-security.test.ts
 
+      - name: Run Foundation Web RC Invariant Audit
+        run: node scripts/verify-foundation-web-rc.mjs
+
       - name: Build Application
         run: npm run build
 

--- a/.github/workflows/pwa-offline-browser.yml
+++ b/.github/workflows/pwa-offline-browser.yml
@@ -5,13 +5,18 @@ on:
     branches: ["main", "master"]
     paths:
       - "client/**"
+      - "server/**"
       - "packages/core/**"
       - "public/**"
+      - "governance/FOUNDATION-WEB-RELEASE-v1.md"
+      - "governance/release-audits/FOUNDATION-WEB-RC-RECEIPT-v1.md"
       - "scripts/generate-pwa-service-worker.mjs"
       - "scripts/validate-pwa-output.mjs"
+      - "scripts/verify-foundation-web-rc.mjs"
       - "tests/pwa/**"
       - "package.json"
       - "package-lock.json"
+      - ".github/workflows/ci.yml"
       - ".github/workflows/pwa-offline-browser.yml"
   workflow_dispatch:
 

--- a/governance/FOUNDATION-WEB-RELEASE-v1.md
+++ b/governance/FOUNDATION-WEB-RELEASE-v1.md
@@ -1,0 +1,155 @@
+# Soul Codex Foundation Web Release v1
+
+## Mission
+
+Ship a trustworthy web-first Soul Codex Foundation that lets a person create one persistent profile, receive an evidence-traceable reading, inspect uncertainty, use Timeline and Compatibility without rebuilding themselves, and return after refresh, restart, or temporary loss of network access.
+
+Canonical promise:
+
+> Understand your patterns. Inspect the reasoning. Track the change. Make better decisions.
+
+## Product standard
+
+Depth must create clarity, not volume.
+
+Every major reading should explain:
+
+1. the pattern;
+2. the mechanism;
+3. the protective function or need beneath it;
+4. how it may be perceived by others;
+5. the gift;
+6. the cost when overused;
+7. one grounded next action;
+8. the evidence, calculation, uncertainty, and limitation behind the claim.
+
+## Included web scope
+
+- One local-first profile reused across Identity, Reading, Timeline, and Compatibility
+- Verified tropical Sun, Moon, and Ascendant when exact required inputs are present
+- Evidence drawer and Essential, Complete, and Technical reading modes
+- Explicit unresolved states instead of guessed placements
+- Deterministic numerology and Timeline cycles
+- Compatibility dimensions covering attraction, emotional fit, intellectual fit, friendship, friction, repair, and growth potential
+- Browser refresh and restart persistence
+- Chromium and WebKit offline restart support
+- Production container validation
+- Dependency security gates
+- Hosted Stripe Checkout boundary with no direct card-data handling
+- Web security headers, rate limiting, no-referrer policy, and non-cacheable API responses
+
+## Deliberately excluded from Foundation v1
+
+The following outputs must not be promoted merely because an old or approximate code path can produce something that looks impressive:
+
+- Astrological houses and Midheaven
+- Nodes, Chiron, planetary house placements, and house-based interpretation
+- Human Design as verified identity fact or compatibility input
+- Human Design variables, incarnation cross, Gene Keys, or derivative interpretation
+- Behavioral prediction engine
+- Companion memory
+- Soul Replay
+- Enterprise HIOS modules
+- Journal intelligence
+- Full relationship graph
+
+These may return only an explicit unresolved or calculated-unverified state until their own independent evidence contract passes.
+
+## Owner-deferred platform scope
+
+The owner has paused these lanes until explicit approval to resume:
+
+- iOS App Store packaging, submission, and validation
+- Google Play packaging, submission, and validation
+
+A pending or failed native-store check does not block this web release. Native source work must not be restarted merely because an automated platform integration makes noise in the distance, as automated platform integrations are known to do.
+
+## Release gates
+
+### Gate A: Trust
+
+- Calculated facts are never altered by AI.
+- Interpretation cannot create or upgrade verification state.
+- Verified Sun, Moon, and Ascendant retain source, engine, UTC input, timestamps, policy, and evidence receipt.
+- Unknown birth time or missing coordinates produce partial output rather than fabricated precision.
+- Human Design remains excluded from compatibility and authoritative interpretation until independently verified.
+- Legacy aliases cannot bypass nested verification state.
+
+### Gate B: One profile
+
+A real user can:
+
+1. create one profile;
+2. open Identity;
+3. open Reading;
+4. open Timeline;
+5. open Compatibility without re-entering their own data;
+6. refresh the page;
+7. close and reopen the browser;
+8. reopen the same profile offline after the application shell has been cached.
+
+### Gate C: Reading clarity
+
+- Essential mode gives the core pattern, why, gift, and next action.
+- Complete mode adds hidden experience, protection, cost, relationships, and repair.
+- Technical mode exposes calculation, provenance, confidence state, and limitations.
+- The interface does not bury the answer beneath raw system labels.
+- Repeated filler does not substitute for depth.
+
+### Gate D: Compatibility
+
+- The user's saved profile is reused.
+- A specific comparison asks only for the other person's data.
+- Strong matches are described by dimension rather than one universal score.
+- Friction is explained without declaring people inherently bad.
+- Growth and repair potential remain visible.
+- Missing or unverified inputs reduce scope instead of increasing confidence.
+
+### Gate E: Security and privacy
+
+- Soul Codex does not collect card numbers, security codes, or expiry dates.
+- Payment entry occurs on hosted Stripe Checkout only.
+- Premium entitlement is granted only after a signature-verified paid webhook event.
+- Billing remains disabled without persistent database storage.
+- API responses are non-cacheable.
+- Referrer leakage is disabled.
+- Standard security headers and rate limits are active.
+- Production errors do not expose internal stack details to the client.
+
+### Gate F: Runtime
+
+- TypeScript passes.
+- Workspace checks and tests pass.
+- Trust and security boundary tests pass.
+- Production build passes.
+- Container smoke passes.
+- Dependency high-severity gates pass.
+- Live astronomy evidence workflow passes.
+- Chromium and WebKit offline restart validation passes.
+- The Foundation web RC invariant audit passes.
+
+## Definition of done
+
+Foundation Web v1 is release-candidate complete when all automated gates pass and a final manual consumer pass confirms:
+
+- no broken primary navigation;
+- no wrong or silently upgraded Big Three result;
+- no profile recreation requirement;
+- no blocked Compatibility path when verified inputs exist;
+- no direct payment-data input;
+- no critical console error during the canonical journey;
+- readable layouts at common phone, tablet, and desktop web widths.
+
+## Honest release classification
+
+Passing this contract means **Foundation Web Release Candidate**.
+
+It does not mean:
+
+- the native stores are complete;
+- every mystical system is verified;
+- every planned premium feature exists;
+- unresolved houses or Human Design may be quietly reintroduced;
+- enterprise layers are production-ready.
+
+A narrower release that tells the truth is stronger than a larger release assembled from confident placeholders.

--- a/governance/release-audits/FOUNDATION-WEB-RC-RECEIPT-v1.md
+++ b/governance/release-audits/FOUNDATION-WEB-RC-RECEIPT-v1.md
@@ -1,0 +1,123 @@
+# Foundation Web RC Receipt v1
+
+Status: **AUTOMATED RE-AUDIT IN PROGRESS**
+
+## Scope
+
+This receipt covers the Soul Codex Foundation web application only.
+
+The owner has explicitly deferred iOS App Store and Google Play work until further notice. Native-store status is therefore recorded but is not a web release gate.
+
+## Canonical journey
+
+```text
+Create one local-first profile
+→ open Identity
+→ reconcile verified Sun, Moon, and Ascendant
+→ open Reading
+→ inspect evidence and limitations
+→ open Timeline
+→ open Compatibility without re-entering the user's data
+→ refresh
+→ close and reopen the browser
+→ reopen the saved profile offline
+```
+
+## Proven merged foundations
+
+| Area | Evidence | Classification |
+|---|---|---|
+| Canonical profile journey | PR #145 | Integrated and browser-validated |
+| Foundation backend receipt | PR #146 | Evidence receipt merged |
+| Sun/Moon candidate engine | PR #147 | Implemented |
+| Independent verification contract | PR #148 | Implemented and tested |
+| NASA/JPL Horizons reference | PR #149 | Integrated |
+| 40-row astronomy evidence matrix | PRs #150-154 | Live evidence passed with zero sign disagreements |
+| Dependency remediation | PR #155 | Production high-severity gate passed |
+| Human Design trust boundary | PR #157 | Unverified output excluded from authoritative use |
+| Local profile verification reconciliation | PR #158 | Integrated |
+| Ascendant verification | PR #159 | Independently verified against 24 Swiss Ephemeris fixtures |
+| Saved-profile Ascendant migration | PR #160 | Integrated |
+| Bobby Big Three golden fixture | PR #161 | Virgo Sun, Virgo Moon, Scorpio Rising locked in CI |
+| Web privacy and billing hardening | PR #162 | Merged and deployed |
+
+## Latest completed security-lane evidence
+
+PR #162 head: `19c5f4b84ad03e0ec63ae2aadf1fd4ea64187abe`
+
+| Workflow | Run | Result |
+|---|---:|---|
+| Ultimate SoulCodex CI | 30884749128 | PASS |
+| CI Tests | 30884750033 | PASS |
+| Dependency Security Audit | 30884749118 | PASS |
+| Live Ephemeris Evidence | 30884749199 | PASS |
+| Railway Container Smoke | 30884749412 | PASS |
+| PWA Offline Browser Validation | 30884749632 | PASS |
+
+PR #162 merge commit: `fe30613d765fdff24a7bd1fc04203cd3bc62a8c7`
+
+Railway deployment for the merge commit: **PASS**.
+
+## New RC gate added in this lane
+
+The `scripts/verify-foundation-web-rc.mjs` audit fails CI unless the following invariants remain true:
+
+- Helmet and API rate limiting are active.
+- API responses are non-cacheable.
+- referrer leakage is disabled.
+- the client contains no card-number, expiry, CVV, or CVC fields;
+- billing uses hosted Stripe Checkout;
+- webhook signatures are verified;
+- raw payment fields are rejected;
+- the retired direct-card route is rejected before JSON parsing;
+- production astrology integrates verified Ascendant output;
+- the approved Ascendant evidence receipt remains attached;
+- saved profiles require the Big Three verification migration;
+- Human Design remains unresolved or calculated-unverified until verified;
+- Human Design cannot contribute to Compatibility without verification;
+- Big Three golden and billing security tests remain in CI;
+- Chromium and WebKit offline restart validation remains configured.
+
+## Billing persistence correction
+
+This lane adds an additional fail-closed requirement discovered during the RC audit:
+
+> Stripe Checkout cannot become enabled unless persistent database storage is configured.
+
+Without `DATABASE_URL`, the active server uses memory storage. Accepting payment in that state could lose a premium entitlement after restart, which would be an astonishingly efficient way to turn a customer into an enemy. The billing status now remains disabled until both Stripe configuration and persistent entitlement storage are present.
+
+## Deliberately unresolved
+
+- Astrological houses and Midheaven
+- Nodes, Chiron, and planetary house placements
+- Human Design verification and interpretation
+- Human Design contribution to Compatibility
+- Native iOS validation and App Store release
+- Native Android validation and Google Play release
+
+## Remaining manual gate
+
+Automated evidence does not replace the final human consumer pass. Before declaring the web build a public release candidate, manually confirm:
+
+- primary navigation works at phone, tablet, and desktop widths;
+- the canonical profile journey completes without recreation;
+- verified Virgo Sun, Virgo Moon, and Scorpio Rising appear for Bobby's exact fixture;
+- Compatibility opens once verified core inputs exist;
+- no direct card-entry interface appears anywhere;
+- no critical console error appears during the canonical journey;
+- the current copy reflects what the product actually includes rather than advertising systems still behind trust boundaries.
+
+## Final classification
+
+To be updated from this PR's final head after all workflows complete.
+
+```text
+Automated web foundation:       RE-AUDIT IN PROGRESS
+Trust boundary:                 PASS on prior merged head
+Security boundary:              PASS on prior merged head
+Persistent billing entitlement: FIX IMPLEMENTED, CI PENDING
+Offline lifecycle:              PASS on prior merged head
+Manual consumer QA:             PENDING
+Foundation Web RC:              NOT DECLARED YET
+Native stores:                  OWNER-DEFERRED
+```

--- a/governance/release-audits/FOUNDATION-WEB-RC-RECEIPT-v1.md
+++ b/governance/release-audits/FOUNDATION-WEB-RC-RECEIPT-v1.md
@@ -1,12 +1,12 @@
 # Foundation Web RC Receipt v1
 
-Status: **AUTOMATED RE-AUDIT IN PROGRESS**
+Status: **AUTOMATED WEB FOUNDATION PASS**
 
 ## Scope
 
 This receipt covers the Soul Codex Foundation web application only.
 
-The owner has explicitly deferred iOS App Store and Google Play work until further notice. Native-store status is therefore recorded but is not a web release gate.
+The owner has explicitly deferred iOS App Store and Google Play work until further notice. Native-store status is recorded but is not a web release gate.
 
 ## Canonical journey
 
@@ -41,50 +41,46 @@ Create one local-first profile
 | Bobby Big Three golden fixture | PR #161 | Virgo Sun, Virgo Moon, Scorpio Rising locked in CI |
 | Web privacy and billing hardening | PR #162 | Merged and deployed |
 
-## Latest completed security-lane evidence
+## Foundation web RC automation evidence
 
-PR #162 head: `19c5f4b84ad03e0ec63ae2aadf1fd4ea64187abe`
+Validated code head: `b3b6a881996e869882262d2da405d38a3209b5a0`
 
 | Workflow | Run | Result |
 |---|---:|---|
-| Ultimate SoulCodex CI | 30884749128 | PASS |
-| CI Tests | 30884750033 | PASS |
-| Dependency Security Audit | 30884749118 | PASS |
-| Live Ephemeris Evidence | 30884749199 | PASS |
-| Railway Container Smoke | 30884749412 | PASS |
-| PWA Offline Browser Validation | 30884749632 | PASS |
+| Ultimate SoulCodex CI | 30885940725 | PASS |
+| CI Tests | 30885940600 | PASS |
+| Dependency Security Audit | 30885940630 | PASS |
+| Live Ephemeris Evidence | 30885940665 | PASS |
+| Railway Container Smoke | 30885940596 | PASS |
+| PWA Offline Browser Validation | 30885940638 | PASS |
 
-PR #162 merge commit: `fe30613d765fdff24a7bd1fc04203cd3bc62a8c7`
+The Ultimate SoulCodex CI run included the new 16-check Foundation Web RC invariant audit. All 16 checks passed.
 
-Railway deployment for the merge commit: **PASS**.
+## Permanent RC invariants
 
-## New RC gate added in this lane
-
-The `scripts/verify-foundation-web-rc.mjs` audit fails CI unless the following invariants remain true:
+The `scripts/verify-foundation-web-rc.mjs` audit fails CI unless the following remain true:
 
 - Helmet and API rate limiting are active.
 - API responses are non-cacheable.
 - referrer leakage is disabled.
-- the client contains no card-number, expiry, CVV, or CVC fields;
-- billing uses hosted Stripe Checkout;
-- webhook signatures are verified;
-- raw payment fields are rejected;
-- the retired direct-card route is rejected before JSON parsing;
-- production astrology integrates verified Ascendant output;
-- the approved Ascendant evidence receipt remains attached;
-- saved profiles require the Big Three verification migration;
-- Human Design remains unresolved or calculated-unverified until verified;
-- Human Design cannot contribute to Compatibility without verification;
-- Big Three golden and billing security tests remain in CI;
+- the client contains no card-number, expiry, CVV, or CVC fields.
+- billing uses hosted Stripe Checkout.
+- webhook signatures are verified.
+- raw payment fields are rejected.
+- the retired direct-card route is rejected before JSON parsing.
+- production astrology integrates verified Ascendant output.
+- the approved Ascendant evidence receipt remains attached.
+- saved profiles require the Big Three verification migration.
+- Human Design remains unresolved or calculated-unverified until verified.
+- Human Design cannot contribute to Compatibility without verification.
+- Big Three golden and billing security tests remain in CI.
 - Chromium and WebKit offline restart validation remains configured.
 
 ## Billing persistence correction
 
-This lane adds an additional fail-closed requirement discovered during the RC audit:
+Stripe Checkout cannot become enabled unless persistent database storage is configured.
 
-> Stripe Checkout cannot become enabled unless persistent database storage is configured.
-
-Without `DATABASE_URL`, the active server uses memory storage. Accepting payment in that state could lose a premium entitlement after restart, which would be an astonishingly efficient way to turn a customer into an enemy. The billing status now remains disabled until both Stripe configuration and persistent entitlement storage are present.
+Without `DATABASE_URL`, the active server uses memory storage. Accepting payment in that state could lose premium entitlement after restart. Billing now remains disabled until both Stripe configuration and persistent entitlement storage are present.
 
 ## Deliberately unresolved
 
@@ -105,19 +101,19 @@ Automated evidence does not replace the final human consumer pass. Before declar
 - Compatibility opens once verified core inputs exist;
 - no direct card-entry interface appears anywhere;
 - no critical console error appears during the canonical journey;
-- the current copy reflects what the product actually includes rather than advertising systems still behind trust boundaries.
+- current copy reflects what the product actually includes rather than advertising systems still behind trust boundaries.
 
 ## Final classification
 
-To be updated from this PR's final head after all workflows complete.
-
 ```text
-Automated web foundation:       RE-AUDIT IN PROGRESS
-Trust boundary:                 PASS on prior merged head
-Security boundary:              PASS on prior merged head
-Persistent billing entitlement: FIX IMPLEMENTED, CI PENDING
-Offline lifecycle:              PASS on prior merged head
+Automated web foundation:       PASS
+Trust boundary:                 PASS
+Security boundary:              PASS
+Persistent billing entitlement: PASS, FAIL-CLOSED WITHOUT DATABASE
+Offline lifecycle:              PASS
 Manual consumer QA:             PENDING
 Foundation Web RC:              NOT DECLARED YET
 Native stores:                  OWNER-DEFERRED
 ```
+
+This receipt establishes that the automated web foundation is release-candidate capable. Public RC declaration remains blocked only by the final manual consumer and responsive-layout pass.

--- a/scripts/verify-foundation-web-rc.mjs
+++ b/scripts/verify-foundation-web-rc.mjs
@@ -1,0 +1,156 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const root = process.cwd();
+
+function read(relativePath) {
+  return readFileSync(path.join(root, relativePath), "utf8");
+}
+
+const files = {
+  server: read("server/index.ts"),
+  billing: read("server/billing.ts"),
+  premiumModal: read("client/src/components/PremiumUpgradeModal.tsx"),
+  astrology: read("server/services/astrology-production.ts"),
+  ascendant: read("server/services/ascendant-verification.ts"),
+  humanDesign: read("server/services/human-design-trust.ts"),
+  reconciliation: read(
+    "client/src/lib/profileVerificationReconciliation.ts",
+  ),
+  ci: read(".github/workflows/ci.yml"),
+  pwaWorkflow: read(".github/workflows/pwa-offline-browser.yml"),
+};
+
+const checks = [];
+
+function check(id, description, condition) {
+  checks.push({ id, description, passed: Boolean(condition) });
+}
+
+check(
+  "WEB-HTTP-01",
+  "Helmet security headers are active",
+  files.server.includes("helmet({"),
+);
+check(
+  "WEB-HTTP-02",
+  "API rate limiting is active",
+  files.server.includes("rateLimit({") && files.server.includes("apiLimiter"),
+);
+check(
+  "WEB-HTTP-03",
+  "API responses are non-cacheable",
+  files.server.includes('Cache-Control", "no-store'),
+);
+check(
+  "WEB-HTTP-04",
+  "Referrer leakage is disabled",
+  files.server.includes('referrerPolicy: { policy: "no-referrer" }'),
+);
+
+check(
+  "BILLING-01",
+  "Client does not collect raw payment fields",
+  !/\b(cardNumber|expiryDate|cvv|cvc)\b/.test(files.premiumModal),
+);
+check(
+  "BILLING-02",
+  "Checkout uses Stripe hosted sessions",
+  files.billing.includes("stripe.checkout.sessions.create") &&
+    files.billing.includes('provider: "stripe_checkout"'),
+);
+check(
+  "BILLING-03",
+  "Stripe webhook signatures are verified",
+  files.billing.includes("stripe.webhooks.constructEvent"),
+);
+check(
+  "BILLING-04",
+  "Raw payment fields are explicitly rejected",
+  files.billing.includes("raw_payment_data_rejected") &&
+    files.billing.includes("containsRawPaymentFields"),
+);
+check(
+  "BILLING-05",
+  "Legacy direct-card endpoint is retired before JSON parsing",
+  files.server.indexOf("registerBillingRawRoutes(app)") <
+    files.server.indexOf("express.json"),
+);
+
+check(
+  "ASTRO-01",
+  "Production astrology integrates independent Ascendant verification",
+  files.astrology.includes("verifyAscendant") &&
+    files.astrology.includes('verifiedBodies.push("Ascendant")'),
+);
+check(
+  "ASTRO-02",
+  "Ascendant policy retains an approved evidence receipt",
+  files.ascendant.includes('status: "approved"') &&
+    files.ascendant.includes("ASCENDANT-VERIFICATION-RECEIPT-v1"),
+);
+check(
+  "ASTRO-03",
+  "Saved profiles require the verified Big Three migration version",
+  files.reconciliation.includes(
+    "CURRENT_ASTROLOGY_VERIFICATION_VERSION = 2",
+  ) && files.reconciliation.includes("hasVerifiedBigThree"),
+);
+
+check(
+  "HD-01",
+  "Human Design has explicit unresolved and unverified states",
+  files.humanDesign.includes('"unresolved"') &&
+    files.humanDesign.includes('"calculated_unverified"'),
+);
+check(
+  "HD-02",
+  "Human Design cannot affect compatibility unless verified",
+  files.humanDesign.includes('return record.status === "verified"'),
+);
+
+check(
+  "CI-01",
+  "Golden Big Three and billing security tests run in CI",
+  files.ci.includes("tests/bobby-big-three-golden.test.ts") &&
+    files.ci.includes("tests/billing-security.test.ts"),
+);
+check(
+  "PWA-01",
+  "Chromium and WebKit offline restart validation remains configured",
+  files.pwaWorkflow.includes("Chromium and WebKit offline restart") &&
+    files.pwaWorkflow.includes("Test offline browser restart"),
+);
+
+const failures = checks.filter((entry) => !entry.passed);
+const receipt = {
+  audit: "Soul Codex Foundation Web RC invariant audit",
+  version: 1,
+  generatedAt: new Date().toISOString(),
+  passed: failures.length === 0,
+  totalChecks: checks.length,
+  passedChecks: checks.length - failures.length,
+  failedChecks: failures.length,
+  checks,
+  deferredByOwner: [
+    "iOS App Store submission and validation",
+    "Google Play submission and validation",
+  ],
+  deliberatelyUnresolved: [
+    "Astrological houses and Midheaven",
+    "Nodes, Chiron, and planetary house placements",
+    "Human Design verification and interpretation",
+  ],
+};
+
+console.log(JSON.stringify(receipt, null, 2));
+
+if (failures.length > 0) {
+  console.error(
+    `Foundation web RC audit failed: ${failures
+      .map((entry) => entry.id)
+      .join(", ")}`,
+  );
+  process.exit(1);
+}

--- a/scripts/verify-foundation-web-rc.mjs
+++ b/scripts/verify-foundation-web-rc.mjs
@@ -57,7 +57,7 @@ check(
 check(
   "BILLING-02",
   "Checkout uses Stripe hosted sessions",
-  files.billing.includes("stripe.checkout.sessions.create") &&
+  /checkout\.sessions\.create\s*\(/.test(files.billing) &&
     files.billing.includes('provider: "stripe_checkout"'),
 );
 check(
@@ -82,7 +82,10 @@ check(
   "ASTRO-01",
   "Production astrology integrates independent Ascendant verification",
   files.astrology.includes("verifyAscendant") &&
-    files.astrology.includes('verifiedBodies.push("Ascendant")'),
+    files.astrology.includes('rising.status === "verified"') &&
+    files.astrology.includes('(["Ascendant"] as const)') &&
+    files.astrology.includes("ASTRO-ASCENDANT-v1") &&
+    files.astrology.includes("withRisingVerificationSummary(base, rising)"),
 );
 check(
   "ASTRO-02",

--- a/server/billing.ts
+++ b/server/billing.ts
@@ -23,6 +23,7 @@ export interface BillingStatus {
   enabled: boolean;
   provider: "stripe_checkout";
   collectsCardDataOnSoulCodex: false;
+  persistentEntitlements: boolean;
   reason?: "not_configured";
 }
 
@@ -46,9 +47,15 @@ function configuredPublicAppUrl(): string | null {
   }
 }
 
+function persistentStorageConfigured(): boolean {
+  return Boolean(process.env.DATABASE_URL?.trim());
+}
+
 export function getBillingStatus(): BillingStatus {
+  const persistentEntitlements = persistentStorageConfigured();
   const enabled = Boolean(
-    process.env.STRIPE_SECRET_KEY?.trim() &&
+    persistentEntitlements &&
+      process.env.STRIPE_SECRET_KEY?.trim() &&
       process.env.STRIPE_PRICE_ID?.trim() &&
       process.env.STRIPE_WEBHOOK_SECRET?.trim() &&
       configuredPublicAppUrl(),
@@ -59,11 +66,13 @@ export function getBillingStatus(): BillingStatus {
         enabled: true,
         provider: "stripe_checkout",
         collectsCardDataOnSoulCodex: false,
+        persistentEntitlements: true,
       }
     : {
         enabled: false,
         provider: "stripe_checkout",
         collectsCardDataOnSoulCodex: false,
+        persistentEntitlements,
         reason: "not_configured",
       };
 }
@@ -129,8 +138,9 @@ export function registerBillingRawRoutes(app: Express): void {
       const stripe = stripeClient();
       const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET?.trim();
       const signature = req.headers["stripe-signature"];
+      const billingStatus = getBillingStatus();
 
-      if (!stripe || !webhookSecret) {
+      if (!stripe || !webhookSecret || !billingStatus.enabled) {
         return res.status(503).json({
           message: "Billing webhook is not configured",
           code: "billing_not_configured",
@@ -229,7 +239,9 @@ export function registerBillingRoutes(app: Express): void {
     const status = getBillingStatus();
     if (!status.enabled) {
       return res.status(503).json({
-        message: "Secure checkout is temporarily unavailable",
+        message: status.persistentEntitlements
+          ? "Secure checkout is temporarily unavailable"
+          : "Secure checkout requires persistent profile storage",
         code: "billing_not_configured",
       });
     }

--- a/tests/billing-security.test.ts
+++ b/tests/billing-security.test.ts
@@ -42,12 +42,13 @@ test("profile billing actions require the existing bearer capability", () => {
   );
 });
 
-test("billing remains disabled unless the complete hosted-checkout configuration exists", () => {
+test("billing remains disabled unless checkout and persistent entitlement storage are complete", () => {
   const previous = {
     secret: process.env.STRIPE_SECRET_KEY,
     price: process.env.STRIPE_PRICE_ID,
     webhook: process.env.STRIPE_WEBHOOK_SECRET,
     appUrl: process.env.PUBLIC_APP_URL,
+    databaseUrl: process.env.DATABASE_URL,
   };
 
   try {
@@ -55,26 +56,39 @@ test("billing remains disabled unless the complete hosted-checkout configuration
     delete process.env.STRIPE_PRICE_ID;
     delete process.env.STRIPE_WEBHOOK_SECRET;
     delete process.env.PUBLIC_APP_URL;
+    delete process.env.DATABASE_URL;
 
     assert.deepEqual(getBillingStatus(), {
       enabled: false,
       provider: "stripe_checkout",
       collectsCardDataOnSoulCodex: false,
+      persistentEntitlements: false,
       reason: "not_configured",
     });
 
     process.env.STRIPE_SECRET_KEY = "sk_test_example";
     process.env.STRIPE_PRICE_ID = "price_example";
     process.env.STRIPE_WEBHOOK_SECRET = "whsec_example";
-    process.env.PUBLIC_APP_URL = "http://not-secure.example.com";
-    assert.equal(getBillingStatus().enabled, false);
-
     process.env.PUBLIC_APP_URL = "https://soulcodex.example.com";
+
+    assert.deepEqual(getBillingStatus(), {
+      enabled: false,
+      provider: "stripe_checkout",
+      collectsCardDataOnSoulCodex: false,
+      persistentEntitlements: false,
+      reason: "not_configured",
+    });
+
+    process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/soulcodex";
     assert.deepEqual(getBillingStatus(), {
       enabled: true,
       provider: "stripe_checkout",
       collectsCardDataOnSoulCodex: false,
+      persistentEntitlements: true,
     });
+
+    process.env.PUBLIC_APP_URL = "http://not-secure.example.com";
+    assert.equal(getBillingStatus().enabled, false);
   } finally {
     if (previous.secret === undefined) delete process.env.STRIPE_SECRET_KEY;
     else process.env.STRIPE_SECRET_KEY = previous.secret;
@@ -87,5 +101,8 @@ test("billing remains disabled unless the complete hosted-checkout configuration
 
     if (previous.appUrl === undefined) delete process.env.PUBLIC_APP_URL;
     else process.env.PUBLIC_APP_URL = previous.appUrl;
+
+    if (previous.databaseUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = previous.databaseUrl;
   }
 });


### PR DESCRIPTION
## Objective

Replace the stale mobile-dependent finish line with the current web-first Foundation release contract and a machine-enforced RC audit.

## Why now

Verified Sun, Moon, and Ascendant are merged. Saved-profile migration is merged. Human Design is behind an explicit unverified boundary. Browser persistence and offline restart are validated. Web payment handling and the HTTP boundary are hardened. The next hurdle is preventing all of that from drifting backward while somebody adds one more decorative mystical subsystem because apparently software repos attract scope like kitchens attract unmatched plastic lids.

## What this lane adds

- canonical Foundation Web v1 scope and definition of done
- explicit owner deferral of App Store and Google Play work
- explicit exclusion of houses, Midheaven, nodes, Chiron, planetary houses, and Human Design interpretation until independently verified
- a machine-readable Foundation web RC invariant audit
- permanent CI enforcement of the audit
- an evidence receipt tying the current merged PRs and workflow runs together
- a newly discovered billing safety gate: Stripe Checkout stays disabled unless persistent database storage exists, so paid entitlement cannot disappear after a process restart

## Release classification

This PR can classify the automated web foundation as release-candidate capable once every workflow passes. A final manual consumer journey and responsive-layout pass remains required before declaring a public web RC.

## Platform scope

No iOS or Android store work is included. Those lanes remain paused until the owner explicitly resumes them.