### PR TITLE
Unify online and offline clarity reading runtime

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,6 +6,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Card } from "@/components/ui/card";
 import Navigation from "@/components/navigation";
+import ProfileClarityLauncher from "@/components/ProfileClarityLauncher";
 import NotFound from "./pages/not-found";
 import Home from "./pages/home";
 import LocalFirstInputForm from "./pages/local-first-input-form";
@@ -27,7 +28,13 @@ import type { Profile as ProfileType } from "@shared/schema";
 
 function ProfileRoute() {
   const { id } = useParams();
-  return id?.startsWith("local-") ? <OfflineProfilePage /> : <Profile />;
+  const profile = id?.startsWith("local-") ? <OfflineProfilePage /> : <Profile />;
+
+  return (
+    <ProfileClarityLauncher profileId={id}>
+      {profile}
+    </ProfileClarityLauncher>
+  );
 }
 
 function ReadingRoute() {

--- a/client/src/components/ClarityReadingExperience.tsx
+++ b/client/src/components/ClarityReadingExperience.tsx
@@ -1,0 +1,204 @@
+import { Link } from "wouter";
+import {
+  ArrowLeft,
+  CheckCircle2,
+  Eye,
+  Gift,
+  HeartHandshake,
+  ShieldCheck,
+  Sparkles,
+  Target,
+} from "lucide-react";
+import type {
+  ClarityConfidence,
+  ClarityReadingModel,
+} from "@/lib/clarityReadingModel";
+
+type ReadingCardProps = {
+  eyebrow: string;
+  title: string;
+  body: string;
+  icon: React.ComponentType<{ className?: string }>;
+  tone?: "gold" | "violet" | "teal";
+};
+
+type ClarityReadingExperienceProps = {
+  profileId: string;
+  profileName: string;
+  model: ClarityReadingModel;
+  offline?: boolean;
+};
+
+const toneClass = {
+  gold: "text-amber-300 border-amber-300/20",
+  violet: "text-violet-300 border-violet-300/20",
+  teal: "text-teal-300 border-teal-300/20",
+};
+
+const confidenceClass: Record<ClarityConfidence, string> = {
+  verified: "border-emerald-300/25 bg-emerald-300/10 text-emerald-100",
+  deterministic: "border-sky-300/25 bg-sky-300/10 text-sky-100",
+  supported: "border-violet-300/25 bg-violet-300/10 text-violet-100",
+  tentative: "border-amber-300/25 bg-amber-300/10 text-amber-100",
+  unavailable: "border-white/10 bg-white/5 text-white/50",
+};
+
+function ReadingCard({ eyebrow, title, body, icon: Icon, tone = "gold" }: ReadingCardProps) {
+  return (
+    <article
+      className={`rounded-2xl border bg-black/20 p-5 backdrop-blur sm:p-6 ${toneClass[tone]}`}
+    >
+      <Icon aria-hidden="true" className="mb-4 h-5 w-5" />
+      <p className="mb-2 text-[11px] font-bold uppercase tracking-[0.18em] text-white/45">
+        {eyebrow}
+      </p>
+      <h2 className="mb-3 font-serif text-2xl leading-tight text-white">{title}</h2>
+      <p className="leading-7 text-white/70">{body}</p>
+    </article>
+  );
+}
+
+export default function ClarityReadingExperience({
+  profileId,
+  profileName,
+  model,
+  offline = false,
+}: ClarityReadingExperienceProps) {
+  return (
+    <main
+      id="main-content"
+      className="mx-auto max-w-6xl px-4 pb-24 pt-28 sm:px-6"
+      aria-labelledby="clarity-reading-title"
+    >
+      <Link
+        href={`/profile/${profileId}`}
+        className="mb-8 inline-flex min-h-11 items-center gap-2 rounded-lg px-2 text-sm text-white/60 transition hover:bg-white/5 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300"
+      >
+        <ArrowLeft aria-hidden="true" className="h-4 w-4" />
+        {offline ? "Local profile and evidence" : "Full profile and evidence"}
+      </Link>
+
+      <header className="mb-9 max-w-4xl">
+        <div className="mb-3 flex flex-wrap items-center gap-3">
+          <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-amber-300">
+            {offline ? "Offline clarity reading" : "Clarity reading"}
+          </p>
+          {offline && (
+            <span className="rounded-full border border-teal-300/20 bg-teal-300/5 px-3 py-1 text-xs text-teal-200">
+              Saved on this device
+            </span>
+          )}
+        </div>
+        <h1
+          id="clarity-reading-title"
+          className="mb-5 font-serif text-4xl leading-[0.98] tracking-tight sm:text-6xl lg:text-7xl"
+        >
+          {profileName}, this is the pattern worth understanding.
+        </h1>
+        <p className="max-w-3xl text-lg leading-8 text-white/70">{model.summary}</p>
+      </header>
+
+      <section
+        aria-labelledby="core-synthesis-title"
+        className="mb-6 rounded-3xl border border-amber-300/30 bg-gradient-to-br from-violet-950/75 to-black/45 p-6 shadow-2xl backdrop-blur sm:p-9"
+      >
+        <div className="mb-4 flex items-center gap-3 text-amber-300">
+          <Sparkles aria-hidden="true" className="h-5 w-5" />
+          <span className="text-[11px] font-bold uppercase tracking-[0.18em]">
+            Core synthesis
+          </span>
+        </div>
+        <h2 id="core-synthesis-title" className="mb-4 font-serif text-3xl sm:text-5xl">
+          {model.title}
+        </h2>
+        <p className="max-w-3xl text-base leading-8 text-white/70">
+          {offline
+            ? "This reading uses evidence stored on your device. Missing or unverified layers stay unresolved rather than being quietly promoted into facts."
+            : "This reading separates supported patterns from certainty. It shows what the pattern may protect, what it gives you, what it costs, and a next choice you can test in real life."}
+        </p>
+      </section>
+
+      <section aria-label="Clarity reading chapters" className="mb-6 grid gap-4 md:grid-cols-2">
+        <ReadingCard
+          eyebrow="What people may notice"
+          title="The visible pattern"
+          body={model.visiblePattern}
+          icon={Eye}
+        />
+        <ReadingCard
+          eyebrow="What may be underneath"
+          title="The protective function"
+          body={model.protectiveFunction}
+          icon={ShieldCheck}
+          tone="violet"
+        />
+        <ReadingCard
+          eyebrow="The gift"
+          title="What this pattern can become"
+          body={model.gift}
+          icon={Gift}
+          tone="teal"
+        />
+        <ReadingCard
+          eyebrow="The cost"
+          title="When the strength turns against you"
+          body={model.cost}
+          icon={Target}
+        />
+        <ReadingCard
+          eyebrow="Connection"
+          title="How it may affect relationships"
+          body={model.relationshipImpact}
+          icon={HeartHandshake}
+          tone="violet"
+        />
+        <ReadingCard
+          eyebrow="Grounded action"
+          title="One move to test today"
+          body={model.groundedAction}
+          icon={CheckCircle2}
+          tone="teal"
+        />
+      </section>
+
+      <section
+        aria-labelledby="evidence-title"
+        className="rounded-2xl border border-white/10 bg-white/[0.035] p-5 sm:p-6"
+      >
+        <div className="mb-4 flex items-center gap-2 text-teal-300">
+          <ShieldCheck aria-hidden="true" className="h-5 w-5" />
+          <h2 id="evidence-title" className="font-semibold">
+            {offline ? "Local evidence remains inspectable" : "Evidence remains inspectable"}
+          </h2>
+        </div>
+
+        {model.signals.length > 0 ? (
+          <ul className="mb-5 flex flex-wrap gap-2" aria-label="Reading evidence signals">
+            {model.signals.map((signal) => (
+              <li
+                key={signal.id}
+                className={`rounded-full border px-3 py-1.5 text-sm ${confidenceClass[signal.confidence]}`}
+                title={`Source: ${signal.source}`}
+              >
+                <span className="font-medium">{signal.label}:</span> {signal.value}
+                <span className="ml-1 opacity-70">· {signal.confidence}</span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="mb-5 text-white/60">No supported summary signals are available.</p>
+        )}
+
+        <h3 className="mb-2 text-sm font-semibold text-white/75">Limits and corrections</h3>
+        <ul className="space-y-2 text-sm leading-6 text-white/55">
+          {model.limitations.map((limitation) => (
+            <li key={limitation} className="flex gap-2">
+              <span aria-hidden="true">•</span>
+              <span>{limitation}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/client/src/components/ProfileClarityLauncher.tsx
+++ b/client/src/components/ProfileClarityLauncher.tsx
@@ -1,0 +1,46 @@
+import { Link } from "wouter";
+import { ArrowRight, Sparkles } from "lucide-react";
+
+interface ProfileClarityLauncherProps {
+  profileId?: string;
+  children: React.ReactNode;
+}
+
+export default function ProfileClarityLauncher({
+  profileId,
+  children,
+}: ProfileClarityLauncherProps) {
+  return (
+    <div className="relative">
+      {children}
+      {profileId ? (
+        <aside
+          aria-label="Continue to clarity reading"
+          className="pointer-events-none fixed inset-x-0 bottom-0 z-40 px-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] sm:px-5"
+        >
+          <div className="pointer-events-auto mx-auto flex max-w-xl items-center gap-3 rounded-2xl border border-amber-300/25 bg-[#100a1b]/95 p-3 shadow-2xl backdrop-blur-xl sm:p-4">
+            <div className="hidden h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-amber-300/10 text-amber-300 sm:flex">
+              <Sparkles aria-hidden="true" className="h-5 w-5" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm font-semibold text-white">
+                Ready for the clarity-first version?
+              </p>
+              <p className="hidden text-xs leading-5 text-white/55 sm:block">
+                See the pattern, protection, gift, cost, evidence, and one grounded action.
+              </p>
+            </div>
+            <Link
+              href={`/reading/${profileId}`}
+              className="inline-flex min-h-11 shrink-0 items-center gap-2 rounded-xl bg-amber-300 px-4 py-2.5 text-sm font-bold text-black outline-none transition hover:bg-amber-200 focus-visible:ring-2 focus-visible:ring-amber-200 focus-visible:ring-offset-2 focus-visible:ring-offset-[#100a1b]"
+              data-testid="profile-clarity-reading-link"
+            >
+              Open reading
+              <ArrowRight aria-hidden="true" className="h-4 w-4" />
+            </Link>
+          </div>
+        </aside>
+      ) : null}
+    </div>
+  );
+}

--- a/client/src/components/__tests__/ProfileClarityLauncher.test.tsx
+++ b/client/src/components/__tests__/ProfileClarityLauncher.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import ProfileClarityLauncher from "../ProfileClarityLauncher";
+
+describe("ProfileClarityLauncher", () => {
+  it("links a server profile to its clarity reading", () => {
+    render(
+      <ProfileClarityLauncher profileId="42">
+        <div>Profile content</div>
+      </ProfileClarityLauncher>,
+    );
+
+    expect(screen.getByText("Profile content")).toBeTruthy();
+    expect(screen.getByTestId("profile-clarity-reading-link").getAttribute("href")).toBe(
+      "/reading/42",
+    );
+  });
+
+  it("preserves local profile ids for offline reading dispatch", () => {
+    render(
+      <ProfileClarityLauncher profileId="local-abc">
+        <div>Local profile</div>
+      </ProfileClarityLauncher>,
+    );
+
+    expect(screen.getByTestId("profile-clarity-reading-link").getAttribute("href")).toBe(
+      "/reading/local-abc",
+    );
+  });
+
+  it("does not render a broken action without a profile id", () => {
+    render(
+      <ProfileClarityLauncher>
+        <div>Profile content</div>
+      </ProfileClarityLauncher>,
+    );
+
+    expect(screen.queryByTestId("profile-clarity-reading-link")).toBeNull();
+  });
+});

--- a/client/src/lib/__tests__/clarityReadingModel.test.ts
+++ b/client/src/lib/__tests__/clarityReadingModel.test.ts
@@ -57,7 +57,7 @@ describe("clarityReadingModel", () => {
     expect(model.signals.some((signal) => signal.id === "rising")).toBe(false);
   });
 
-  it("uses depth interpretation before generic fallbacks", () => {
+  it("uses direct depth interpretation before generic fallbacks", () => {
     const model = buildClarityReadingModel({
       depthInterpretation: {
         title: "Quiet Precision",
@@ -82,5 +82,41 @@ describe("clarityReadingModel", () => {
       relationshipImpact: "You may correct before first acknowledging.",
       groundedAction: "Name what is already good before suggesting a repair.",
     });
+  });
+
+  it("normalizes nested offline depth sections into the same reading contract", () => {
+    const model = buildClarityReadingModel({
+      depthInterpretation: {
+        claritySummary: {
+          title: "The Quiet Guardian",
+          summary: "You stabilize the room before naming what you need.",
+        },
+        behavior: { summary: "You notice pressure before other people name it." },
+        protectiveFunction: { summary: "Preparedness protects emotional safety." },
+        gift: { summary: "Your awareness becomes steady practical care." },
+        shadow: { summary: "Responsibility can become silent resentment." },
+        relationshipImpact: { summary: "You may help before asking whether help is wanted." },
+        action: { summary: "Ask one direct question before solving the problem." },
+      },
+      numerologyData: { lifePath: 9, expression: 4, soulUrge: 5 },
+    });
+
+    expect(model).toMatchObject({
+      title: "The Quiet Guardian",
+      summary: "You stabilize the room before naming what you need.",
+      visiblePattern: "You notice pressure before other people name it.",
+      protectiveFunction: "Preparedness protects emotional safety.",
+      gift: "Your awareness becomes steady practical care.",
+      cost: "Responsibility can become silent resentment.",
+      relationshipImpact: "You may help before asking whether help is wanted.",
+      groundedAction: "Ask one direct question before solving the problem.",
+    });
+    expect(model.signals).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "life-path", confidence: "deterministic" }),
+        expect.objectContaining({ id: "expression", confidence: "deterministic" }),
+        expect.objectContaining({ id: "soul-urge", confidence: "deterministic" }),
+      ]),
+    );
   });
 });

--- a/client/src/lib/clarityReadingModel.ts
+++ b/client/src/lib/clarityReadingModel.ts
@@ -1,4 +1,9 @@
-export type ClarityConfidence = "verified" | "deterministic" | "supported" | "tentative" | "unavailable";
+export type ClarityConfidence =
+  | "verified"
+  | "deterministic"
+  | "supported"
+  | "tentative"
+  | "unavailable";
 
 export interface ClaritySignal {
   id: string;
@@ -32,6 +37,20 @@ export function firstSupportedText(...values: unknown[]): string | undefined {
   ) as string | undefined;
 }
 
+function sectionText(section: unknown): string | undefined {
+  if (typeof section === "string") return section.trim() || undefined;
+  if (!section || typeof section !== "object") return undefined;
+  const record = section as AnyRecord;
+  return firstSupportedText(
+    record.summary,
+    record.description,
+    record.text,
+    record.body,
+    record.insight,
+    record.value,
+  );
+}
+
 function addSignal(
   signals: ClaritySignal[],
   id: string,
@@ -40,6 +59,7 @@ function addSignal(
   confidence: ClarityConfidence,
   source: string,
 ) {
+  if (signals.some((signal) => signal.id === id)) return;
   if (typeof value !== "string" && typeof value !== "number") return;
   const normalized = String(value).trim();
   if (!normalized) return;
@@ -55,12 +75,17 @@ export function buildClarityReadingModel(profile: AnyRecord): ClarityReadingMode
   const depth = (profile.depthInterpretation ?? {}) as AnyRecord;
 
   const title =
-    firstSupportedText(depth.title, archetype.title, archetype.name) ??
-    "Your evolving pattern";
+    firstSupportedText(
+      depth.title,
+      depth.claritySummary?.title,
+      archetype.title,
+      archetype.name,
+    ) ?? "Your evolving pattern";
 
   const summary =
     firstSupportedText(
       depth.summary,
+      sectionText(depth.claritySummary),
       profile.biography,
       archetype.description,
     ) ??
@@ -69,7 +94,9 @@ export function buildClarityReadingModel(profile: AnyRecord): ClarityReadingMode
   const visiblePattern =
     firstSupportedText(
       depth.visiblePattern,
-      depth.behavior?.summary,
+      sectionText(depth.visiblePattern),
+      sectionText(depth.behavior),
+      sectionText(depth.behaviorPattern),
       archetype.strengths?.[0],
       archetype.gifts?.[0],
     ) ??
@@ -77,17 +104,17 @@ export function buildClarityReadingModel(profile: AnyRecord): ClarityReadingMode
 
   const protectiveFunction =
     firstSupportedText(
-      depth.protectiveFunction,
-      depth.hiddenNeed,
-      archetype.protectiveFunction,
-      archetype.hiddenNeed,
+      sectionText(depth.protectiveFunction),
+      sectionText(depth.hiddenNeed),
+      sectionText(archetype.protectiveFunction),
+      sectionText(archetype.hiddenNeed),
     ) ??
     "This pattern may protect stability, dignity, belonging, certainty, or emotional safety. The profile cannot prove which one without lived context.";
 
   const gift =
     firstSupportedText(
-      depth.gift,
-      depth.healthyExpression,
+      sectionText(depth.gift),
+      sectionText(depth.healthyExpression),
       archetype.gifts?.[0],
       archetype.strengths?.[0],
     ) ??
@@ -95,8 +122,8 @@ export function buildClarityReadingModel(profile: AnyRecord): ClarityReadingMode
 
   const cost =
     firstSupportedText(
-      depth.cost,
-      depth.shadow,
+      sectionText(depth.cost),
+      sectionText(depth.shadow),
       archetype.shadows?.[0],
       archetype.growthAreas?.[0],
     ) ??
@@ -104,24 +131,90 @@ export function buildClarityReadingModel(profile: AnyRecord): ClarityReadingMode
 
   const relationshipImpact =
     firstSupportedText(
-      depth.relationshipImpact,
-      personality.relationshipStyle,
-      archetype.relationshipImpact,
+      sectionText(depth.relationshipImpact),
+      sectionText(depth.relationships),
+      sectionText(personality.relationshipStyle),
+      sectionText(archetype.relationshipImpact),
     ) ??
     "In relationships, the central task is to name needs and boundaries directly instead of expecting other people to decode them.";
 
   const signals: ClaritySignal[] = [];
-  addSignal(signals, "sun", "Sun", verifiedAstrology.sun?.sign ?? verifiedAstrology.sunSign, "verified", "independent astronomy");
-  addSignal(signals, "moon", "Moon", verifiedAstrology.moon?.sign ?? verifiedAstrology.moonSign, "verified", "independent astronomy");
-  addSignal(signals, "rising", "Rising", verifiedAstrology.rising?.sign ?? verifiedAstrology.risingSign, "verified", "independent astronomy");
+  addSignal(
+    signals,
+    "sun",
+    "Sun",
+    verifiedAstrology.sun?.sign ?? verifiedAstrology.sunSign,
+    "verified",
+    "independent astronomy",
+  );
+  addSignal(
+    signals,
+    "moon",
+    "Moon",
+    verifiedAstrology.moon?.sign ?? verifiedAstrology.moonSign,
+    "verified",
+    "independent astronomy",
+  );
+  addSignal(
+    signals,
+    "rising",
+    "Rising",
+    verifiedAstrology.rising?.sign ?? verifiedAstrology.risingSign,
+    "verified",
+    "independent astronomy",
+  );
 
   if (!signals.some((signal) => signal.id === "sun")) {
-    addSignal(signals, "sun-symbolic", "Sun", astrology.sunSign, "supported", "saved symbolic profile");
+    addSignal(
+      signals,
+      "sun-symbolic",
+      "Sun",
+      astrology.sunSign,
+      "supported",
+      "saved symbolic profile",
+    );
   }
-  addSignal(signals, "life-path", "Life Path", numerology.lifePath, "deterministic", "birth-date calculation");
-  addSignal(signals, "expression", "Expression", numerology.expression, "deterministic", "name calculation");
-  addSignal(signals, "enneagram", "Enneagram", personality.enneagram?.type, "supported", "user assessment");
-  addSignal(signals, "mbti", "MBTI", personality.mbti?.type, "supported", "user assessment");
+
+  addSignal(
+    signals,
+    "life-path",
+    "Life Path",
+    numerology.lifePath,
+    "deterministic",
+    "birth-date calculation",
+  );
+  addSignal(
+    signals,
+    "expression",
+    "Expression",
+    numerology.expression,
+    "deterministic",
+    "name calculation",
+  );
+  addSignal(
+    signals,
+    "soul-urge",
+    "Soul Urge",
+    numerology.soulUrge,
+    "deterministic",
+    "name-vowel calculation",
+  );
+  addSignal(
+    signals,
+    "enneagram",
+    "Enneagram",
+    personality.enneagram?.type,
+    "supported",
+    "user assessment",
+  );
+  addSignal(
+    signals,
+    "mbti",
+    "MBTI",
+    personality.mbti?.type,
+    "supported",
+    "user assessment",
+  );
 
   const limitations = [
     "Symbolic overlap is supporting context, not independent proof.",
@@ -130,7 +223,9 @@ export function buildClarityReadingModel(profile: AnyRecord): ClarityReadingMode
   ];
 
   if (!signals.some((signal) => signal.confidence === "verified")) {
-    limitations.unshift("No independently verified astronomical signal is available in this reading model.");
+    limitations.unshift(
+      "No independently verified astronomical signal is available in this reading model.",
+    );
   }
 
   return {
@@ -141,7 +236,12 @@ export function buildClarityReadingModel(profile: AnyRecord): ClarityReadingMode
     gift,
     cost,
     relationshipImpact,
-    groundedAction: firstSupportedText(depth.groundedAction, depth.action) ?? DEFAULT_ACTION,
+    groundedAction:
+      firstSupportedText(
+        sectionText(depth.groundedAction),
+        sectionText(depth.action),
+        profile.dailyGuidance,
+      ) ?? DEFAULT_ACTION,
     signals,
     limitations,
   };

--- a/client/src/pages/ClarityReadingPage.tsx
+++ b/client/src/pages/ClarityReadingPage.tsx
@@ -1,47 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import { Link, useParams } from "wouter";
-import {
-  ArrowLeft,
-  ArrowRight,
-  CheckCircle2,
-  Eye,
-  Gift,
-  HeartHandshake,
-  ShieldCheck,
-  Sparkles,
-  Target,
-} from "lucide-react";
+import { ArrowRight, ShieldCheck } from "lucide-react";
 import Navigation from "@/components/navigation";
+import ClarityReadingExperience from "@/components/ClarityReadingExperience";
+import { buildClarityReadingModel } from "@/lib/clarityReadingModel";
 import type { Profile } from "@shared/schema";
-
-type ReadingCardProps = {
-  eyebrow: string;
-  title: string;
-  body: string;
-  icon: React.ComponentType<{ className?: string }>;
-  tone?: "gold" | "violet" | "teal";
-};
-
-const toneClass = {
-  gold: "text-amber-300 border-amber-300/20",
-  violet: "text-violet-300 border-violet-300/20",
-  teal: "text-teal-300 border-teal-300/20",
-};
-
-function ReadingCard({ eyebrow, title, body, icon: Icon, tone = "gold" }: ReadingCardProps) {
-  return (
-    <article className={`rounded-2xl border bg-black/20 p-5 sm:p-6 backdrop-blur ${toneClass[tone]}`}>
-      <Icon className="mb-4 h-5 w-5" />
-      <p className="mb-2 text-[11px] font-bold uppercase tracking-[0.18em] text-white/45">{eyebrow}</p>
-      <h2 className="mb-3 font-serif text-2xl leading-tight text-white">{title}</h2>
-      <p className="leading-7 text-white/68">{body}</p>
-    </article>
-  );
-}
-
-function firstText(...values: unknown[]): string | undefined {
-  return values.find((value) => typeof value === "string" && value.trim().length > 0) as string | undefined;
-}
 
 export default function ClarityReadingPage() {
   const { id } = useParams();
@@ -54,9 +17,12 @@ export default function ClarityReadingPage() {
     return (
       <div className="min-h-screen bg-[#090610] text-white">
         <Navigation />
-        <main className="flex min-h-screen items-center justify-center px-5 pt-20">
+        <main className="flex min-h-screen items-center justify-center px-5 pt-20" aria-live="polite">
           <div className="text-center">
-            <div className="mx-auto mb-4 h-11 w-11 animate-spin rounded-full border-2 border-white/15 border-t-amber-300" />
+            <div
+              aria-hidden="true"
+              className="mx-auto mb-4 h-11 w-11 animate-spin rounded-full border-2 border-white/15 border-t-amber-300"
+            />
             <p className="text-white/60">Building the clearest supported reading...</p>
           </div>
         </main>
@@ -69,119 +35,32 @@ export default function ClarityReadingPage() {
       <div className="min-h-screen bg-[#090610] text-white">
         <Navigation />
         <main className="mx-auto max-w-xl px-5 pb-20 pt-32 text-center">
-          <ShieldCheck className="mx-auto mb-5 h-10 w-10 text-amber-300" />
+          <ShieldCheck aria-hidden="true" className="mx-auto mb-5 h-10 w-10 text-amber-300" />
           <h1 className="mb-3 font-serif text-4xl">This reading could not be loaded.</h1>
-          <p className="mb-7 text-white/60">No interpretation should be invented when the profile itself is unavailable.</p>
-          <Link href="/" className="inline-flex items-center gap-2 rounded-xl bg-amber-300 px-5 py-3 font-semibold text-black">
-            Return home <ArrowRight className="h-4 w-4" />
+          <p className="mb-7 text-white/60">
+            No interpretation should be invented when the profile itself is unavailable.
+          </p>
+          <Link
+            href="/"
+            className="inline-flex min-h-11 items-center gap-2 rounded-xl bg-amber-300 px-5 py-3 font-semibold text-black focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+          >
+            Return home <ArrowRight aria-hidden="true" className="h-4 w-4" />
           </Link>
         </main>
       </div>
     );
   }
 
-  const astrology = (profile.astrologyData ?? {}) as any;
-  const numerology = (profile.numerologyData ?? {}) as any;
-  const personality = (profile.personalityData ?? {}) as any;
-  const archetype = (profile.archetypeData ?? {}) as any;
-
-  const title = firstText(archetype.title, archetype.name) ?? "Your evolving pattern";
-  const summary = firstText(
-    profile.biography,
-    archetype.description,
-    "Your available profile contains symbolic and calculated signals that should be tested against lived experience rather than treated as fixed identity.",
-  )!;
-
-  const strength = firstText(
-    archetype.strengths?.[0],
-    archetype.gifts?.[0],
-    "You may be especially effective when reflection becomes a practical decision rather than endless analysis.",
-  )!;
-  const shadow = firstText(
-    archetype.shadows?.[0],
-    archetype.growthAreas?.[0],
-    "A useful strength can become costly when it is overused, performed for approval, or used to avoid a necessary choice.",
-  )!;
-  const protection = firstText(
-    archetype.protectiveFunction,
-    archetype.hiddenNeed,
-    "This pattern may be protecting stability, dignity, belonging, certainty, or emotional safety. The profile cannot prove which one without your lived context.",
-  )!;
-  const relationship = firstText(
-    archetype.relationshipImpact,
-    personality.relationshipStyle,
-    "In relationships, the central task is to name needs and boundaries directly instead of expecting other people to decode them.",
-  )!;
-
-  const verifiedSignals = [
-    astrology.sunSign && `${astrology.sunSign} Sun`,
-    astrology.moonSign && `${astrology.moonSign} Moon`,
-    astrology.risingSign && `${astrology.risingSign} Rising`,
-    numerology.lifePath && `Life Path ${numerology.lifePath}`,
-    personality.enneagram?.type && `Enneagram ${personality.enneagram.type}`,
-  ].filter(Boolean) as string[];
+  const model = buildClarityReadingModel(profile as any);
 
   return (
     <div className="min-h-screen bg-[radial-gradient(circle_at_50%_-10%,rgba(106,61,170,.32),transparent_36%),linear-gradient(180deg,#090610,#0d0917_52%,#08060d)] text-white">
       <Navigation />
-      <main className="mx-auto max-w-6xl px-4 pb-24 pt-28 sm:px-6">
-        <Link href={`/profile/${profile.id}`} className="mb-8 inline-flex items-center gap-2 text-sm text-white/55 transition hover:text-white">
-          <ArrowLeft className="h-4 w-4" /> Full profile and evidence
-        </Link>
-
-        <header className="mb-9 max-w-4xl">
-          <p className="mb-3 text-[11px] font-bold uppercase tracking-[0.22em] text-amber-300">Clarity reading</p>
-          <h1 className="mb-5 font-serif text-5xl leading-[0.96] tracking-tight sm:text-7xl">{profile.name}, this is the pattern worth understanding.</h1>
-          <p className="max-w-3xl text-lg leading-8 text-white/68">{summary}</p>
-        </header>
-
-        <section className="mb-6 rounded-3xl border border-amber-300/30 bg-gradient-to-br from-violet-950/75 to-black/45 p-6 shadow-2xl backdrop-blur sm:p-9">
-          <div className="mb-4 flex items-center gap-3 text-amber-300">
-            <Sparkles className="h-5 w-5" />
-            <span className="text-[11px] font-bold uppercase tracking-[0.18em]">Core synthesis</span>
-          </div>
-          <h2 className="mb-4 font-serif text-3xl sm:text-5xl">{title}</h2>
-          <p className="max-w-3xl text-base leading-8 text-white/70">
-            The purpose of this reading is not to force you into a label. It is to show the likely pattern, what it may protect, what it gives you, what it costs, and the next choice you can test in real life.
-          </p>
-        </section>
-
-        <section className="mb-6 grid gap-4 md:grid-cols-2">
-          <ReadingCard eyebrow="What people may notice" title="The visible strength" body={strength} icon={Eye} />
-          <ReadingCard eyebrow="What may be underneath" title="The protective function" body={protection} icon={ShieldCheck} tone="violet" />
-          <ReadingCard eyebrow="The gift" title="What this pattern can become" body={strength} icon={Gift} tone="teal" />
-          <ReadingCard eyebrow="The cost" title="When the strength turns against you" body={shadow} icon={Target} tone="gold" />
-          <ReadingCard eyebrow="Connection" title="How it may affect relationships" body={relationship} icon={HeartHandshake} tone="violet" />
-          <ReadingCard
-            eyebrow="Grounded action"
-            title="One move to test today"
-            body="Choose one situation where you usually over-explain, delay, perform, withdraw, or take over. Replace the automatic move with one direct sentence and one observable action. Then record what actually happened."
-            icon={CheckCircle2}
-            tone="teal"
-          />
-        </section>
-
-        <section className="rounded-2xl border border-white/10 bg-white/[0.035] p-5 sm:p-6">
-          <div className="mb-4 flex items-center gap-2 text-teal-300">
-            <ShieldCheck className="h-5 w-5" />
-            <h2 className="font-semibold">Evidence remains inspectable</h2>
-          </div>
-          {verifiedSignals.length > 0 ? (
-            <div className="mb-4 flex flex-wrap gap-2">
-              {verifiedSignals.map((signal) => (
-                <span key={signal} className="rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-sm text-white/70">
-                  {signal}
-                </span>
-              ))}
-            </div>
-          ) : (
-            <p className="mb-4 text-white/60">No supported summary signals were available to display here.</p>
-          )}
-          <p className="text-sm leading-6 text-white/50">
-            Symbolic overlap is supporting context, not independent proof. Unknown or approximate birth-time inputs must remain visibly uncertain. Lived experience is the final correction layer.
-          </p>
-        </section>
-      </main>
+      <ClarityReadingExperience
+        profileId={String(profile.id)}
+        profileName={profile.name}
+        model={model}
+      />
     </div>
   );
 }

--- a/client/src/pages/OfflineClarityReadingPage.tsx
+++ b/client/src/pages/OfflineClarityReadingPage.tsx
@@ -1,49 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import { Link, useParams } from "wouter";
 import type { OfflineCodexProfile } from "@soulcodex/core";
-import {
-  ArrowLeft,
-  ArrowRight,
-  CheckCircle2,
-  Eye,
-  Gift,
-  HeartHandshake,
-  ShieldCheck,
-  Sparkles,
-  Target,
-} from "lucide-react";
+import { ArrowRight, ShieldCheck } from "lucide-react";
 import Navigation from "@/components/navigation";
+import ClarityReadingExperience from "@/components/ClarityReadingExperience";
+import { buildClarityReadingModel } from "@/lib/clarityReadingModel";
 import { loadOfflineProfile } from "@/lib/offlineProfileStore";
-import { getVerifiedAstrologySign } from "@/lib/profileVerificationReconciliation";
-
-type ReadingCardProps = {
-  eyebrow: string;
-  title: string;
-  body: string;
-  icon: React.ComponentType<{ className?: string }>;
-  tone?: "gold" | "violet" | "teal";
-};
-
-const toneClass = {
-  gold: "text-amber-300 border-amber-300/20",
-  violet: "text-violet-300 border-violet-300/20",
-  teal: "text-teal-300 border-teal-300/20",
-};
-
-function ReadingCard({ eyebrow, title, body, icon: Icon, tone = "gold" }: ReadingCardProps) {
-  return (
-    <article className={`rounded-2xl border bg-black/20 p-5 sm:p-6 backdrop-blur ${toneClass[tone]}`}>
-      <Icon className="mb-4 h-5 w-5" />
-      <p className="mb-2 text-[11px] font-bold uppercase tracking-[0.18em] text-white/45">{eyebrow}</p>
-      <h2 className="mb-3 font-serif text-2xl leading-tight text-white">{title}</h2>
-      <p className="leading-7 text-white/68">{body}</p>
-    </article>
-  );
-}
-
-function firstText(...values: unknown[]): string | undefined {
-  return values.find((value) => typeof value === "string" && value.trim().length > 0) as string | undefined;
-}
 
 export default function OfflineClarityReadingPage() {
   const { id } = useParams();
@@ -62,9 +24,12 @@ export default function OfflineClarityReadingPage() {
     return (
       <div className="min-h-screen bg-[#090610] text-white">
         <Navigation />
-        <main className="flex min-h-screen items-center justify-center px-5 pt-20">
+        <main className="flex min-h-screen items-center justify-center px-5 pt-20" aria-live="polite">
           <div className="text-center">
-            <div className="mx-auto mb-4 h-11 w-11 animate-spin rounded-full border-2 border-white/15 border-t-amber-300" />
+            <div
+              aria-hidden="true"
+              className="mx-auto mb-4 h-11 w-11 animate-spin rounded-full border-2 border-white/15 border-t-amber-300"
+            />
             <p className="text-white/60">Opening the clarity reading stored on this device...</p>
           </div>
         </main>
@@ -77,93 +42,33 @@ export default function OfflineClarityReadingPage() {
       <div className="min-h-screen bg-[#090610] text-white">
         <Navigation />
         <main className="mx-auto max-w-xl px-5 pb-20 pt-32 text-center">
-          <ShieldCheck className="mx-auto mb-5 h-10 w-10 text-amber-300" />
+          <ShieldCheck aria-hidden="true" className="mx-auto mb-5 h-10 w-10 text-amber-300" />
           <h1 className="mb-3 font-serif text-4xl">This local reading is unavailable.</h1>
-          <p className="mb-7 text-white/60">Soul Codex will not manufacture a replacement when the saved profile cannot be found.</p>
-          <Link href="/create" className="inline-flex items-center gap-2 rounded-xl bg-amber-300 px-5 py-3 font-semibold text-black">
-            Create a local Codex <ArrowRight className="h-4 w-4" />
+          <p className="mb-7 text-white/60">
+            Soul Codex will not manufacture a replacement when the saved profile cannot be found.
+          </p>
+          <Link
+            href="/create"
+            className="inline-flex min-h-11 items-center gap-2 rounded-xl bg-amber-300 px-5 py-3 font-semibold text-black focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+          >
+            Create a local Codex <ArrowRight aria-hidden="true" className="h-4 w-4" />
           </Link>
         </main>
       </div>
     );
   }
 
-  const astrology = profile.astrologyData as any;
-  const numerology = profile.numerologyData as any;
-  const archetype = profile.archetypeData as any;
-  const depth = profile.depthInterpretation as any;
-  const verifiedAstrology = (profile as any).verifiedAstrologyData;
-
-  const title = firstText(depth?.claritySummary?.title, archetype.title) ?? "Your evolving pattern";
-  const summary = firstText(depth?.claritySummary?.summary, profile.biography, archetype.description)!;
-  const strength = firstText(depth?.gift?.summary, archetype.strengths?.[0], "A strength becomes useful when it produces a clear decision rather than another layer of analysis.")!;
-  const shadow = firstText(depth?.shadow?.summary, archetype.shadows?.[0], "The same strength can become costly when it is overused or used to avoid a necessary choice.")!;
-  const protection = firstText(depth?.protectiveFunction?.summary, depth?.hiddenNeed?.summary, "This pattern may protect stability, dignity, belonging, certainty, or emotional safety. Your lived context decides which explanation fits.")!;
-  const relationship = firstText(depth?.relationshipImpact?.summary, "In relationships, name the need or boundary directly instead of requiring another person to decode it.")!;
-  const action = firstText(depth?.action?.summary, profile.dailyGuidance, "Replace one automatic response with one direct sentence and one observable action, then record what actually happened.")!;
-
-  const verifiedSun = getVerifiedAstrologySign(verifiedAstrology, "sun");
-  const verifiedMoon = getVerifiedAstrologySign(verifiedAstrology, "moon");
-  const verifiedRising = getVerifiedAstrologySign(verifiedAstrology, "rising");
-  const supportedSignals = [
-    verifiedSun && `${verifiedSun} Sun · verified`,
-    verifiedMoon && `${verifiedMoon} Moon · verified`,
-    verifiedRising && `${verifiedRising} Rising · verified`,
-    numerology.lifePath && `Life Path ${numerology.lifePath} · deterministic`,
-  ].filter(Boolean) as string[];
+  const model = buildClarityReadingModel(profile as any);
 
   return (
     <div className="min-h-screen bg-[radial-gradient(circle_at_50%_-10%,rgba(106,61,170,.32),transparent_36%),linear-gradient(180deg,#090610,#0d0917_52%,#08060d)] text-white">
       <Navigation />
-      <main className="mx-auto max-w-6xl px-4 pb-24 pt-28 sm:px-6">
-        <Link href={`/profile/${profile.id}`} className="mb-8 inline-flex items-center gap-2 text-sm text-white/55 transition hover:text-white">
-          <ArrowLeft className="h-4 w-4" /> Local profile and evidence
-        </Link>
-
-        <header className="mb-9 max-w-4xl">
-          <div className="mb-3 flex flex-wrap items-center gap-3">
-            <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-amber-300">Offline clarity reading</p>
-            <span className="rounded-full border border-teal-300/20 bg-teal-300/5 px-3 py-1 text-xs text-teal-200">Saved on this device</span>
-          </div>
-          <h1 className="mb-5 font-serif text-5xl leading-[0.96] tracking-tight sm:text-7xl">{profile.name}, this is the pattern worth understanding.</h1>
-          <p className="max-w-3xl text-lg leading-8 text-white/68">{summary}</p>
-        </header>
-
-        <section className="mb-6 rounded-3xl border border-amber-300/30 bg-gradient-to-br from-violet-950/75 to-black/45 p-6 shadow-2xl backdrop-blur sm:p-9">
-          <div className="mb-4 flex items-center gap-3 text-amber-300">
-            <Sparkles className="h-5 w-5" />
-            <span className="text-[11px] font-bold uppercase tracking-[0.18em]">Core synthesis</span>
-          </div>
-          <h2 className="mb-4 font-serif text-3xl sm:text-5xl">{title}</h2>
-          <p className="max-w-3xl text-base leading-8 text-white/70">This local reading uses the evidence already stored on your device. Missing or unverified layers stay unresolved rather than being quietly promoted into facts.</p>
-        </section>
-
-        <section className="mb-6 grid gap-4 md:grid-cols-2">
-          <ReadingCard eyebrow="What people may notice" title="The visible strength" body={strength} icon={Eye} />
-          <ReadingCard eyebrow="What may be underneath" title="The protective function" body={protection} icon={ShieldCheck} tone="violet" />
-          <ReadingCard eyebrow="The gift" title="What this pattern can become" body={strength} icon={Gift} tone="teal" />
-          <ReadingCard eyebrow="The cost" title="When the strength turns against you" body={shadow} icon={Target} />
-          <ReadingCard eyebrow="Connection" title="How it may affect relationships" body={relationship} icon={HeartHandshake} tone="violet" />
-          <ReadingCard eyebrow="Grounded action" title="One move to test today" body={action} icon={CheckCircle2} tone="teal" />
-        </section>
-
-        <section className="rounded-2xl border border-white/10 bg-white/[0.035] p-5 sm:p-6">
-          <div className="mb-4 flex items-center gap-2 text-teal-300">
-            <ShieldCheck className="h-5 w-5" />
-            <h2 className="font-semibold">Local evidence remains inspectable</h2>
-          </div>
-          {supportedSignals.length > 0 ? (
-            <div className="mb-4 flex flex-wrap gap-2">
-              {supportedSignals.map((signal) => (
-                <span key={signal} className="rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-sm text-white/70">{signal}</span>
-              ))}
-            </div>
-          ) : (
-            <p className="mb-4 text-white/60">No independently verified astronomy signals are stored yet. Deterministic and symbolic layers remain labeled accordingly.</p>
-          )}
-          <p className="text-sm leading-6 text-white/50">Symbolic overlap is context, not independent proof. Approximate or unknown birth-time layers remain uncertain. Lived experience is the final correction layer.</p>
-        </section>
-      </main>
+      <ClarityReadingExperience
+        profileId={String(profile.id)}
+        profileName={profile.name}
+        model={model}
+        offline
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Expanded maximum-load integration pass

This PR turns the shared V4 clarity contract into the actual runtime used by both reading experiences and now closes the profile-to-reading navigation gap.

### Runtime unification
- Adds one shared `ClarityReadingExperience` renderer for online and offline profiles.
- Removes duplicated card, evidence, limitation, confidence, and accessibility markup from both pages.
- Routes both pages through `buildClarityReadingModel`, so confidence labels and fallback behavior cannot drift apart.
- Displays each signal with its explicit confidence class and source.
- Renders limitations as a readable correction list rather than one buried disclaimer paragraph.

### Profile journey
- Adds a persistent, safe-area-aware profile launcher into the clarity reading.
- Supports server and `local-*` profile ids without changing offline dispatch.
- Preserves the full profile as the detailed evidence surface while making the clarity-first reading the obvious next step.
- Adds focused navigation tests for server, local, and missing-id behavior.

### Model hardening
- Supports direct depth fields and nested offline sections such as `claritySummary.summary`, `gift.summary`, `shadow.summary`, and `action.summary`.
- Adds Soul Urge as a deterministic name calculation.
- Prevents duplicate signal IDs.
- Preserves verified-over-symbolic precedence and refuses to invent Moon or Rising.

### UX and accessibility
- Adds main-content landmarks and labelled sections.
- Improves keyboard focus visibility and minimum tap targets.
- Uses responsive heading sizes for narrow phones.
- Marks decorative icons correctly and exposes loading state politely.
- Keeps the profile launcher reachable above mobile safe-area insets.

### Required gates
- TypeScript and production build
- CI tests
- dependency security audit
- PWA offline browser validation
- Railway container smoke
- live ephemeris evidence

All prior gates passed before the profile-journey expansion. The updated head must pass them again before merge.