### PR TITLE
Turn Depth Engine traits into lived human explanations

### DIFF
--- a/client/src/components/ClarityReadingExperience.tsx
+++ b/client/src/components/ClarityReadingExperience.tsx
@@ -19,6 +19,7 @@ import {
   buildDepthChapters,
   type DepthChapter,
   type ReadingDepth,
+  type ReadingFit,
 } from "@/lib/depthEngine";
 import { getProfilePath } from "@/lib/clarityNavigation";
 
@@ -28,6 +29,8 @@ type ClarityReadingExperienceProps = {
   model: ClarityReadingModel;
   offline?: boolean;
 };
+
+type FitMap = Record<string, ReadingFit | undefined>;
 
 const confidenceClass: Record<ClarityConfidence, string> = {
   verified: "border-emerald-300/25 bg-emerald-300/10 text-emerald-100",
@@ -39,7 +42,25 @@ const confidenceClass: Record<ClarityConfidence, string> = {
 
 const chapterIcons = [Eye, ShieldCheck, Gift, Target, HeartHandshake];
 
-function DepthChapterCard({ chapter, depth, index }: { chapter: DepthChapter; depth: ReadingDepth; index: number }) {
+const fitOptions: Array<{ value: ReadingFit; label: string }> = [
+  { value: "very-much", label: "Very much" },
+  { value: "partly", label: "Partly" },
+  { value: "not-really", label: "Not really" },
+];
+
+function DepthChapterCard({
+  chapter,
+  depth,
+  index,
+  fit,
+  onFit,
+}: {
+  chapter: DepthChapter;
+  depth: ReadingDepth;
+  index: number;
+  fit?: ReadingFit;
+  onFit: (fit: ReadingFit) => void;
+}) {
   const Icon = chapterIcons[index] ?? Sparkles;
   const showStandard = depth === "standard" || depth === "deep";
   const showDeep = depth === "deep";
@@ -56,30 +77,34 @@ function DepthChapterCard({ chapter, depth, index }: { chapter: DepthChapter; de
         </div>
       </div>
 
-      <p className="mb-4 leading-7 text-white/75">{chapter.observation}</p>
+      <p className="mb-4 leading-7 text-white/78">{chapter.observation}</p>
 
       {showStandard && (
         <div className="space-y-5 border-t border-white/10 pt-5">
           <section>
             <h3 className="mb-2 text-sm font-bold uppercase tracking-[0.13em] text-violet-200">What this means in plain language</h3>
-            <p className="leading-7 text-white/68">{chapter.translation}</p>
+            <p className="leading-7 text-white/70">{chapter.translation}</p>
           </section>
           <section>
-            <h3 className="mb-2 text-sm font-bold uppercase tracking-[0.13em] text-teal-200">How it may show up</h3>
-            <ul className="space-y-2 text-white/65">
+            <h3 className="mb-2 text-sm font-bold uppercase tracking-[0.13em] text-teal-200">What this may look like in real life</h3>
+            <ul className="space-y-2 text-white/68">
               {chapter.dailyLife.map((item) => <li key={item} className="flex gap-2 leading-7"><span aria-hidden="true">•</span><span>{item}</span></li>)}
             </ul>
           </section>
           <div className="grid gap-4 md:grid-cols-2">
             <section className="rounded-2xl border border-teal-300/15 bg-teal-300/[0.04] p-4">
-              <h3 className="mb-2 font-semibold text-teal-200">Healthy strength</h3>
-              <p className="leading-7 text-white/65">{chapter.strength}</p>
+              <h3 className="mb-2 font-semibold text-teal-200">What this gives you</h3>
+              <p className="leading-7 text-white/68">{chapter.strength}</p>
             </section>
             <section className="rounded-2xl border border-amber-300/15 bg-amber-300/[0.04] p-4">
-              <h3 className="mb-2 font-semibold text-amber-200">Cost when overused</h3>
-              <p className="leading-7 text-white/65">{chapter.cost}</p>
+              <h3 className="mb-2 font-semibold text-amber-200">What it may cost</h3>
+              <p className="leading-7 text-white/68">{chapter.cost}</p>
             </section>
           </div>
+          <section className="rounded-2xl border border-white/10 bg-white/[0.035] p-4">
+            <h3 className="mb-2 font-semibold text-white/85">How this may be misunderstood</h3>
+            <p className="leading-7 text-white/68">{chapter.misunderstanding}</p>
+          </section>
         </div>
       )}
 
@@ -87,29 +112,69 @@ function DepthChapterCard({ chapter, depth, index }: { chapter: DepthChapter; de
         <div className="mt-5 space-y-5 border-t border-white/10 pt-5">
           <section>
             <h3 className="mb-2 font-semibold text-violet-200">How other people may experience it</h3>
-            <p className="leading-7 text-white/65">{chapter.relationshipView}</p>
+            <p className="leading-7 text-white/68">{chapter.relationshipView}</p>
           </section>
           <section>
             <h3 className="mb-2 font-semibold text-amber-200">What changes under stress</h3>
-            <p className="leading-7 text-white/65">{chapter.stressView}</p>
+            <p className="leading-7 text-white/68">{chapter.stressView}</p>
+          </section>
+          <section>
+            <h3 className="mb-2 font-semibold text-teal-200">What to do with this insight</h3>
+            <p className="leading-7 text-white/68">{chapter.practicalTakeaway}</p>
           </section>
           <section className="rounded-2xl border border-violet-300/20 bg-violet-300/[0.05] p-4">
             <h3 className="mb-2 font-semibold text-violet-100">Reflection check</h3>
-            <p className="leading-7 text-white/75">{chapter.reflection}</p>
+            <p className="leading-7 text-white/78">{chapter.reflection}</p>
           </section>
           <section className="rounded-2xl border border-teal-300/20 bg-teal-300/[0.05] p-4">
             <h3 className="mb-2 flex items-center gap-2 font-semibold text-teal-100"><CheckCircle2 aria-hidden="true" className="h-4 w-4" /> One grounded move</h3>
-            <p className="leading-7 text-white/75">{chapter.action}</p>
+            <p className="leading-7 text-white/78">{chapter.action}</p>
           </section>
         </div>
       )}
+
+      <section className="mt-5 border-t border-white/10 pt-5" aria-label={`Does ${chapter.title.toLowerCase()} fit your experience?`}>
+        <p className="mb-3 text-sm font-semibold text-white/80">Does this fit your experience?</p>
+        <div className="flex flex-wrap gap-2" role="group" aria-label="Reading fit feedback">
+          {fitOptions.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => onFit(option.value)}
+              aria-pressed={fit === option.value}
+              className={`min-h-11 rounded-xl border px-4 py-2 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300 ${fit === option.value ? "border-violet-300/45 bg-violet-300/15 text-violet-100" : "border-white/10 bg-black/20 text-white/60 hover:bg-white/5"}`}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+        {fit && <p className="mt-3 text-sm leading-6 text-white/50">Saved on this device. Your response corrects the interpretation; it does not rewrite your birth data or pretend the app knows more than you do.</p>}
+      </section>
     </article>
   );
 }
 
 export default function ClarityReadingExperience({ profileId, profileName, model, offline = false }: ClarityReadingExperienceProps) {
   const [depth, setDepth] = useState<ReadingDepth>("standard");
+  const [fits, setFits] = useState<FitMap>(() => {
+    if (typeof window === "undefined") return {};
+    try {
+      return JSON.parse(window.localStorage.getItem(`soulcodex:reading-fit:${profileId}`) ?? "{}") as FitMap;
+    } catch {
+      return {};
+    }
+  });
   const chapters = useMemo(() => buildDepthChapters(model), [model]);
+
+  const recordFit = (chapterId: string, fit: ReadingFit) => {
+    const next = { ...fits, [chapterId]: fit };
+    setFits(next);
+    try {
+      window.localStorage.setItem(`soulcodex:reading-fit:${profileId}`, JSON.stringify(next));
+    } catch {
+      // The reading remains usable when storage is unavailable.
+    }
+  };
 
   return (
     <main id="main-content" className="mx-auto max-w-6xl px-4 pb-24 pt-28 sm:px-6" aria-labelledby="clarity-reading-title">
@@ -119,15 +184,15 @@ export default function ClarityReadingExperience({ profileId, profileName, model
       </Link>
 
       <header className="mb-8 max-w-4xl">
-        <p className="mb-3 text-[11px] font-bold uppercase tracking-[0.22em] text-amber-300">{offline ? "Offline depth reading" : "Depth reading"}</p>
-        <h1 id="clarity-reading-title" className="mb-5 font-serif text-4xl leading-[0.98] tracking-tight sm:text-6xl lg:text-7xl">{profileName}, let&apos;s explain the pattern instead of naming it.</h1>
+        <p className="mb-3 text-[11px] font-bold uppercase tracking-[0.22em] text-amber-300">{offline ? "Offline human-depth reading" : "Human-depth reading"}</p>
+        <h1 id="clarity-reading-title" className="mb-5 font-serif text-4xl leading-[0.98] tracking-tight sm:text-6xl lg:text-7xl">{profileName}, let&apos;s follow the pattern into real life.</h1>
         <p className="max-w-3xl text-lg leading-8 text-white/70">{model.summary}</p>
       </header>
 
       <section aria-labelledby="core-synthesis-title" className="mb-6 rounded-3xl border border-amber-300/30 bg-gradient-to-br from-violet-950/75 to-black/45 p-6 shadow-2xl backdrop-blur sm:p-9">
         <div className="mb-4 flex items-center gap-3 text-amber-300"><Sparkles aria-hidden="true" className="h-5 w-5" /><span className="text-[11px] font-bold uppercase tracking-[0.18em]">Core synthesis</span></div>
         <h2 id="core-synthesis-title" className="mb-4 font-serif text-3xl sm:text-5xl">{model.title}</h2>
-        <p className="max-w-3xl text-base leading-8 text-white/70">This reading separates observation from interpretation, then follows the pattern into daily life, strengths, costs, relationships, stress, reflection, and action.</p>
+        <p className="max-w-3xl text-base leading-8 text-white/70">The goal is not to hand you another list of traits. Each chapter follows the pattern into decisions, work, relationships, stress, misunderstanding, tradeoffs, and one action you can test.</p>
       </section>
 
       <section aria-label="Reading depth" className="mb-6 rounded-2xl border border-white/10 bg-white/[0.035] p-4">
@@ -141,8 +206,17 @@ export default function ClarityReadingExperience({ profileId, profileName, model
         </div>
       </section>
 
-      <section aria-label="Depth reading chapters" className="mb-6 grid gap-5">
-        {chapters.map((chapter, index) => <DepthChapterCard key={chapter.id} chapter={chapter} depth={depth} index={index} />)}
+      <section aria-label="Human-depth reading chapters" className="mb-6 grid gap-5">
+        {chapters.map((chapter, index) => (
+          <DepthChapterCard
+            key={chapter.id}
+            chapter={chapter}
+            depth={depth}
+            index={index}
+            fit={fits[chapter.id]}
+            onFit={(fit) => recordFit(chapter.id, fit)}
+          />
+        ))}
       </section>
 
       <section aria-labelledby="evidence-title" className="rounded-2xl border border-white/10 bg-white/[0.035] p-5 sm:p-6">

--- a/client/src/lib/depthEngine.ts
+++ b/client/src/lib/depthEngine.ts
@@ -1,6 +1,7 @@
 import type { ClarityReadingModel } from "@/lib/clarityReadingModel";
 
 export type ReadingDepth = "quick" | "standard" | "deep";
+export type ReadingFit = "very-much" | "partly" | "not-really";
 
 export interface DepthChapter {
   id: string;
@@ -11,8 +12,10 @@ export interface DepthChapter {
   dailyLife: string[];
   strength: string;
   cost: string;
+  misunderstanding: string;
   relationshipView: string;
   stressView: string;
+  practicalTakeaway: string;
   reflection: string;
   action: string;
 }
@@ -22,7 +25,12 @@ type ChapterSeed = {
   eyebrow: string;
   title: string;
   observation: string;
-  counterpart: string;
+  healthyAim: string;
+  overuseRisk: string;
+  misunderstanding: string;
+  decisionExample: string;
+  relationshipExample: string;
+  workExample: string;
 };
 
 const sentenceCount = (value: string) =>
@@ -37,14 +45,14 @@ function clean(value: string): string {
 }
 
 function translate(seed: ChapterSeed): string {
-  return `${clean(seed.observation)} In ordinary life, this is less about a permanent label and more about the move you are most likely to make when the situation touches this theme. The useful question is not only whether the description sounds familiar, but what the move is trying to accomplish and whether it still fits the present moment.`;
+  return `${clean(seed.observation)} This is not best understood as a fixed trait stamped onto your identity. It is a pattern of attention and response that may become more visible when this part of life matters to you. In real situations, the pattern can help you create ${seed.healthyAim}; the important question is whether you are choosing it for the present moment or repeating it because it once kept you safe.`;
 }
 
 function dailyExamples(seed: ChapterSeed): string[] {
   return [
-    `In decisions, this may appear as a preference for ${seed.counterpart} before you feel settled enough to move.`,
-    `In work or creativity, the same pattern may become a reliable skill when you choose it deliberately instead of reacting automatically.`,
-    `In conflict, other people may notice the behavior before they understand the need or concern underneath it.`,
+    seed.decisionExample,
+    seed.relationshipExample,
+    seed.workExample,
   ];
 }
 
@@ -54,11 +62,13 @@ function chapter(seed: ChapterSeed, action: string): DepthChapter {
     observation: clean(seed.observation),
     translation: translate(seed),
     dailyLife: dailyExamples(seed),
-    strength: `At its healthiest, this pattern gives you a deliberate way to create ${seed.counterpart}. The strength is not the reflex itself; it is the judgment, awareness, and timing you develop around it.`,
-    cost: `The tradeoff begins when the pattern becomes the only available response. Then a useful strategy can turn rigid, hide new information, or make the present situation answer for an older fear.`,
-    relationshipView: `Other people may react to the visible behavior without seeing its purpose. Clarity improves when you name the underlying need directly instead of requiring someone else to decode the pattern from distance, intensity, silence, control, or over-explanation.`,
-    stressView: `Under stress, expect this theme to become faster and less flexible. The first sign is usually not the feeling itself, but the urge to repeat a familiar move before checking what this specific moment requires.`,
-    reflection: `Where did this pattern protect or strengthen you recently, and where did it continue after the danger or pressure had already passed?`,
+    strength: `When used consciously, this pattern can become ${seed.healthyAim}. You are not merely reacting; you are turning sensitivity to this theme into judgment, timing, and a dependable way of responding. That is the part other people may come to trust in you.`,
+    cost: `The tradeoff appears when the same strategy becomes automatic. Then ${seed.overuseRisk}. A strength can keep its honorable name long after it has stopped helping, which is how people end up defending exhaustion as loyalty, delay as wisdom, or control as responsibility.`,
+    misunderstanding: seed.misunderstanding,
+    relationshipView: `In close relationships, people usually meet the visible behavior before they understand the need beneath it. Naming the need directly gives the other person a fair chance to respond. Without that translation, they may react to your silence, intensity, distance, fixing, or over-explaining and completely miss what you were trying to protect.`,
+    stressView: `Under pressure, this theme is likely to become faster, narrower, and less flexible. You may repeat the familiar move before checking whether this situation is actually the same as the one that taught you the move. The earliest warning sign is often urgency: the feeling that you must decide, withdraw, explain, repair, or take over immediately.`,
+    practicalTakeaway: `Before acting, name three things: what you are protecting, what the present evidence actually shows, and what response would preserve both self-respect and flexibility. That turns a personality description into a usable decision.` ,
+    reflection: `Where has this pattern genuinely helped you recently, and where did it continue after the pressure, danger, or obligation had already passed?`,
     action: clean(action),
   };
 }
@@ -70,35 +80,60 @@ export function buildDepthChapters(model: ClarityReadingModel): DepthChapter[] {
       eyebrow: "What people may notice",
       title: "The visible pattern",
       observation: model.visiblePattern,
-      counterpart: "clarity, control, safety, distance, or forward movement",
+      healthyAim: "clarity and deliberate movement without pretending certainty",
+      overuseRisk: "you can keep analyzing, explaining, or managing long after a simpler response would be more honest",
+      misunderstanding: "Other people may read careful processing as hesitation, emotional distance, or a need to control the outcome. They may not realize you are trying to reduce avoidable mistakes before you commit.",
+      decisionExample: "In decisions, you may gather more context than other people expect because acting without understanding feels less responsible than waiting a little longer.",
+      relationshipExample: "In conflict, you may become quieter or more explanatory while you sort out what is true, even when the other person interprets that pause as withdrawal.",
+      workExample: "In work or creativity, you may notice weak links, inconsistencies, and unfinished details before others do, which can improve the result but also make completion harder.",
     },
     {
       id: "protective-function",
       eyebrow: "What may be underneath",
       title: "The protective function",
       observation: model.protectiveFunction,
-      counterpart: "protection without losing honesty or flexibility",
+      healthyAim: "safety that does not require losing honesty, dignity, or freedom",
+      overuseRisk: "protection can become isolation, testing, over-preparation, or an attempt to prevent every possible disappointment",
+      misunderstanding: "Someone may call the behavior guarded, stubborn, or overly cautious when the deeper issue is often a wish to avoid being exposed without support or trapped without options.",
+      decisionExample: "Before agreeing, you may check whether you can reverse the decision, whether the other person is dependable, and what happens if the plan fails.",
+      relationshipExample: "You may reveal yourself in stages, watching how someone handles smaller truths before trusting them with the more vulnerable ones.",
+      workExample: "You may build backups, contingency plans, or extra structure because being unprepared feels more dangerous than doing additional work.",
     },
     {
       id: "gift",
       eyebrow: "The developed strength",
       title: "What this pattern can become",
       observation: model.gift,
-      counterpart: "discernment, skill, courage, and useful contribution",
+      healthyAim: "discernment, courage, practical wisdom, and contribution that other people can actually use",
+      overuseRisk: "competence can turn into carrying everything, solving what was not yours, or believing you must remain useful to remain valued",
+      misunderstanding: "People may see the result and assume it comes easily. They may miss the private effort, observation, restraint, and repeated correction behind what looks like natural ability.",
+      decisionExample: "You may be strongest when a situation is messy enough to require pattern recognition but real enough that the answer must work outside theory.",
+      relationshipExample: "You may show care through fixing, researching, remembering details, or building something useful rather than relying only on emotional language.",
+      workExample: "You can connect ideas across subjects and turn them into systems, stories, tools, or explanations that did not exist in that form before.",
     },
     {
       id: "cost",
       eyebrow: "The tradeoff",
       title: "When the strength turns against you",
       observation: model.cost,
-      counterpart: "choice instead of repetition",
+      healthyAim: "choice instead of repetition and completion without abandoning quality",
+      overuseRisk: "improvement can become endless revision, loyalty can outlive reciprocity, and responsibility can expand until there is no room left for rest",
+      misunderstanding: "From the outside, this may look inconsistent: highly capable in one moment and stalled in another. The missing context is often that the internal standard has grown larger than the task itself.",
+      decisionExample: "You may delay releasing something because you can already see the next five improvements, even though the current version is useful and ready to be tested.",
+      relationshipExample: "You may keep repairing a bond because leaving feels like failure, even after the relationship has stopped meeting you with the same effort.",
+      workExample: "You may absorb extra roles because you can see how to do them, then become resentful that everyone assumes you will continue carrying the weight.",
     },
     {
       id: "relationships",
       eyebrow: "Connection",
       title: "How it may affect relationships",
       observation: model.relationshipImpact,
-      counterpart: "connection that does not require mind-reading",
+      healthyAim: "loyal connection with room for truth, boundaries, independence, and repair",
+      overuseRisk: "care can become mind-reading, silent testing, over-functioning, or staying loyal to the history of a bond rather than its present reality",
+      misunderstanding: "A need for space may be mistaken for rejection, while intense loyalty may be mistaken for unlimited tolerance. Both readings miss the need for closeness without loss of self.",
+      decisionExample: "You may take longer to decide whether someone is truly safe, but once you decide they belong in your inner circle, you may invest deeply.",
+      relationshipExample: "You may tolerate more than people realize before walking away because ending the bond can feel like abandoning the meaning, effort, and history attached to it.",
+      workExample: "In teams, you may become the translator, stabilizer, or person who quietly notices what everyone else is avoiding, even when that labor is not formally recognized.",
     },
   ];
 
@@ -112,8 +147,10 @@ export function chapterWordCount(chapter: DepthChapter): number {
     ...chapter.dailyLife,
     chapter.strength,
     chapter.cost,
+    chapter.misunderstanding,
     chapter.relationshipView,
     chapter.stressView,
+    chapter.practicalTakeaway,
     chapter.reflection,
     chapter.action,
   ].join(" ").split(/\s+/).filter(Boolean).length;

--- a/tests/human-depth.test.ts
+++ b/tests/human-depth.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import { buildDepthChapters } from "../client/src/lib/depthEngine";
+import type { ClarityReadingModel } from "../client/src/lib/clarityReadingModel";
+
+const model: ClarityReadingModel = {
+  title: "The thoughtful builder",
+  summary: "A test reading.",
+  visiblePattern: "You may pause before committing.",
+  protectiveFunction: "Pausing can protect you from acting before the picture feels complete.",
+  gift: "Deliberate attention can become discernment.",
+  cost: "Waiting too long can turn care into stalled movement.",
+  relationshipImpact: "Other people may mistake processing time for distance.",
+  groundedAction: "Name what you know, what you do not know, and the next reversible step.",
+  signals: [],
+  limitations: ["This is interpretive, not diagnostic."],
+};
+
+describe("Human Depth reading contract", () => {
+  it("gives each chapter real-life examples, benefit, tradeoff, misunderstanding, and action", () => {
+    const chapters = buildDepthChapters(model);
+    for (const chapter of chapters) {
+      expect(chapter.dailyLife).toHaveLength(3);
+      expect(chapter.dailyLife.join(" ")).toMatch(/decisions|conflict|work|relationship|teams/i);
+      expect(chapter.strength.length).toBeGreaterThan(120);
+      expect(chapter.cost.length).toBeGreaterThan(120);
+      expect(chapter.misunderstanding.length).toBeGreaterThan(90);
+      expect(chapter.practicalTakeaway.length).toBeGreaterThan(120);
+      expect(chapter.action).toBe(model.groundedAction);
+    }
+  });
+
+  it("lets the user correct each interpretation without changing source data", () => {
+    const source = fs.readFileSync("client/src/components/ClarityReadingExperience.tsx", "utf8");
+    expect(source).toContain("Does this fit your experience?");
+    expect(source).toContain("Very much");
+    expect(source).toContain("Partly");
+    expect(source).toContain("Not really");
+    expect(source).toContain("localStorage");
+    expect(source).toContain("does not rewrite your birth data");
+  });
+
+  it("renders the human questions the test recording proved were missing", () => {
+    const source = fs.readFileSync("client/src/components/ClarityReadingExperience.tsx", "utf8");
+    expect(source).toContain("What this may look like in real life");
+    expect(source).toContain("What this gives you");
+    expect(source).toContain("What it may cost");
+    expect(source).toContain("How this may be misunderstood");
+    expect(source).toContain("What to do with this insight");
+  });
+});


### PR DESCRIPTION
## Purpose

Implement the Human Depth pass from the live test recording so Soul Codex stops presenting polished trait labels and starts explaining how a pattern may actually appear in a person's life.

## Changes

- Rewrites each depth chapter around lived examples in decisions, work, conflict, loyalty, completion, and relationships
- Adds an explicit benefit, tradeoff, common misunderstanding, stress response, and practical takeaway to every chapter
- Adds per-chapter `Very much`, `Partly`, and `Not really` feedback
- Stores feedback locally by profile without altering birth data or pretending the interpretation is factual
- Adds regression tests for the Human Depth writing and correction contract

## Trust boundary

User feedback corrects the interpretation layer only. It does not rewrite calculated or verified profile data.

## Validation

Run through the documented Google Cloud Shell local validation sequence before merge while hosted Actions remain billing-blocked.