### PR TITLE
Build the V4 Depth Engine and replace terminal one-line readings

### DIFF
--- a/client/src/components/ClarityReadingExperience.tsx
+++ b/client/src/components/ClarityReadingExperience.tsx
@@ -1,3 +1,4 @@
+import { useMemo, useState } from "react";
 import { Link } from "wouter";
 import {
   ArrowLeft,
@@ -14,27 +15,18 @@ import type {
   ClarityConfidence,
   ClarityReadingModel,
 } from "@/lib/clarityReadingModel";
+import {
+  buildDepthChapters,
+  type DepthChapter,
+  type ReadingDepth,
+} from "@/lib/depthEngine";
 import { getProfilePath } from "@/lib/clarityNavigation";
-
-type ReadingCardProps = {
-  eyebrow: string;
-  title: string;
-  body: string;
-  icon: React.ComponentType<{ className?: string }>;
-  tone?: "gold" | "violet" | "teal";
-};
 
 type ClarityReadingExperienceProps = {
   profileId: string;
   profileName: string;
   model: ClarityReadingModel;
   offline?: boolean;
-};
-
-const toneClass = {
-  gold: "text-amber-300 border-amber-300/20",
-  violet: "text-violet-300 border-violet-300/20",
-  teal: "text-teal-300 border-teal-300/20",
 };
 
 const confidenceClass: Record<ClarityConfidence, string> = {
@@ -45,18 +37,80 @@ const confidenceClass: Record<ClarityConfidence, string> = {
   unavailable: "border-white/10 bg-white/5 text-white/50",
 };
 
-function ReadingCard({ eyebrow, title, body, icon: Icon, tone = "gold" }: ReadingCardProps) {
+const chapterIcons = [Eye, ShieldCheck, Gift, Target, HeartHandshake];
+
+function DepthChapterCard({ chapter, depth, index }: { chapter: DepthChapter; depth: ReadingDepth; index: number }) {
+  const Icon = chapterIcons[index] ?? Sparkles;
+  const showStandard = depth === "standard" || depth === "deep";
+  const showDeep = depth === "deep";
+
   return (
-    <article className={`rounded-2xl border bg-black/20 p-5 backdrop-blur sm:p-6 ${toneClass[tone]}`}>
-      <Icon aria-hidden="true" className="mb-4 h-5 w-5" />
-      <p className="mb-2 text-[11px] font-bold uppercase tracking-[0.18em] text-white/45">{eyebrow}</p>
-      <h2 className="mb-3 font-serif text-2xl leading-tight text-white">{title}</h2>
-      <p className="leading-7 text-white/70">{body}</p>
+    <article className="rounded-3xl border border-white/10 bg-black/25 p-5 shadow-xl backdrop-blur sm:p-7">
+      <div className="mb-4 flex items-start gap-3">
+        <span className="mt-0.5 rounded-xl border border-amber-300/20 bg-amber-300/10 p-2 text-amber-300">
+          <Icon aria-hidden="true" className="h-5 w-5" />
+        </span>
+        <div>
+          <p className="mb-1 text-[11px] font-bold uppercase tracking-[0.18em] text-white/45">{chapter.eyebrow}</p>
+          <h2 className="font-serif text-2xl leading-tight text-white sm:text-3xl">{chapter.title}</h2>
+        </div>
+      </div>
+
+      <p className="mb-4 leading-7 text-white/75">{chapter.observation}</p>
+
+      {showStandard && (
+        <div className="space-y-5 border-t border-white/10 pt-5">
+          <section>
+            <h3 className="mb-2 text-sm font-bold uppercase tracking-[0.13em] text-violet-200">What this means in plain language</h3>
+            <p className="leading-7 text-white/68">{chapter.translation}</p>
+          </section>
+          <section>
+            <h3 className="mb-2 text-sm font-bold uppercase tracking-[0.13em] text-teal-200">How it may show up</h3>
+            <ul className="space-y-2 text-white/65">
+              {chapter.dailyLife.map((item) => <li key={item} className="flex gap-2 leading-7"><span aria-hidden="true">•</span><span>{item}</span></li>)}
+            </ul>
+          </section>
+          <div className="grid gap-4 md:grid-cols-2">
+            <section className="rounded-2xl border border-teal-300/15 bg-teal-300/[0.04] p-4">
+              <h3 className="mb-2 font-semibold text-teal-200">Healthy strength</h3>
+              <p className="leading-7 text-white/65">{chapter.strength}</p>
+            </section>
+            <section className="rounded-2xl border border-amber-300/15 bg-amber-300/[0.04] p-4">
+              <h3 className="mb-2 font-semibold text-amber-200">Cost when overused</h3>
+              <p className="leading-7 text-white/65">{chapter.cost}</p>
+            </section>
+          </div>
+        </div>
+      )}
+
+      {showDeep && (
+        <div className="mt-5 space-y-5 border-t border-white/10 pt-5">
+          <section>
+            <h3 className="mb-2 font-semibold text-violet-200">How other people may experience it</h3>
+            <p className="leading-7 text-white/65">{chapter.relationshipView}</p>
+          </section>
+          <section>
+            <h3 className="mb-2 font-semibold text-amber-200">What changes under stress</h3>
+            <p className="leading-7 text-white/65">{chapter.stressView}</p>
+          </section>
+          <section className="rounded-2xl border border-violet-300/20 bg-violet-300/[0.05] p-4">
+            <h3 className="mb-2 font-semibold text-violet-100">Reflection check</h3>
+            <p className="leading-7 text-white/75">{chapter.reflection}</p>
+          </section>
+          <section className="rounded-2xl border border-teal-300/20 bg-teal-300/[0.05] p-4">
+            <h3 className="mb-2 flex items-center gap-2 font-semibold text-teal-100"><CheckCircle2 aria-hidden="true" className="h-4 w-4" /> One grounded move</h3>
+            <p className="leading-7 text-white/75">{chapter.action}</p>
+          </section>
+        </div>
+      )}
     </article>
   );
 }
 
 export default function ClarityReadingExperience({ profileId, profileName, model, offline = false }: ClarityReadingExperienceProps) {
+  const [depth, setDepth] = useState<ReadingDepth>("standard");
+  const chapters = useMemo(() => buildDepthChapters(model), [model]);
+
   return (
     <main id="main-content" className="mx-auto max-w-6xl px-4 pb-24 pt-28 sm:px-6" aria-labelledby="clarity-reading-title">
       <Link href={getProfilePath(profileId)} className="mb-8 inline-flex min-h-11 items-center gap-2 rounded-lg px-2 text-sm text-white/60 transition hover:bg-white/5 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300">
@@ -64,61 +118,42 @@ export default function ClarityReadingExperience({ profileId, profileName, model
         {offline ? "Local profile and evidence" : "Full profile and evidence"}
       </Link>
 
-      <header className="mb-9 max-w-4xl">
-        <div className="mb-3 flex flex-wrap items-center gap-3">
-          <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-amber-300">{offline ? "Offline clarity reading" : "Clarity reading"}</p>
-          {offline && <span className="rounded-full border border-teal-300/20 bg-teal-300/5 px-3 py-1 text-xs text-teal-200">Saved on this device</span>}
-        </div>
-        <h1 id="clarity-reading-title" className="mb-5 font-serif text-4xl leading-[0.98] tracking-tight sm:text-6xl lg:text-7xl">{profileName}, this is the pattern worth understanding.</h1>
+      <header className="mb-8 max-w-4xl">
+        <p className="mb-3 text-[11px] font-bold uppercase tracking-[0.22em] text-amber-300">{offline ? "Offline depth reading" : "Depth reading"}</p>
+        <h1 id="clarity-reading-title" className="mb-5 font-serif text-4xl leading-[0.98] tracking-tight sm:text-6xl lg:text-7xl">{profileName}, let&apos;s explain the pattern instead of naming it.</h1>
         <p className="max-w-3xl text-lg leading-8 text-white/70">{model.summary}</p>
       </header>
 
       <section aria-labelledby="core-synthesis-title" className="mb-6 rounded-3xl border border-amber-300/30 bg-gradient-to-br from-violet-950/75 to-black/45 p-6 shadow-2xl backdrop-blur sm:p-9">
-        <div className="mb-4 flex items-center gap-3 text-amber-300">
-          <Sparkles aria-hidden="true" className="h-5 w-5" />
-          <span className="text-[11px] font-bold uppercase tracking-[0.18em]">Core synthesis</span>
-        </div>
+        <div className="mb-4 flex items-center gap-3 text-amber-300"><Sparkles aria-hidden="true" className="h-5 w-5" /><span className="text-[11px] font-bold uppercase tracking-[0.18em]">Core synthesis</span></div>
         <h2 id="core-synthesis-title" className="mb-4 font-serif text-3xl sm:text-5xl">{model.title}</h2>
-        <p className="max-w-3xl text-base leading-8 text-white/70">{offline ? "This reading uses evidence stored on your device. Missing or unverified layers stay unresolved rather than being quietly promoted into facts." : "This reading separates supported patterns from certainty. It shows what the pattern may protect, what it gives you, what it costs, and a next choice you can test in real life."}</p>
+        <p className="max-w-3xl text-base leading-8 text-white/70">This reading separates observation from interpretation, then follows the pattern into daily life, strengths, costs, relationships, stress, reflection, and action.</p>
       </section>
 
-      <section aria-label="Clarity reading chapters" className="mb-6 grid gap-4 md:grid-cols-2">
-        <ReadingCard eyebrow="What people may notice" title="The visible pattern" body={model.visiblePattern} icon={Eye} />
-        <ReadingCard eyebrow="What may be underneath" title="The protective function" body={model.protectiveFunction} icon={ShieldCheck} tone="violet" />
-        <ReadingCard eyebrow="The gift" title="What this pattern can become" body={model.gift} icon={Gift} tone="teal" />
-        <ReadingCard eyebrow="The cost" title="When the strength turns against you" body={model.cost} icon={Target} />
-        <ReadingCard eyebrow="Connection" title="How it may affect relationships" body={model.relationshipImpact} icon={HeartHandshake} tone="violet" />
-        <ReadingCard eyebrow="Grounded action" title="One move to test today" body={model.groundedAction} icon={CheckCircle2} tone="teal" />
+      <section aria-label="Reading depth" className="mb-6 rounded-2xl border border-white/10 bg-white/[0.035] p-4">
+        <p className="mb-3 text-sm font-semibold text-white/75">Choose how far to go</p>
+        <div className="grid gap-2 sm:grid-cols-3" role="group" aria-label="Choose reading depth">
+          {(["quick", "standard", "deep"] as ReadingDepth[]).map((option) => (
+            <button key={option} type="button" onClick={() => setDepth(option)} aria-pressed={depth === option} className={`min-h-11 rounded-xl border px-4 py-2 text-sm font-semibold capitalize transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300 ${depth === option ? "border-amber-300/40 bg-amber-300/15 text-amber-100" : "border-white/10 bg-black/20 text-white/60 hover:bg-white/5"}`}>
+              {option === "quick" ? "Quick insight" : option === "standard" ? "Standard reading" : "Deep dive"}
+            </button>
+          ))}
+        </div>
+      </section>
+
+      <section aria-label="Depth reading chapters" className="mb-6 grid gap-5">
+        {chapters.map((chapter, index) => <DepthChapterCard key={chapter.id} chapter={chapter} depth={depth} index={index} />)}
       </section>
 
       <section aria-labelledby="evidence-title" className="rounded-2xl border border-white/10 bg-white/[0.035] p-5 sm:p-6">
-        <div className="mb-4 flex items-center gap-2 text-teal-300">
-          <ShieldCheck aria-hidden="true" className="h-5 w-5" />
-          <h2 id="evidence-title" className="font-semibold">{offline ? "Local evidence remains inspectable" : "Evidence remains inspectable"}</h2>
-        </div>
-        <p className="mb-4 text-sm leading-6 text-white/55">The reading stays simple up front. Open the details below when you want to inspect sources, confidence, and unresolved limits.</p>
-
+        <div className="mb-4 flex items-center gap-2 text-teal-300"><ShieldCheck aria-hidden="true" className="h-5 w-5" /><h2 id="evidence-title" className="font-semibold">Evidence remains inspectable</h2></div>
+        <p className="mb-4 text-sm leading-6 text-white/55">Depth does not grant certainty. Open the details to inspect sources, confidence, and unresolved limits.</p>
         <details className="group rounded-xl border border-white/10 bg-black/20 p-4">
-          <summary className="flex min-h-11 cursor-pointer list-none items-center justify-between gap-3 rounded-lg text-sm font-semibold text-white/80 outline-none focus-visible:ring-2 focus-visible:ring-amber-300">
-            Evidence and confidence details
-            <ChevronDown aria-hidden="true" className="h-4 w-4 transition group-open:rotate-180" />
-          </summary>
+          <summary className="flex min-h-11 cursor-pointer list-none items-center justify-between gap-3 rounded-lg text-sm font-semibold text-white/80 outline-none focus-visible:ring-2 focus-visible:ring-amber-300">Evidence and confidence details<ChevronDown aria-hidden="true" className="h-4 w-4 transition group-open:rotate-180" /></summary>
           <div className="pt-4">
-            {model.signals.length > 0 ? (
-              <ul className="mb-5 grid gap-2 sm:grid-cols-2" aria-label="Reading evidence signals">
-                {model.signals.map((signal) => (
-                  <li key={signal.id} className={`rounded-xl border px-3 py-2.5 text-sm ${confidenceClass[signal.confidence]}`}>
-                    <div><span className="font-semibold">{signal.label}:</span> {signal.value}</div>
-                    <div className="mt-1 text-xs opacity-70">{signal.confidence} · {signal.source}</div>
-                  </li>
-                ))}
-              </ul>
-            ) : <p className="mb-5 text-white/60">No supported summary signals are available.</p>}
-
+            {model.signals.length > 0 ? <ul className="mb-5 grid gap-2 sm:grid-cols-2" aria-label="Reading evidence signals">{model.signals.map((signal) => <li key={signal.id} className={`rounded-xl border px-3 py-2.5 text-sm ${confidenceClass[signal.confidence]}`}><div><span className="font-semibold">{signal.label}:</span> {signal.value}</div><div className="mt-1 text-xs opacity-70">{signal.confidence} · {signal.source}</div></li>)}</ul> : <p className="mb-5 text-white/60">No supported summary signals are available.</p>}
             <h3 className="mb-2 text-sm font-semibold text-white/75">Limits and corrections</h3>
-            <ul className="space-y-2 text-sm leading-6 text-white/55">
-              {model.limitations.map((limitation) => <li key={limitation} className="flex gap-2"><span aria-hidden="true">•</span><span>{limitation}</span></li>)}
-            </ul>
+            <ul className="space-y-2 text-sm leading-6 text-white/55">{model.limitations.map((limitation) => <li key={limitation} className="flex gap-2"><span aria-hidden="true">•</span><span>{limitation}</span></li>)}</ul>
           </div>
         </details>
       </section>

--- a/client/src/lib/depthEngine.ts
+++ b/client/src/lib/depthEngine.ts
@@ -1,0 +1,120 @@
+import type { ClarityReadingModel } from "@/lib/clarityReadingModel";
+
+export type ReadingDepth = "quick" | "standard" | "deep";
+
+export interface DepthChapter {
+  id: string;
+  eyebrow: string;
+  title: string;
+  observation: string;
+  translation: string;
+  dailyLife: string[];
+  strength: string;
+  cost: string;
+  relationshipView: string;
+  stressView: string;
+  reflection: string;
+  action: string;
+}
+
+type ChapterSeed = {
+  id: string;
+  eyebrow: string;
+  title: string;
+  observation: string;
+  counterpart: string;
+};
+
+const sentenceCount = (value: string) =>
+  value.split(/[.!?]+/).map((part) => part.trim()).filter(Boolean).length;
+
+export function isTerminalOneLiner(value: string): boolean {
+  return value.trim().length < 140 || sentenceCount(value) < 2;
+}
+
+function clean(value: string): string {
+  return value.trim().replace(/\s+/g, " ");
+}
+
+function translate(seed: ChapterSeed): string {
+  return `${clean(seed.observation)} In ordinary life, this is less about a permanent label and more about the move you are most likely to make when the situation touches this theme. The useful question is not only whether the description sounds familiar, but what the move is trying to accomplish and whether it still fits the present moment.`;
+}
+
+function dailyExamples(seed: ChapterSeed): string[] {
+  return [
+    `In decisions, this may appear as a preference for ${seed.counterpart} before you feel settled enough to move.`,
+    `In work or creativity, the same pattern may become a reliable skill when you choose it deliberately instead of reacting automatically.`,
+    `In conflict, other people may notice the behavior before they understand the need or concern underneath it.`,
+  ];
+}
+
+function chapter(seed: ChapterSeed, action: string): DepthChapter {
+  return {
+    ...seed,
+    observation: clean(seed.observation),
+    translation: translate(seed),
+    dailyLife: dailyExamples(seed),
+    strength: `At its healthiest, this pattern gives you a deliberate way to create ${seed.counterpart}. The strength is not the reflex itself; it is the judgment, awareness, and timing you develop around it.`,
+    cost: `The tradeoff begins when the pattern becomes the only available response. Then a useful strategy can turn rigid, hide new information, or make the present situation answer for an older fear.`,
+    relationshipView: `Other people may react to the visible behavior without seeing its purpose. Clarity improves when you name the underlying need directly instead of requiring someone else to decode the pattern from distance, intensity, silence, control, or over-explanation.`,
+    stressView: `Under stress, expect this theme to become faster and less flexible. The first sign is usually not the feeling itself, but the urge to repeat a familiar move before checking what this specific moment requires.`,
+    reflection: `Where did this pattern protect or strengthen you recently, and where did it continue after the danger or pressure had already passed?`,
+    action: clean(action),
+  };
+}
+
+export function buildDepthChapters(model: ClarityReadingModel): DepthChapter[] {
+  const seeds: ChapterSeed[] = [
+    {
+      id: "visible-pattern",
+      eyebrow: "What people may notice",
+      title: "The visible pattern",
+      observation: model.visiblePattern,
+      counterpart: "clarity, control, safety, distance, or forward movement",
+    },
+    {
+      id: "protective-function",
+      eyebrow: "What may be underneath",
+      title: "The protective function",
+      observation: model.protectiveFunction,
+      counterpart: "protection without losing honesty or flexibility",
+    },
+    {
+      id: "gift",
+      eyebrow: "The developed strength",
+      title: "What this pattern can become",
+      observation: model.gift,
+      counterpart: "discernment, skill, courage, and useful contribution",
+    },
+    {
+      id: "cost",
+      eyebrow: "The tradeoff",
+      title: "When the strength turns against you",
+      observation: model.cost,
+      counterpart: "choice instead of repetition",
+    },
+    {
+      id: "relationships",
+      eyebrow: "Connection",
+      title: "How it may affect relationships",
+      observation: model.relationshipImpact,
+      counterpart: "connection that does not require mind-reading",
+    },
+  ];
+
+  return seeds.map((seed) => chapter(seed, model.groundedAction));
+}
+
+export function chapterWordCount(chapter: DepthChapter): number {
+  return [
+    chapter.observation,
+    chapter.translation,
+    ...chapter.dailyLife,
+    chapter.strength,
+    chapter.cost,
+    chapter.relationshipView,
+    chapter.stressView,
+    chapter.reflection,
+    chapter.action,
+  ].join(" ").split(/\s+/).filter(Boolean).length;
+}

--- a/tests/depth-engine.test.ts
+++ b/tests/depth-engine.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDepthChapters,
+  chapterWordCount,
+  isTerminalOneLiner,
+} from "../client/src/lib/depthEngine";
+import type { ClarityReadingModel } from "../client/src/lib/clarityReadingModel";
+
+const model: ClarityReadingModel = {
+  title: "The thoughtful builder",
+  summary: "A test reading.",
+  visiblePattern: "You may pause before committing.",
+  protectiveFunction: "Pausing can protect you from acting before the picture feels complete.",
+  gift: "Deliberate attention can become discernment.",
+  cost: "Waiting too long can turn care into stalled movement.",
+  relationshipImpact: "Other people may mistake processing time for distance.",
+  groundedAction: "Name what you know, what you do not know, and the next reversible step.",
+  signals: [],
+  limitations: ["This is interpretive, not diagnostic."],
+};
+
+describe("Depth Engine", () => {
+  it("detects terminal one-line answers", () => {
+    expect(isTerminalOneLiner("You need freedom.")).toBe(true);
+    expect(isTerminalOneLiner("You need freedom. In practice, that can mean needing room to decide without feeling managed, while still remaining capable of commitment and honest connection when boundaries are clear.")).toBe(false);
+  });
+
+  it("turns every major insight into a complete chapter", () => {
+    const chapters = buildDepthChapters(model);
+    expect(chapters).toHaveLength(5);
+    for (const chapter of chapters) {
+      expect(chapter.translation.length).toBeGreaterThan(140);
+      expect(chapter.dailyLife).toHaveLength(3);
+      expect(chapter.strength).toBeTruthy();
+      expect(chapter.cost).toBeTruthy();
+      expect(chapter.relationshipView).toBeTruthy();
+      expect(chapter.stressView).toBeTruthy();
+      expect(chapter.reflection).toContain("?");
+      expect(chapter.action).toBe(model.groundedAction);
+      expect(chapterWordCount(chapter)).toBeGreaterThan(150);
+    }
+  });
+
+  it("keeps progressive depth controls in the reading experience", () => {
+    const source = require("node:fs").readFileSync("client/src/components/ClarityReadingExperience.tsx", "utf8");
+    expect(source).toContain("Quick insight");
+    expect(source).toContain("Standard reading");
+    expect(source).toContain("Deep dive");
+    expect(source).toContain("What this means in plain language");
+    expect(source).toContain("How other people may experience it");
+    expect(source).toContain("Reflection check");
+  });
+});

--- a/tests/depth-engine.test.ts
+++ b/tests/depth-engine.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import { describe, expect, it } from "vitest";
 import {
   buildDepthChapters,
@@ -42,7 +43,7 @@ describe("Depth Engine", () => {
   });
 
   it("keeps progressive depth controls in the reading experience", () => {
-    const source = require("node:fs").readFileSync("client/src/components/ClarityReadingExperience.tsx", "utf8");
+    const source = fs.readFileSync("client/src/components/ClarityReadingExperience.tsx", "utf8");
     expect(source).toContain("Quick insight");
     expect(source).toContain("Standard reading");
     expect(source).toContain("Deep dive");


### PR DESCRIPTION
## Purpose

Implement the first real Depth Engine pass so Soul Codex explains a pattern instead of ending after one sentence.

## Adds

- Progressive reading depth: Quick Insight, Standard Reading, and Deep Dive
- A reusable chapter model for visible pattern, protection, gift, cost, and relationship impact
- Plain-language translation
- Daily-life examples
- Healthy strength and overuse cost
- Relationship and stress views
- Reflection questions and grounded actions
- Minimum-depth regression tests that reject terminal one-liners

## Trust boundaries

- Depth does not increase certainty
- Evidence and limitations remain inspectable
- Interpretations remain separate from verified and deterministic signals
- No new symbolic systems, navigation concepts, or V5 work

## Validation

GitHub-hosted Actions remain billing-blocked. Validate through the documented Google Cloud Shell process before merge.