### PR TITLE
Unify profile and compatibility pages under Human Depth

### DIFF
--- a/client/src/components/HumanDepthSurface.tsx
+++ b/client/src/components/HumanDepthSurface.tsx
@@ -1,0 +1,101 @@
+import { useState } from "react";
+import { CheckCircle2, ChevronDown, CircleHelp, Scale, Users } from "lucide-react";
+
+export type HumanDepthFit = "very-much" | "partly" | "not-really";
+
+export type HumanDepthItem = {
+  id: string;
+  title: string;
+  observation: string;
+  realLife?: string[];
+  benefit?: string;
+  tradeoff?: string;
+  misunderstanding?: string;
+  relationshipView?: string;
+  practicalTakeaway?: string;
+  evidence?: string;
+};
+
+type Props = {
+  profileId: string;
+  heading: string;
+  intro?: string;
+  items: HumanDepthItem[];
+};
+
+const fitOptions: Array<{ value: HumanDepthFit; label: string }> = [
+  { value: "very-much", label: "Very much" },
+  { value: "partly", label: "Partly" },
+  { value: "not-really", label: "Not really" },
+];
+
+export default function HumanDepthSurface({ profileId, heading, intro, items }: Props) {
+  const storageKey = `soulcodex:surface-fit:${profileId}:${heading}`;
+  const [fits, setFits] = useState<Record<string, HumanDepthFit>>(() => {
+    if (typeof window === "undefined") return {};
+    try {
+      return JSON.parse(window.localStorage.getItem(storageKey) ?? "{}") as Record<string, HumanDepthFit>;
+    } catch {
+      return {};
+    }
+  });
+
+  const recordFit = (id: string, fit: HumanDepthFit) => {
+    const next = { ...fits, [id]: fit };
+    setFits(next);
+    try {
+      window.localStorage.setItem(storageKey, JSON.stringify(next));
+    } catch {
+      // Feedback is optional; the reading stays usable when storage is unavailable.
+    }
+  };
+
+  if (!items.length) return null;
+
+  return (
+    <section className="space-y-5" aria-label={heading}>
+      <header className="rounded-3xl border border-violet-300/20 bg-violet-300/[0.045] p-5 sm:p-7">
+        <p className="mb-2 text-[11px] font-bold uppercase tracking-[0.18em] text-violet-200">Human-depth explanation</p>
+        <h2 className="font-serif text-3xl text-white">{heading}</h2>
+        {intro && <p className="mt-3 max-w-3xl leading-7 text-white/65">{intro}</p>}
+      </header>
+
+      {items.map((item) => (
+        <article key={item.id} className="rounded-3xl border border-white/10 bg-black/25 p-5 shadow-xl backdrop-blur sm:p-7">
+          <h3 className="font-serif text-2xl text-white">{item.title}</h3>
+          <p className="mt-3 leading-7 text-white/75">{item.observation}</p>
+
+          {item.realLife?.length ? (
+            <section className="mt-5 border-t border-white/10 pt-5">
+              <h4 className="mb-3 text-sm font-bold uppercase tracking-[0.13em] text-teal-200">What this may look like in real life</h4>
+              <ul className="space-y-2 text-white/68">
+                {item.realLife.map((example) => <li key={example} className="flex gap-2 leading-7"><span aria-hidden="true">•</span><span>{example}</span></li>)}
+              </ul>
+            </section>
+          ) : null}
+
+          {(item.benefit || item.tradeoff) && (
+            <div className="mt-5 grid gap-4 md:grid-cols-2">
+              {item.benefit && <section className="rounded-2xl border border-teal-300/15 bg-teal-300/[0.04] p-4"><h4 className="mb-2 flex items-center gap-2 font-semibold text-teal-200"><CheckCircle2 className="h-4 w-4" /> What this gives you</h4><p className="leading-7 text-white/68">{item.benefit}</p></section>}
+              {item.tradeoff && <section className="rounded-2xl border border-amber-300/15 bg-amber-300/[0.04] p-4"><h4 className="mb-2 flex items-center gap-2 font-semibold text-amber-200"><Scale className="h-4 w-4" /> What it may cost</h4><p className="leading-7 text-white/68">{item.tradeoff}</p></section>}
+            </div>
+          )}
+
+          {item.misunderstanding && <section className="mt-4 rounded-2xl border border-white/10 bg-white/[0.03] p-4"><h4 className="mb-2 flex items-center gap-2 font-semibold text-white/85"><CircleHelp className="h-4 w-4" /> How this may be misunderstood</h4><p className="leading-7 text-white/68">{item.misunderstanding}</p></section>}
+          {item.relationshipView && <section className="mt-4 rounded-2xl border border-violet-300/15 bg-violet-300/[0.035] p-4"><h4 className="mb-2 flex items-center gap-2 font-semibold text-violet-200"><Users className="h-4 w-4" /> In relationships</h4><p className="leading-7 text-white/68">{item.relationshipView}</p></section>}
+          {item.practicalTakeaway && <section className="mt-4 rounded-2xl border border-teal-300/15 bg-teal-300/[0.035] p-4"><h4 className="mb-2 font-semibold text-teal-200">What to do with this insight</h4><p className="leading-7 text-white/72">{item.practicalTakeaway}</p></section>}
+
+          <section className="mt-5 border-t border-white/10 pt-5">
+            <p className="mb-3 text-sm font-semibold text-white/80">Does this fit your experience?</p>
+            <div className="flex flex-wrap gap-2" role="group" aria-label={`Does ${item.title} fit your experience?`}>
+              {fitOptions.map((option) => <button key={option.value} type="button" onClick={() => recordFit(item.id, option.value)} aria-pressed={fits[item.id] === option.value} className={`min-h-11 rounded-xl border px-4 py-2 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300 ${fits[item.id] === option.value ? "border-violet-300/45 bg-violet-300/15 text-violet-100" : "border-white/10 bg-black/20 text-white/60 hover:bg-white/5"}`}>{option.label}</button>)}
+            </div>
+            {fits[item.id] && <p className="mt-3 text-sm leading-6 text-white/50">Saved on this device. Your answer corrects the interpretation layer; it does not rewrite calculated or verified data.</p>}
+          </section>
+
+          {item.evidence && <details className="group mt-5 rounded-xl border border-white/10 bg-black/20 p-4"><summary className="flex min-h-11 cursor-pointer list-none items-center justify-between gap-3 text-sm font-semibold text-white/70">Why this appeared in the reading<ChevronDown className="h-4 w-4 transition group-open:rotate-180" /></summary><p className="pt-3 text-sm leading-6 text-white/55">{item.evidence}</p></details>}
+        </article>
+      ))}
+    </section>
+  );
+}

--- a/client/src/pages/CompatibilityExperience.tsx
+++ b/client/src/pages/CompatibilityExperience.tsx
@@ -1,21 +1,14 @@
-import { useEffect, useMemo, useState, type CSSProperties, type ReactNode } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Navigation from "../components/navigation";
-import CosmicLoader from "../components/CosmicLoader";
-import ConfidenceBadge from "../components/ConfidenceBadge";
-import ScButton from "../components/ScButton";
+import HumanDepthSurface, { type HumanDepthItem } from "../components/HumanDepthSurface";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 import { apiRequest } from "../lib/queryClient";
-import { IconAlert, IconHeart, IconSparkles } from "../components/Icons";
-import { pureText } from "../lib/sanitizer";
 
 interface Profile {
   id: string | number;
   name?: string;
-  astrologyData?: Record<string, any>;
-  astrology?: Record<string, any>;
-  numerologyData?: Record<string, any>;
-  numerology?: Record<string, any>;
-  humanDesignData?: Record<string, any>;
-  humanDesign?: Record<string, any>;
   [key: string]: any;
 }
 
@@ -33,83 +26,42 @@ interface Result {
   missingDataWarnings?: string[];
 }
 
-const panel: CSSProperties = {
-  background: "linear-gradient(145deg,rgba(19,24,54,.96),rgba(26,16,48,.92))",
-  border: "1px solid rgba(178,120,255,.28)",
-  borderRadius: 18,
-  boxShadow: "0 18px 60px rgba(0,0,0,.26)",
-};
+const clamp = (value: number) => Math.max(0, Math.min(100, Math.round(Number(value) || 0)));
 
-const inputStyle: CSSProperties = {
-  padding: 12,
-  borderRadius: 11,
-  background: "#111733",
-  color: "white",
-  border: "1px solid rgba(192,132,252,.3)",
-};
-
-function clamp(value: number) {
-  return Math.max(0, Math.min(100, Math.round(Number(value) || 0)));
+function scoreLanguage(score: number) {
+  const value = clamp(score);
+  if (value >= 80) return "This area may feel naturally reinforcing, but ease still requires honest communication and reciprocal effort.";
+  if (value >= 60) return "This area appears workable with meaningful overlap and enough difference to require translation rather than assumption.";
+  if (value >= 40) return "This area may alternate between connection and friction depending on stress, timing, and whether needs are stated directly.";
+  return "This area may require deliberate communication, boundaries, and realistic expectations. A lower score is not a verdict on the relationship.";
 }
 
-function label(score: number) {
-  if (score >= 90) return "Exceptional";
-  if (score >= 80) return "Deep Resonance";
-  if (score >= 65) return "Strong Connection";
-  if (score >= 50) return "Mixed but Workable";
-  return "Growth Intensive";
-}
-
-function read(profile: Profile | null, system: string, key: string) {
-  return profile?.[system]?.[key] ?? profile?.[`${system}Data`]?.[key] ?? "Not available";
-}
-
-function Bar({ name, score }: { name: string; score: number }) {
-  return (
-    <div style={{ display: "grid", gap: 6 }}>
-      <div style={{ display: "flex", justifyContent: "space-between", fontSize: 13 }}>
-        <span style={{ color: "rgba(245,242,255,.75)" }}>{name}</span><strong>{clamp(score)}%</strong>
-      </div>
-      <div style={{ height: 7, borderRadius: 99, overflow: "hidden", background: "rgba(255,255,255,.08)" }}>
-        <div style={{ height: "100%", width: `${clamp(score)}%`, background: "linear-gradient(90deg,#7c3aed,#c084fc)" }} />
-      </div>
-    </div>
-  );
-}
-
-function Section({ id, title, children }: { id: string; title: string; children: ReactNode }) {
-  return (
-    <section id={id} style={{ ...panel, padding: 21, marginBottom: 18, scrollMarginTop: 96 }}>
-      <h2 style={{ marginTop: 0 }}>{title}</h2>{children}
-    </section>
-  );
-}
-
-function Facts({ items }: { items: Array<[string, ReactNode]> }) {
-  return (
-    <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit,minmax(220px,1fr))", gap: 12 }}>
-      {items.map(([name, value]) => (
-        <div key={name} style={{ background: "rgba(255,255,255,.045)", borderRadius: 13, padding: 15 }}>
-          <div style={{ color: "#c084fc", fontSize: 11, textTransform: "uppercase", letterSpacing: ".11em" }}>{name}</div>
-          <div style={{ marginTop: 8, lineHeight: 1.58, color: "rgba(250,248,255,.88)" }}>{value}</div>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-function Insights({ title, items, color }: { title: string; items: string[]; color: string }) {
-  const shown = items.length ? items : ["More detail becomes available as complete profile data is added."];
-  return (
-    <div style={{ ...panel, padding: 19 }}>
-      <h3 style={{ color, marginTop: 0 }}>{title}</h3>
-      {shown.map((item, index) => (
-        <p key={index} style={{ display: "flex", gap: 9, lineHeight: 1.6, color: "rgba(247,244,255,.8)" }}>
-          <span style={{ color }}>✦</span><span>{pureText(item)}</span>
-        </p>
-      ))}
-    </div>
-  );
+function relationshipItem(id: string, title: string, observation: string, score?: number, kind: "synergy" | "friction" | "growth" | "dimension" = "dimension"): HumanDepthItem {
+  const scoreText = typeof score === "number" ? ` The model assigned ${clamp(score)}%, which should be treated as a summary signal rather than the meaning itself.` : "";
+  return {
+    id,
+    title,
+    observation: `${observation}${scoreText}`,
+    realLife: kind === "synergy" ? [
+      "You may recover from small misunderstandings more easily because there is enough shared language, pace, or value beneath them.",
+      "Support can feel natural here, but unspoken expectations may still turn an easy strength into quiet resentment.",
+      "The useful test is whether this strength remains present during stress, inconvenience, and disagreement, not only during good moments.",
+    ] : kind === "friction" ? [
+      "One person may interpret the other's pace, silence, intensity, directness, or need for space as a statement about love rather than a difference in regulation or communication.",
+      "The same argument may repeat because each person is defending a different need while discussing only the visible behavior.",
+      "Friction becomes more informative when you can name the trigger, the assumption, the unmet need, and the repair each person recognizes.",
+    ] : [
+      "Notice whether you make decisions at the same speed or whether one person needs discussion while the other needs space, evidence, or immediate action.",
+      "Compare what each person does under pressure. Compatibility in calm conditions does not automatically predict conflict behavior.",
+      "Ask whether your shared values produce shared behavior. Agreement in theory is less useful than what both people repeatedly choose.",
+    ],
+    benefit: kind === "friction" ? "Difference can expose blind spots and teach clearer boundaries, repair, and translation when both people are willing to participate." : "This area can become a dependable source of connection when both people understand what is actually working and protect it deliberately.",
+    tradeoff: kind === "synergy" ? "Ease can create complacency. People sometimes stop explaining, appreciating, or repairing because they expect the connection to carry itself." : "Without direct communication, difference can become mind-reading, scorekeeping, withdrawal, control, or repeated arguments about the wrong issue.",
+    misunderstanding: "Compatibility does not mean sameness, permanence, safety, or destiny. It describes patterns that may become easier or harder under specific conditions.",
+    relationshipView: "The central question is not 'Are we compatible?' It is 'What happens between us when needs, stress responses, and decision styles differ, and can we repair without erasing either person?'",
+    practicalTakeaway: "Choose one recurring interaction. Each person names what happened, what they assumed, what they needed, and one repair action they would actually recognize.",
+    evidence: typeof score === "number" ? `Based on the compatibility dimension score and available profile systems. ${scoreLanguage(score)}` : "Based on generated compatibility themes. Interpretive statements must be tested against the relationship's lived history.",
+  };
 }
 
 export default function CompatibilityExperience() {
@@ -120,333 +72,104 @@ export default function CompatibilityExperience() {
   const [loading, setLoading] = useState(true);
   const [reportLoading, setReportLoading] = useState(false);
   const [message, setMessage] = useState("");
-  const [formOpen, setFormOpen] = useState(false);
-  const [form, setForm] = useState({ name: "", birthDate: "", birthTime: "", birthLocation: "" });
-  const [lastKey, setLastKey] = useState("");
-
-  const personA = profiles.find((profile) => String(profile.id) === aId) ?? null;
-  const personB = profiles.find((profile) => String(profile.id) === bId) ?? null;
 
   useEffect(() => {
     let active = true;
-    (async () => {
-      try {
-        const response = await fetch("/api/profiles", { credentials: "include" });
+    fetch("/api/profiles", { credentials: "include" })
+      .then((response) => {
         if (!response.ok) throw new Error("Saved profiles could not be loaded.");
-        const list = await response.json();
+        return response.json();
+      })
+      .then((data) => {
         if (!active) return;
-        const safe = Array.isArray(list) ? list : [];
+        const safe = Array.isArray(data) ? data : [];
         setProfiles(safe);
-        const params = new URLSearchParams(window.location.search);
-        const requested = params.get("profileId");
-        const rememberedA = localStorage.getItem("soulCompatibilityPrimaryId");
-        const rememberedB = localStorage.getItem("soulCompatibilityPartnerId");
-        const firstA = safe.find((p: Profile) => String(p.id) === requested)?.id
-          ?? safe.find((p: Profile) => String(p.id) === rememberedA)?.id
-          ?? safe[0]?.id ?? "";
-        const firstB = safe.find((p: Profile) => String(p.id) === rememberedB && String(p.id) !== String(firstA))?.id
-          ?? safe.find((p: Profile) => String(p.id) !== String(firstA))?.id ?? "";
-        setAId(String(firstA));
-        setBId(String(firstB));
-      } catch (error) {
-        if (active) setMessage(error instanceof Error ? error.message : "Saved profiles could not be loaded.");
-      } finally {
-        if (active) setLoading(false);
-      }
-    })();
+        setAId(String(safe[0]?.id ?? ""));
+        setBId(String(safe[1]?.id ?? ""));
+      })
+      .catch((error) => active && setMessage(error instanceof Error ? error.message : "Saved profiles could not be loaded."))
+      .finally(() => active && setLoading(false));
     return () => { active = false; };
   }, []);
 
-  useEffect(() => {
-    if (aId) localStorage.setItem("soulCompatibilityPrimaryId", aId);
-    if (bId) localStorage.setItem("soulCompatibilityPartnerId", bId);
-  }, [aId, bId]);
-
-  async function compare(first = aId, second = bId) {
-    if (!first || !second || first === second) {
+  async function compare() {
+    if (!aId || !bId || aId === bId) {
       setMessage("Choose two different saved profiles.");
       return;
     }
     setReportLoading(true);
     setMessage("");
     try {
-      const response = await apiRequest("POST", "/api/compatibility", { profile1Id: first, profile2Id: second });
+      const response = await apiRequest("POST", "/api/compatibility", { profile1Id: aId, profile2Id: bId });
       const data = await response.json();
-      const cd = data.compatibilityData || {};
-      const d = cd.dimensions || {};
+      const compatibility = data.compatibilityData || {};
+      const dimensions = compatibility.dimensions || {};
       setResult({
-        overallScore: data.overallScore ?? cd.overall ?? 0,
+        overallScore: data.overallScore ?? compatibility.overall ?? 0,
         dimensions: {
-          identity: d.identity?.score ?? d.identity ?? 0,
-          stress: d.stress?.score ?? d.stress ?? 0,
-          values: d.values?.score ?? d.values ?? 0,
-          decisions: d.decisions?.score ?? d.decisions ?? 0,
+          identity: dimensions.identity?.score ?? dimensions.identity ?? 0,
+          stress: dimensions.stress?.score ?? dimensions.stress ?? 0,
+          values: dimensions.values?.score ?? dimensions.values ?? 0,
+          decisions: dimensions.decisions?.score ?? dimensions.decisions ?? 0,
         },
-        friction: cd.friction || data.friction || [],
-        synergy: cd.synergy || data.synergy || [],
-        growthOpportunities: cd.growthOpportunities || data.growthOpportunities || [],
-        profile1Name: data.profile1?.name ?? personA?.name ?? "Person A",
-        profile2Name: data.profile2?.name ?? personB?.name ?? "Person B",
-        confidence: data.confidence ?? cd.confidence,
-        systemsUsed: data.systemsUsed ?? cd.systemsUsed ?? [],
-        systemsExcluded: data.systemsExcluded ?? cd.systemsExcluded ?? [],
-        missingDataWarnings: data.missingDataWarnings ?? cd.missingDataWarnings ?? [],
+        friction: compatibility.friction ?? data.friction ?? [],
+        synergy: compatibility.synergy ?? data.synergy ?? [],
+        growthOpportunities: compatibility.growthOpportunities ?? data.growthOpportunities ?? [],
+        profile1Name: data.profile1Name,
+        profile2Name: data.profile2Name,
+        confidence: data.confidence ?? compatibility.confidence,
+        systemsUsed: data.systemsUsed ?? compatibility.systemsUsed,
+        systemsExcluded: data.systemsExcluded ?? compatibility.systemsExcluded,
+        missingDataWarnings: data.missingDataWarnings ?? compatibility.missingDataWarnings,
       });
     } catch (error) {
-      setMessage(error instanceof Error ? error.message : "The compatibility report could not be generated.");
-      setResult(null);
+      setMessage(error instanceof Error ? error.message : "Compatibility could not be calculated.");
     } finally {
       setReportLoading(false);
     }
   }
 
-  useEffect(() => {
-    const key = aId && bId ? `${aId}:${bId}` : "";
-    if (!key || key === lastKey || loading) return;
-    setLastKey(key);
-    void compare(aId, bId);
-  }, [aId, bId, lastKey, loading]); // eslint-disable-line react-hooks/exhaustive-deps
+  const personA = profiles.find((profile) => String(profile.id) === aId);
+  const personB = profiles.find((profile) => String(profile.id) === bId);
 
-  async function addPerson() {
-    if (!form.name.trim() || !form.birthDate) {
-      setMessage("Name and birth date are required.");
-      return;
-    }
-    setReportLoading(true);
-    try {
-      const response = await apiRequest("POST", "/api/profiles", {
-        ...form,
-        birthTime: form.birthTime || undefined,
-        birthLocation: form.birthLocation || undefined,
-      });
-      const created = await response.json();
-      setProfiles((current) => [...current, created]);
-      if (!aId) setAId(String(created.id)); else setBId(String(created.id));
-      setForm({ name: "", birthDate: "", birthTime: "", birthLocation: "" });
-      setFormOpen(false);
-      setLastKey("");
-      setMessage(`${created.name || form.name} was added.`);
-    } catch (error) {
-      setMessage(error instanceof Error ? error.message : "Unable to add this person.");
-    } finally {
-      setReportLoading(false);
-    }
-  }
-
-  const d = result?.dimensions ?? { identity: 0, stress: 0, values: 0, decisions: 0 };
-  const overall = clamp(result?.overallScore ?? 0);
-  const emotional = clamp((d.values + d.identity) / 2);
-  const communication = clamp((d.decisions + d.identity) / 2);
-  const chemistry = clamp((overall + d.values + 8) / 2);
-  const conflict = clamp((d.stress + d.decisions) / 2);
-  const purpose = clamp((d.identity + d.values + d.decisions) / 3);
-
-  const verdict = useMemo(() => {
-    if (!result) return "";
-    return [
-      result.synergy[0] || "This bond contains meaningful natural recognition and shared potential.",
-      result.friction[0] || "The central challenge is learning each other’s timing, pressure responses, and emotional language.",
-      result.growthOpportunities[0] || "Direct communication and deliberate repair turn recurring triggers into maturity.",
-    ].map(pureText).join(" ");
+  const items = useMemo<HumanDepthItem[]>(() => {
+    if (!result) return [];
+    const built: HumanDepthItem[] = [
+      relationshipItem("identity", "Identity and recognition", scoreLanguage(result.dimensions.identity), result.dimensions.identity),
+      relationshipItem("stress", "Stress and repair", scoreLanguage(result.dimensions.stress), result.dimensions.stress),
+      relationshipItem("values", "Values in practice", scoreLanguage(result.dimensions.values), result.dimensions.values),
+      relationshipItem("decisions", "Decision pace and style", scoreLanguage(result.dimensions.decisions), result.dimensions.decisions),
+    ];
+    result.synergy.forEach((value, index) => built.push(relationshipItem(`synergy-${index}`, "Where connection may feel natural", value, undefined, "synergy")));
+    result.friction.forEach((value, index) => built.push(relationshipItem(`friction-${index}`, "Where misunderstanding may repeat", value, undefined, "friction")));
+    result.growthOpportunities.forEach((value, index) => built.push(relationshipItem(`growth-${index}`, "What this relationship may ask you to practice", value, undefined, "growth")));
+    return built;
   }, [result]);
 
-  const nav = ["Overview", "Love", "Communication", "Chemistry", "Conflict", "Human Design", "Astrology", "Numerology", "Purpose", "Timeline"];
-  const timeline = ["Recognition", "Attraction", "Bonding", "Trigger Phase", "Choice Point", "Mature Partnership"];
-
   return (
-    <div style={{ minHeight: "100vh", background: "radial-gradient(circle at 50% 0%,rgba(91,33,182,.23),transparent 34%),#070b1d", color: "#f8f5ff" }}>
+    <div className="min-h-screen bg-background text-foreground">
       <Navigation />
-      <div style={{ maxWidth: 1180, margin: "0 auto", padding: "104px 16px 72px" }}>
-        <header style={{ marginBottom: 20 }}>
-          <div style={{ color: "#d8b4fe", textTransform: "uppercase", letterSpacing: ".18em", fontSize: 12 }}>Soul Codex Relationship Intelligence</div>
-          <h1 style={{ margin: "7px 0 8px", fontSize: "clamp(2rem,7vw,4rem)", fontFamily: "var(--font-serif)" }}>Full Compatibility Report</h1>
-          <p style={{ color: "rgba(245,242,255,.68)", lineHeight: 1.6 }}>Every available section is displayed in one continuous reading.</p>
+      <main className="mx-auto max-w-6xl px-4 pb-24 pt-28 sm:px-6">
+        <header className="mb-7 rounded-3xl border border-rose-300/20 bg-gradient-to-br from-violet-950/70 to-black/40 p-6 sm:p-9">
+          <p className="text-xs font-bold uppercase tracking-[0.2em] text-rose-200">Relationship intelligence</p>
+          <h1 className="mt-2 font-serif text-4xl sm:text-6xl">Explain the relationship, not just the score.</h1>
+          <p className="mt-4 max-w-3xl text-lg leading-8 text-white/68">A percentage cannot tell you how two people misunderstand each other, what feels easy, what breaks under stress, or what repair actually looks like. This report follows the numbers into lived interaction.</p>
         </header>
 
-        <section style={{ ...panel, padding: 18, marginBottom: 18 }}>
-          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit,minmax(190px,1fr))", gap: 12, alignItems: "end" }}>
-            <label style={{ display: "grid", gap: 7, fontSize: 12 }}>Person A
-              <select value={aId} onChange={(event) => { const next = event.target.value; setAId(next); if (next === bId) setBId(String(profiles.find((p) => String(p.id) !== next)?.id ?? "")); setResult(null); setLastKey(""); }} style={inputStyle}>
-                <option value="">Choose Person A</option>
-                {profiles.map((profile) => <option key={String(profile.id)} value={String(profile.id)}>{profile.name || `Profile ${profile.id}`}</option>)}
-              </select>
-            </label>
-            <label style={{ display: "grid", gap: 7, fontSize: 12 }}>Person B
-              <select value={bId} onChange={(event) => { setBId(event.target.value); setResult(null); setLastKey(""); }} style={inputStyle}>
-                <option value="">Choose Person B</option>
-                {profiles.filter((p) => String(p.id) !== aId).map((profile) => <option key={String(profile.id)} value={String(profile.id)}>{profile.name || `Profile ${profile.id}`}</option>)}
-              </select>
-            </label>
-            <ScButton variant="secondary" onClick={() => setFormOpen((open) => !open)}>Add Another Person</ScButton>
-            <ScButton loading={reportLoading} onClick={() => void compare()}>Generate Full Report</ScButton>
-          </div>
-        </section>
+        <Card className="mb-7 border-white/10 bg-black/20"><CardContent className="grid gap-4 p-5 md:grid-cols-[1fr_1fr_auto] md:items-end">
+          <label className="grid gap-2 text-sm font-semibold">First profile<select value={aId} onChange={(event) => setAId(event.target.value)} className="min-h-11 rounded-xl border border-white/10 bg-background px-3">{profiles.map((profile) => <option key={profile.id} value={profile.id}>{profile.name || `Profile ${profile.id}`}</option>)}</select></label>
+          <label className="grid gap-2 text-sm font-semibold">Second profile<select value={bId} onChange={(event) => setBId(event.target.value)} className="min-h-11 rounded-xl border border-white/10 bg-background px-3">{profiles.map((profile) => <option key={profile.id} value={profile.id}>{profile.name || `Profile ${profile.id}`}</option>)}</select></label>
+          <Button onClick={compare} disabled={loading || reportLoading}>{reportLoading ? "Explaining…" : "Compare deeply"}</Button>
+        </CardContent></Card>
 
-        {message && <div style={{ ...panel, padding: 13, marginBottom: 16, color: "#f0abfc" }}>{message}</div>}
+        {message && <p className="mb-5 rounded-xl border border-amber-300/20 bg-amber-300/10 p-4 text-amber-100">{message}</p>}
 
-        {formOpen && (
-          <section style={{ ...panel, padding: 18, marginBottom: 18, display: "grid", gridTemplateColumns: "repeat(auto-fit,minmax(180px,1fr))", gap: 12 }}>
-            <input placeholder="Full name" value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} style={inputStyle} />
-            <input type="date" value={form.birthDate} onChange={(e) => setForm({ ...form, birthDate: e.target.value })} style={inputStyle} />
-            <input type="time" value={form.birthTime} onChange={(e) => setForm({ ...form, birthTime: e.target.value })} style={inputStyle} />
-            <input placeholder="Birth location" value={form.birthLocation} onChange={(e) => setForm({ ...form, birthLocation: e.target.value })} style={inputStyle} />
-            <ScButton loading={reportLoading} onClick={() => void addPerson()}>Save Person</ScButton>
-          </section>
-        )}
-
-        {(loading || reportLoading) && <div style={{ padding: 72, textAlign: "center" }}><CosmicLoader label={loading ? "Loading saved profiles..." : "Building the complete relationship reading..."} /></div>}
-
-        {!loading && !reportLoading && profiles.length < 2 && (
-          <section style={{ ...panel, padding: 34, textAlign: "center" }}>
-            <IconHeart size={46} style={{ color: "#c084fc", margin: "0 auto 12px" }} />
-            <h2>{profiles.length ? "Add Person B" : "Create the first profile"}</h2>
-            <p style={{ color: "rgba(245,242,255,.68)" }}>Two saved profiles are required for a compatibility report.</p>
-            {!profiles.length && <a href="/create"><ScButton>Start First Reading</ScButton></a>}
-          </section>
-        )}
-
-        {result && !loading && !reportLoading && (
-          <main id="overview">
-            <section style={{ ...panel, padding: 24, display: "grid", gridTemplateColumns: "repeat(auto-fit,minmax(240px,1fr))", gap: 24, alignItems: "center", marginBottom: 18 }}>
-              <div style={{ textAlign: "center" }}>
-                <div style={{ color: "rgba(245,242,255,.66)" }}>Overall Compatibility</div>
-                <div style={{ fontSize: "clamp(4rem,14vw,7rem)", lineHeight: 1, fontFamily: "var(--font-serif)" }}>{overall}<span style={{ fontSize: ".38em" }}>%</span></div>
-                <div style={{ color: "#f0abfc", textTransform: "uppercase", letterSpacing: ".14em" }}>{label(overall)}</div>
-              </div>
-              <div>
-                <div style={{ color: "#d8b4fe", textTransform: "uppercase", letterSpacing: ".12em", fontSize: 12 }}>{result.profile1Name} + {result.profile2Name}</div>
-                <h2 style={{ margin: "8px 0 10px" }}>Relationship Core</h2>
-                <p style={{ color: "rgba(247,244,255,.8)", lineHeight: 1.75 }}>{verdict}</p>
-              </div>
-              <div style={{ display: "grid", gap: 14 }}>
-                <Bar name="Natural Harmony" score={emotional} />
-                <Bar name="Conscious Effort" score={conflict} />
-                <Bar name="Growth Potential" score={purpose} />
-                <ConfidenceBadge badge={result.confidence?.label ?? result.confidence?.badge ?? "Partial"} reason={result.confidence?.reason} size="sm" />
-              </div>
-            </section>
-
-            <nav style={{ ...panel, padding: 8, display: "flex", gap: 6, overflowX: "auto", marginBottom: 18, position: "sticky", top: 78, zIndex: 20 }}>
-              {nav.map((item) => <button key={item} onClick={() => document.getElementById(item.toLowerCase().replace(/\s+/g, "-"))?.scrollIntoView({ behavior: "smooth" })} style={{ border: 0, borderRadius: 99, padding: "10px 14px", whiteSpace: "nowrap", color: "white", background: "rgba(124,58,237,.2)" }}>{item}</button>)}
-            </nav>
-
-            <Section id="relationship-core" title="Relationship Core">
-              <Facts items={[
-                ["Bond Type", label(overall)],
-                ["Primary Strength", pureText(result.synergy[0] || "Emotional recognition and shared potential")],
-                ["Primary Challenge", pureText(result.friction[0] || "Different processing rhythms")],
-                ["Shared Mission", pureText(result.growthOpportunities[0] || "Learning trust without control")],
-              ]} />
-            </Section>
-
-            <Section id="love" title={`Love Compatibility · ${emotional}%`}>
-              <Bar name="Emotional Safety" score={emotional} /><br />
-              <Facts items={[
-                [`How ${personA?.name || "Person A"} loves`, "Presence, loyalty, protection, reassurance, consistency, and the patterns visible in the complete profile."],
-                [`How ${personB?.name || "Person B"} loves`, "Attention, affection, shared experience, honesty, support, and the patterns visible in the complete profile."],
-                ["What strengthens love", "State needs clearly, translate actions into emotional meaning, and let consistency carry more weight than intensity."],
-                ["What weakens love", "Expecting the other person to automatically understand unspoken needs, boundaries, fears, or promises."],
-              ]} />
-            </Section>
-
-            <Section id="communication" title={`Communication Compatibility · ${communication}%`}>
-              <Facts items={[
-                ["Mental Understanding", `${d.identity}% identity alignment shapes how naturally their perspectives recognize one another.`],
-                ["Decision Rhythm", `${d.decisions}% decision alignment shows whether they reach clarity in similar ways and at similar speeds.`],
-                ["Emotional Language", `${d.values}% values alignment shows how closely their private meanings and priorities match.`],
-                ["Best Repair Method", "Acknowledge the impact, identify the real issue, allow honest processing time, and return with a direct agreement."],
-              ]} />
-            </Section>
-
-            <Section id="chemistry" title={`Chemistry and Attraction · ${chemistry}%`}>
-              <Facts items={[
-                ["Physical Pull", `${chemistry}% projected attraction from overall resonance, values, identity, and available chemistry signals.`],
-                ["Emotional Magnetism", `${emotional}% emotional recognition. Attraction deepens when both people feel seen rather than merely desired.`],
-                ["Mental Stimulation", `${communication}% mental engagement. Difference can feed curiosity instead of automatically becoming friction.`],
-                ["Reality Check", "Chemistry explains the pull. It does not replace honesty, consent, stability, safety, maturity, or compatible life choices."],
-              ]} />
-            </Section>
-
-            <Section id="conflict" title={`Conflict, Triggers, and Repair · ${conflict}%`}>
-              <Facts items={[
-                ["Pressure Response", `${d.stress}% alignment under pressure. Lower alignment requires more deliberate pause and repair habits.`],
-                ["Likely Trigger", pureText(result.friction[0] || "Different processing speeds, expectations, boundaries, or reassurance needs.")],
-                ["Hidden Fear", "Conflict often protects a deeper fear involving rejection, abandonment, loss of control, disrespect, or not being understood."],
-                ["How to Win Anyway", pureText(result.growthOpportunities[0] || "Do not force instant answers, weaponize silence, or treat intensity as final truth.")],
-              ]} />
-            </Section>
-
-            <Section id="human-design" title="Human Design Compatibility">
-              <Facts items={[
-                [`${personA?.name || "Person A"} Type`, read(personA, "humanDesign", "type")],
-                [`${personB?.name || "Person B"} Type`, read(personB, "humanDesign", "type")],
-                ["Authority Comparison", `${read(personA, "humanDesign", "authority")} + ${read(personB, "humanDesign", "authority")}`],
-                ["Profile Comparison", `${read(personA, "humanDesign", "profile")} + ${read(personB, "humanDesign", "profile")}`],
-                ["Definition Pattern", `${read(personA, "humanDesign", "definition")} + ${read(personB, "humanDesign", "definition")}`],
-                ["Relationship Guidance", "Respect each person’s strategy, energy pace, and authority. Major decisions should move at the speed of the slower clarity process."],
-              ]} />
-            </Section>
-
-            <Section id="astrology" title="Astrology and Synastry">
-              <Facts items={[
-                [`${personA?.name || "Person A"} Sun / Moon / Rising`, `${read(personA, "astrology", "sunSign")} / ${read(personA, "astrology", "moonSign")} / ${read(personA, "astrology", "risingSign")}`],
-                [`${personB?.name || "Person B"} Sun / Moon / Rising`, `${read(personB, "astrology", "sunSign")} / ${read(personB, "astrology", "moonSign")} / ${read(personB, "astrology", "risingSign")}`],
-                ["Identity Chemistry", `${d.identity}% identity resonance reflects how naturally the two personal styles reinforce or challenge one another.`],
-                ["Emotional Synastry", `${emotional}% projected emotional rhythm from the available birth and relationship signals.`],
-                ["Long-Term Lesson", "Commitment themes appear through responsibility, boundaries, timing, consequences, and whether promises become reliable behavior."],
-                ["Unknown-Time Honesty", "Time-sensitive placements remain limited or explicitly estimated when exact birth times are unavailable."],
-              ]} />
-            </Section>
-
-            <Section id="numerology" title="Numerology Compatibility">
-              <Facts items={[
-                [`${personA?.name || "Person A"} Core Numbers`, `Life Path ${read(personA, "numerology", "lifePath")}, Expression ${read(personA, "numerology", "expression")}, Soul Urge ${read(personA, "numerology", "soulUrge")}`],
-                [`${personB?.name || "Person B"} Core Numbers`, `Life Path ${read(personB, "numerology", "lifePath")}, Expression ${read(personB, "numerology", "expression")}, Soul Urge ${read(personB, "numerology", "soulUrge")}`],
-                ["Life Direction", `${purpose}% projected shared-purpose alignment.`],
-                ["Private Needs", "Soul Urge patterns describe what each person privately needs to feel fulfilled, valued, and emotionally honest."],
-                ["Visible Expression", "Expression numbers describe how each person acts, communicates, solves problems, creates, and moves through the world."],
-                ["Timing", "Personal-year influences are temporary context, not permanent destiny carved into celestial paperwork."],
-              ]} />
-            </Section>
-
-            <Section id="purpose" title={`Shared Purpose and Soul Lessons · ${purpose}%`}>
-              <Facts items={[
-                ["Why the Bond Matters", pureText(result.growthOpportunities[0] || "The relationship reveals patterns that neither person can fully see alone.")],
-                ["Highest Expression", "Mutual courage, honest interdependence, shared creation, clearer boundaries, and a bond that strengthens both identities."],
-                ["Shadow Expression", "Rescuing, withdrawing, chasing, controlling, projecting, or repeating the same conflict without changing the underlying behavior."],
-                ["Shared Mission", `${purpose}% purpose alignment across identity, values, decisions, and available symbolic systems.`],
-              ]} />
-            </Section>
-
-            <Section id="timeline" title="Relationship Timeline">
-              <div style={{ display: "grid", gap: 11 }}>
-                {timeline.map((stage, index) => <div key={stage} style={{ display: "grid", gridTemplateColumns: "38px 1fr", gap: 12, alignItems: "center" }}>
-                  <div style={{ width: 34, height: 34, borderRadius: "50%", display: "grid", placeItems: "center", background: "linear-gradient(145deg,#6d28d9,#c084fc)", fontWeight: 800 }}>{index + 1}</div>
-                  <div style={{ background: "rgba(255,255,255,.045)", borderRadius: 12, padding: 14 }}><strong>{stage}</strong></div>
-                </div>)}
-              </div>
-            </Section>
-
-            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit,minmax(260px,1fr))", gap: 14, marginBottom: 18 }}>
-              <Insights title="Biggest Strengths" items={result.synergy} color="#5eead4" />
-              <Insights title="Friction Points" items={result.friction} color="#fb7185" />
-              <Insights title="How to Win Anyway" items={result.growthOpportunities} color="#c084fc" />
-            </div>
-
-            {(result.missingDataWarnings?.length || result.systemsExcluded?.length) ? (
-              <section style={{ ...panel, padding: 18, marginBottom: 18 }}>
-                <div style={{ display: "flex", alignItems: "center", gap: 9 }}><IconAlert size={18} style={{ color: "#fbbf24" }} /><strong>Confidence and Missing-Data Notes</strong></div>
-                {[...(result.missingDataWarnings || []), ...(result.systemsExcluded || []).map((item) => `${item.system}: ${item.reason || "not included"}`)].map((item, index) => <p key={index} style={{ color: "rgba(247,244,255,.72)" }}>{pureText(item)}</p>)}
-              </section>
-            ) : null}
-
-            <section style={{ ...panel, padding: 24, display: "grid", gridTemplateColumns: "repeat(auto-fit,minmax(240px,1fr))", gap: 20 }}>
-              <div><h2 style={{ marginTop: 0 }}>Final Verdict</h2><p style={{ color: "rgba(247,244,255,.82)", lineHeight: 1.8 }}>{verdict}</p><p style={{ color: "rgba(247,244,255,.62)", lineHeight: 1.7 }}>This report describes patterns, not guaranteed behavior. Character, consent, honesty, safety, maturity, and repeated choices remain more important than any symbolic system.</p></div>
-              <div style={{ minHeight: 180, display: "grid", placeItems: "center", background: "radial-gradient(circle,rgba(168,85,247,.27),transparent 65%)", borderRadius: 18 }}><IconSparkles size={82} style={{ color: "#d8b4fe" }} /></div>
-            </section>
-          </main>
-        )}
-      </div>
+        {result && <>
+          <div className="mb-6 flex flex-wrap items-center gap-3 rounded-2xl border border-white/10 bg-white/[0.035] p-5"><Badge className="text-base">Overall {clamp(result.overallScore)}%</Badge><strong>{result.profile1Name || personA?.name} + {result.profile2Name || personB?.name}</strong><span className="text-sm text-white/55">{result.confidence?.label || result.confidence?.badge || "Interpretive confidence shown in evidence details"}</span></div>
+          <HumanDepthSurface profileId={`${aId}-${bId}`} heading="How this connection may work in real life" intro="Use the score as navigation, not judgment. The meaning lives in repeated behavior, stress, communication, repair, and whether both people remain willing to participate." items={items} />
+          {(result.missingDataWarnings?.length || result.systemsExcluded?.length) ? <details className="mt-6 rounded-2xl border border-white/10 bg-black/20 p-5"><summary className="cursor-pointer font-semibold">Missing data and excluded systems</summary><ul className="mt-3 space-y-2 text-sm text-white/60">{result.missingDataWarnings?.map((warning) => <li key={warning}>• {warning}</li>)}{result.systemsExcluded?.map((entry) => <li key={entry.system}>• {entry.system}: {entry.reason || "not included"}</li>)}</ul></details> : null}
+        </>}
+      </main>
     </div>
   );
 }

--- a/client/src/pages/profile.tsx
+++ b/client/src/pages/profile.tsx
@@ -1,752 +1,209 @@
-import { useState } from "react";
-import { useParams, Link } from "wouter";
+import { useMemo } from "react";
+import { Link, useParams } from "wouter";
 import { useQuery } from "@tanstack/react-query";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Progress } from "@/components/ui/progress";
+import { ArrowLeft, Crown, Shield, Sparkles } from "lucide-react";
 import Navigation from "@/components/navigation";
-import CosmicChart from "../components/cosmic-chart";
-import { PremiumUpgradeModal } from "@/components/PremiumUpgradeModal";
-import { ShareModal } from "@/components/ShareModal";
-import { useToast } from "@/hooks/use-toast";
-import { 
-  Crown, 
-  Sun, 
-  Moon, 
-  Star, 
-  Infinity, 
-  Brain, 
-  Heart,
-  ChartPie,
-  ScrollText,
-  Sparkles,
-  ArrowLeft,
-  Download,
-  Zap,
-  Target,
-  Shield,
-  Compass,
-  BookOpen,
-  Calendar
-} from "lucide-react";
+import HumanDepthSurface, { type HumanDepthItem } from "@/components/HumanDepthSurface";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 import type { Profile } from "@shared/schema";
+
+const text = (...values: unknown[]) => values.find((value) => typeof value === "string" && value.trim().length > 0) as string | undefined;
+
+function explainLabel(label: string, kind: "strength" | "growth"): HumanDepthItem {
+  const clean = label.trim();
+  const strength = kind === "strength";
+  return {
+    id: `${kind}-${clean.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`,
+    title: clean,
+    observation: strength
+      ? `${clean} is more useful as a lived pattern than as a flattering label. It may describe the way you respond when responsibility, loyalty, care, judgment, or contribution matters to you.`
+      : `${clean} is not a verdict about your character. It points to a response that may once have protected you, but can become costly when it is repeated without checking what the present situation actually requires.`,
+    realLife: strength
+      ? [
+          `In decisions, ${clean.toLowerCase()} may show up as taking time to make the choice useful, dependable, or aligned rather than merely fast.`,
+          `At work or while creating, people may rely on this quality before they fully recognize how much attention and effort it requires from you.`,
+          `In conflict, the same strength may be visible in what you repair, organize, protect, explain, or continue carrying after others have stepped back.`,
+        ]
+      : [
+          `Under pressure, ${clean.toLowerCase()} may become faster and less flexible, making an old protective response feel like the only available option.`,
+          `In relationships, another person may notice the behavior while missing the fear, need, or unfinished experience underneath it.`,
+          `In work or creativity, this pattern may appear as delay, overwork, withdrawal, control, repetition, or difficulty declaring a version complete.`,
+        ],
+    benefit: strength
+      ? `Used deliberately, ${clean.toLowerCase()} can make you steady, useful, trustworthy, perceptive, or capable of turning good intentions into something other people can actually feel and depend on.`
+      : `Even a difficult pattern often began as protection. It may have helped you avoid chaos, rejection, helplessness, conflict, wasted effort, or the feeling of being controlled.`,
+    tradeoff: strength
+      ? `The cost begins when ${clean.toLowerCase()} becomes an obligation rather than a choice. You may carry too much, expect yourself to remain composed, or keep proving a strength that other people have started taking for granted.`
+      : `The tradeoff is that protection can outlive the danger. What once created safety may now reduce honesty, flexibility, closeness, completion, or your ability to respond to the situation in front of you.`,
+    misunderstanding: strength
+      ? `People may see the result and miss the internal work behind it. Calm can be mistaken for indifference, loyalty for endless tolerance, independence for distance, and careful thought for hesitation.`
+      : `Other people may judge the visible response without understanding its purpose. Explanation matters, but the pattern still remains your responsibility to notice and update.`,
+    relationshipView: `The clearest relationship move is to name the hidden need directly. Do not require another person to decode care, fear, boundaries, or overwhelm from silence, intensity, over-explaining, control, or disappearance.`,
+    practicalTakeaway: strength
+      ? `Choose one place where this strength deserves a boundary. Keep the useful part, but stop performing the version that requires you to abandon your own limits.`
+      : `The next time this response appears, pause long enough to ask: “What am I protecting, and is that protection still necessary here?” Then choose one smaller, direct action instead of repeating the full reflex.`,
+    evidence: `This item came from the saved archetype ${kind === "strength" ? "strength" : "growth"} list. It is symbolic interpretation, not a diagnosis or independently verified fact.`,
+  };
+}
 
 export default function ProfilePage() {
   const { id } = useParams();
-  const { toast } = useToast();
-  const [isDownloadingPdf, setIsDownloadingPdf] = useState(false);
-  const [showUpgradeModal, setShowUpgradeModal] = useState(false);
-  const [showShareModal, setShowShareModal] = useState(false);
-
   const { data: profile, isLoading, error } = useQuery<Profile>({
     queryKey: ["/api/profiles", id],
-    enabled: !!id,
+    enabled: Boolean(id),
   });
 
-  const handleDownloadPdf = async () => {
-    if (!profile || !profile.isPremium) {
-      toast({
-        title: "Premium Required",
-        description: "PDF downloads are available for premium members.",
-        variant: "destructive",
+  const items = useMemo<HumanDepthItem[]>(() => {
+    if (!profile) return [];
+    const astrology = (profile.astrologyData ?? {}) as any;
+    const numerology = (profile.numerologyData ?? {}) as any;
+    const personality = (profile.personalityData ?? {}) as any;
+    const archetype = (profile.archetypeData ?? {}) as any;
+    const result: HumanDepthItem[] = [];
+
+    const biography = text(profile.biography, archetype.description);
+    if (biography) {
+      result.push({
+        id: "core-story",
+        title: archetype.title || "Your core story",
+        observation: biography,
+        realLife: [
+          "Notice where this theme appears in actual decisions rather than only in words that sound meaningful.",
+          "Compare how the pattern changes at work, with family, in close relationships, and when you are alone.",
+          "Pay attention to the contradiction: a real pattern often contains both a strength and the behavior that protects it.",
+        ],
+        benefit: "A useful core story can organize scattered details into a pattern you can recognize and work with.",
+        tradeoff: "A story becomes limiting when it hardens into identity and makes contradictory experiences feel invalid.",
+        misunderstanding: "Symbolic language can sound more certain than the evidence allows. Recognition matters more than dramatic wording.",
+        relationshipView: "The people closest to you may see different versions of this pattern. Their experience can add context without overruling your own.",
+        practicalTakeaway: "Name one recent event that supports this description and one that complicates it. Keep both. Nuance is more useful than forced agreement.",
+        evidence: "Built from the saved biography and archetype description. These are interpretive synthesis fields, not clinical findings.",
       });
-      return;
     }
 
-    setIsDownloadingPdf(true);
-    try {
-      const response = await fetch(`/api/pdf/profile/${id}`, {
-        method: "GET",
-      });
+    for (const strength of archetype.strengths ?? []) result.push(explainLabel(String(strength), "strength"));
+    for (const growth of archetype.shadows ?? archetype.growthAreas ?? []) result.push(explainLabel(String(growth), "growth"));
 
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-
-      const blob = await response.blob();
-      const url = window.URL.createObjectURL(blob);
-      const link = document.createElement("a");
-      link.href = url;
-      link.download = `${profile.name}-soul-codex.pdf`;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      window.URL.revokeObjectURL(url);
-
-      toast({
-        title: "Success",
-        description: "Your Soul Codex PDF has been downloaded.",
+    const sun = astrology.sunSign ?? astrology.sun?.sign;
+    const moon = astrology.moonSign ?? astrology.moon?.sign;
+    const rising = astrology.risingSign ?? astrology.rising?.sign;
+    if (sun || moon || rising) {
+      result.push({
+        id: "astrology-big-three",
+        title: "How the Big Three may divide the work",
+        observation: `Your saved profile lists ${sun ? `${sun} Sun` : "an unresolved Sun"}, ${moon ? `${moon} Moon` : "an unresolved Moon"}, and ${rising ? `${rising} Rising` : "an unresolved Rising"}. Rather than treating these as three personality slogans, use them as three different questions about identity, emotional processing, and first response.`,
+        realLife: [
+          "The Sun layer is most useful when asking what you are trying to develop, express, or stand behind consciously.",
+          "The Moon layer is most useful when asking what restores safety and what becomes automatic when emotions are involved.",
+          "The Rising layer is most useful when asking what other people meet first and how you enter unfamiliar situations.",
+        ],
+        benefit: "Separating the layers can explain why you may appear one way, feel another way privately, and still choose a third response deliberately.",
+        tradeoff: "The model becomes shallow when signs are reduced to stereotypes or used to excuse behavior.",
+        misunderstanding: "A placement does not force a trait. It offers symbolic language for testing patterns against lived experience.",
+        relationshipView: "Conflict often begins when another person responds to the visible layer while you expect them to understand the private one.",
+        practicalTakeaway: "During one emotionally important moment, write down what you showed, what you felt, and what you chose. Compare the three without forcing them to match.",
+        evidence: "Derived from saved astrology fields. Birth-time-dependent claims remain limited when the recorded time is missing or approximate.",
       });
-    } catch (error) {
-      console.error("PDF download error:", error);
-      toast({
-        title: "Download Failed",
-        description: "Failed to download PDF. Please try again.",
-        variant: "destructive",
-      });
-    } finally {
-      setIsDownloadingPdf(false);
     }
-  };
 
-  if (isLoading) {
-    return (
-      <div className="min-h-screen bg-background">
-        <Navigation />
-        <div className="pt-24 flex items-center justify-center min-h-[calc(100vh-6rem)]">
-          <div className="text-center">
-            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
-            <p className="text-muted-foreground">Generating your cosmic blueprint...</p>
-          </div>
-        </div>
-      </div>
-    );
-  }
+    if (numerology.lifePath || numerology.expression || numerology.soulUrge) {
+      result.push({
+        id: "numerology-core",
+        title: "What your core numbers are trying to describe",
+        observation: `The saved profile includes Life Path ${numerology.lifePath ?? "unknown"}, Expression ${numerology.expression ?? "unknown"}, and Soul Urge ${numerology.soulUrge ?? "unknown"}. These numbers should not sit on the page like serial numbers for a soul. Each points to a different question: recurring life lessons, outward capacity, and inward motivation.`,
+        realLife: [
+          "Life Path is most useful when looking for themes that repeat across different periods rather than predicting a fixed destiny.",
+          "Expression is most useful when asking what skills or modes of contribution become available when you are engaged and practiced.",
+          "Soul Urge is most useful when asking what feels meaningful even when nobody is watching or rewarding you.",
+        ],
+        benefit: "Used together, the numbers can expose a gap between what you can do, what life keeps asking you to learn, and what you privately want.",
+        tradeoff: "A number becomes restrictive when it is treated as permission to stop growing or as proof that every matching sentence must be true.",
+        misunderstanding: "Numerology is deterministic as arithmetic but interpretive in meaning. The calculation can be exact while the explanation remains symbolic.",
+        relationshipView: "Differences often matter less than whether two people understand each other's priorities, pace, and way of contributing.",
+        practicalTakeaway: "Choose one current responsibility. Ask whether it serves your development, uses your real capacities, and matters to you inwardly. A mismatch tells you more than the number alone.",
+        evidence: "The numeric values come from saved calculations. Their psychological or spiritual meanings are interpretive.",
+      });
+    }
 
-  if (error || !profile) {
-    return (
-      <div className="min-h-screen bg-background">
-        <Navigation />
-        <div className="pt-24 flex items-center justify-center min-h-[calc(100vh-6rem)]">
-          <Card className="max-w-md">
-            <CardContent className="pt-6 text-center">
-              <Shield className="h-12 w-12 text-destructive mx-auto mb-4" />
-              <h2 className="text-xl font-semibold mb-2">Profile Not Found</h2>
-              <p className="text-muted-foreground mb-4">
-                The soul profile you're looking for doesn't exist or couldn't be loaded.
-              </p>
-              <Link href="/">
-                <Button>Return Home</Button>
-              </Link>
-            </CardContent>
-          </Card>
-        </div>
-      </div>
-    );
-  }
+    if (personality.enneagram?.type || personality.mbti?.type) {
+      result.push({
+        id: "personality-bridge",
+        title: "How assessed personality may show up under pressure",
+        observation: `Your saved assessments include ${personality.enneagram?.type ? `Enneagram Type ${personality.enneagram.type}` : "no Enneagram result"} and ${personality.mbti?.type ? personality.mbti.type : "no MBTI result"}. These systems are most useful when they explain motivation and information-processing habits, not when they become decorative identity badges.`,
+        realLife: [
+          "Notice which need becomes urgent during conflict: safety, control, understanding, approval, freedom, competence, peace, or something else.",
+          "Notice what kind of information you trust first and what evidence you tend to ignore when rushed.",
+          "Compare your relaxed behavior with your stressed behavior. A useful model should explain the change, not pretend you act the same everywhere.",
+        ],
+        benefit: "Assessment language can make invisible motives and decision habits easier to discuss.",
+        tradeoff: "Typing can become an excuse, a social costume, or a way to avoid evidence that does not fit the preferred identity.",
+        misunderstanding: "Your type describes a tendency within a model. It does not contain your history, maturity, context, culture, or every choice.",
+        relationshipView: "The practical value is learning how another person interprets your behavior and how to state the need underneath it before resentment does the translating.",
+        practicalTakeaway: "Identify one recent disagreement. Separate what happened, what you assumed, what you needed, and what you actually communicated.",
+        evidence: "Based on saved user-assessment fields. Assessment quality depends on honest responses and the limits of each framework.",
+      });
+    }
 
-  const astrologyData = profile.astrologyData as any;
-  const numerologyData = profile.numerologyData as any;
-  const personalityData = profile.personalityData as any;
-  const archetypeData = profile.archetypeData as any;
+    const guidance = text(profile.dailyGuidance, archetype.guidance);
+    if (guidance) {
+      result.push({
+        id: "guidance",
+        title: "Turn guidance into an observable experiment",
+        observation: guidance,
+        realLife: [
+          "A useful guidance statement should change one decision, conversation, boundary, or repeated behavior.",
+          "The action should be small enough to complete and specific enough that you can tell what happened afterward.",
+          "If the statement only sounds beautiful, it belongs in decoration rather than guidance.",
+        ],
+        benefit: "Guidance becomes valuable when it turns reflection into a testable next step.",
+        tradeoff: "Vague guidance can create the feeling of insight without producing evidence, change, or clearer self-understanding.",
+        misunderstanding: "Symbolic guidance is not a command or prediction. You remain responsible for context and consequences.",
+        relationshipView: "When guidance involves another person, communicate directly rather than silently testing whether they can guess what you need.",
+        practicalTakeaway: "Rewrite the guidance as one sentence beginning with “Today I will…” and include a behavior another person could observe.",
+        evidence: "Drawn from the saved daily and archetype guidance fields. Relevance must be confirmed through lived experience.",
+      });
+    }
+
+    return result;
+  }, [profile]);
+
+  if (isLoading) return <div className="min-h-screen bg-background"><Navigation /><main className="mx-auto flex min-h-screen max-w-3xl items-center justify-center px-4"><p className="text-muted-foreground">Building the reading from available evidence…</p></main></div>;
+
+  if (error || !profile) return <div className="min-h-screen bg-background"><Navigation /><main className="mx-auto flex min-h-screen max-w-lg items-center justify-center px-4"><Card><CardContent className="p-8 text-center"><Shield className="mx-auto mb-4 h-10 w-10 text-destructive" /><h1 className="mb-2 text-2xl font-bold">Profile not found</h1><p className="mb-5 text-muted-foreground">The requested profile could not be loaded.</p><Link href="/"><Button>Return home</Button></Link></CardContent></Card></main></div>;
+
+  const astrology = (profile.astrologyData ?? {}) as any;
+  const numerology = (profile.numerologyData ?? {}) as any;
+  const archetype = (profile.archetypeData ?? {}) as any;
 
   return (
     <div className="min-h-screen bg-background text-foreground">
       <Navigation />
-      
-      <div className="pt-24 pb-12">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          {/* Header */}
-          <div className="mb-8">
-            <Link href="/">
-              <Button variant="ghost" className="mb-4" data-testid="button-back">
-                <ArrowLeft className="mr-2 h-4 w-4" />
-                Back to Home
-              </Button>
-            </Link>
-            
-            <div className="text-center">
-              <h1 className="text-3xl sm:text-4xl font-bold mb-2">
-                {profile.name}'s
-                <span className="text-transparent bg-gradient-to-r from-primary to-accent bg-clip-text font-serif ml-2">
-                  Soul Codex
-                </span>
-              </h1>
-              <p className="text-muted-foreground">
-                Generated on {new Date(profile.createdAt!).toLocaleDateString()}
-              </p>
-            </div>
+      <main className="mx-auto max-w-6xl px-4 pb-24 pt-28 sm:px-6">
+        <Link href="/"><Button variant="ghost" className="mb-6"><ArrowLeft className="mr-2 h-4 w-4" /> Back home</Button></Link>
+
+        <header className="mb-8 rounded-3xl border border-amber-300/25 bg-gradient-to-br from-violet-950/70 to-black/40 p-6 sm:p-9">
+          <div className="mb-4 flex items-center gap-3 text-amber-300"><Crown className="h-6 w-6" /><span className="text-xs font-bold uppercase tracking-[0.2em]">Unified Soul Codex</span></div>
+          <h1 className="font-serif text-4xl sm:text-6xl">{profile.name}</h1>
+          <p className="mt-3 max-w-3xl text-lg leading-8 text-white/70">This page now explains the profile as one connected human story. Labels remain visible, but none of them are allowed to stand alone and pretend they explained you.</p>
+          <div className="mt-5 flex flex-wrap gap-2">
+            {astrology.sunSign && <Badge variant="secondary">{astrology.sunSign} Sun</Badge>}
+            {astrology.moonSign && <Badge variant="secondary">{astrology.moonSign} Moon</Badge>}
+            {astrology.risingSign && <Badge variant="secondary">{astrology.risingSign} Rising</Badge>}
+            {numerology.lifePath && <Badge variant="secondary">Life Path {numerology.lifePath}</Badge>}
+            {archetype.title && <Badge variant="secondary">{archetype.title}</Badge>}
           </div>
+        </header>
 
-          {/* Archetype Hero Card */}
-          <Card className="cosmic-border mystical-glow bg-transparent border-0 mb-8">
-            <div className="cosmic-border-inner">
-              <CardContent className="p-8">
-                <div className="text-center">
-                  <Crown className="h-12 w-12 text-accent mx-auto mb-4" />
-                  <h2 className="text-2xl sm:text-3xl font-bold mb-2" data-testid="text-archetype-title">
-                    {archetypeData?.title || "Cosmic Soul"}
-                  </h2>
-                  <p className="text-lg text-muted-foreground mb-6 max-w-2xl mx-auto" data-testid="text-archetype-description">
-                    {archetypeData?.description || "Your unique spiritual essence is being revealed..."}
-                  </p>
-                  
-                  {/* Astrology Big 3 */}
-                  <div className="flex items-center justify-center space-x-6 text-sm">
-                    <div className="flex items-center space-x-2">
-                      <Sun className="h-4 w-4 text-accent" />
-                      <span data-testid="text-sun-sign">{astrologyData?.sunSign || "Unknown"} ☉</span>
-                    </div>
-                    <div className="flex items-center space-x-2">
-                      <Moon className="h-4 w-4 text-accent" />
-                      <span data-testid="text-moon-sign">{astrologyData?.moonSign || "Unknown"} ☽</span>
-                    </div>
-                    <div className="flex items-center space-x-2">
-                      <Star className="h-4 w-4 text-accent" />
-                      <span data-testid="text-rising-sign">{astrologyData?.risingSign || "Unknown"} ↑</span>
-                    </div>
-                  </div>
-                </div>
-              </CardContent>
-            </div>
-          </Card>
-
-          {/* Biography Card */}
-          {profile.biography && (
-            <Card className="glassmorphism mb-8">
-              <CardHeader>
-                <CardTitle className="flex items-center space-x-2">
-                  <ScrollText className="h-5 w-5 text-primary" />
-                  <span>Your Soul Biography</span>
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-lg leading-relaxed" data-testid="text-biography">
-                  {profile.biography}
-                </p>
-              </CardContent>
-            </Card>
-          )}
-
-          {/* Main Content Tabs */}
-          <Tabs defaultValue="overview" className="space-y-6">
-            <TabsList className="grid grid-cols-2 md:grid-cols-7 w-full">
-              <TabsTrigger value="overview" data-testid="tab-overview">Overview</TabsTrigger>
-              <TabsTrigger value="astrology" data-testid="tab-astrology">Astrology</TabsTrigger>
-              <TabsTrigger value="numerology" data-testid="tab-numerology">Numerology</TabsTrigger>
-              <TabsTrigger value="personality" data-testid="tab-personality">Personality</TabsTrigger>
-              <TabsTrigger value="guidance" data-testid="tab-guidance">Guidance</TabsTrigger>
-              {profile.isPremium && (
-                <>
-                  <TabsTrigger value="astrocartography" data-testid="tab-astrocartography">Maps</TabsTrigger>
-                  <TabsTrigger value="palmistry" data-testid="tab-palmistry">Palm</TabsTrigger>
-                </>
-              )}
-            </TabsList>
-
-            {/* Overview Tab */}
-            <TabsContent value="overview" className="space-y-6">
-              <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
-                {/* Core Numbers */}
-                <Card className="glassmorphism">
-                  <CardHeader>
-                    <CardTitle className="flex items-center space-x-2">
-                      <Infinity className="h-5 w-5 text-primary" />
-                      <span>Core Numbers</span>
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent className="space-y-4">
-                    <div className="flex justify-between items-center">
-                      <span>Life Path</span>
-                      <Badge variant="secondary" data-testid="text-life-path">
-                        {numerologyData?.lifePath || "Unknown"}
-                      </Badge>
-                    </div>
-                    <div className="flex justify-between items-center">
-                      <span>Expression</span>
-                      <Badge variant="secondary" data-testid="text-expression">
-                        {numerologyData?.expression || "Unknown"}
-                      </Badge>
-                    </div>
-                    <div className="flex justify-between items-center">
-                      <span>Soul Urge</span>
-                      <Badge variant="secondary" data-testid="text-soul-urge">
-                        {numerologyData?.soulUrge || "Unknown"}
-                      </Badge>
-                    </div>
-                  </CardContent>
-                </Card>
-
-                {/* Personality Types */}
-                <Card className="glassmorphism">
-                  <CardHeader>
-                    <CardTitle className="flex items-center space-x-2">
-                      <Brain className="h-5 w-5 text-primary" />
-                      <span>Personality</span>
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent className="space-y-4">
-                    <div className="flex justify-between items-center">
-                      <span>Enneagram</span>
-                      <Badge variant="secondary" data-testid="text-enneagram">
-                        {personalityData?.enneagram?.type ? `Type ${personalityData.enneagram.type}` : "Take Assessment"}
-                      </Badge>
-                    </div>
-                    <div className="flex justify-between items-center">
-                      <span>MBTI</span>
-                      <Badge variant="secondary" data-testid="text-mbti">
-                        {personalityData?.mbti?.type || "Take Assessment"}
-                      </Badge>
-                    </div>
-                  </CardContent>
-                </Card>
-
-                {/* Tarot Birth Cards */}
-                {archetypeData?.tarotCards && (
-                  <Card className="glassmorphism">
-                    <CardHeader>
-                      <CardTitle className="flex items-center space-x-2">
-                        <Sparkles className="h-5 w-5 text-primary" />
-                        <span>Tarot Birth Cards</span>
-                      </CardTitle>
-                    </CardHeader>
-                    <CardContent className="space-y-3">
-                      <div>
-                        <div className="font-medium text-sm mb-1">Primary Cards</div>
-                        <div className="text-accent font-semibold" data-testid="text-tarot-cards">
-                          {archetypeData.tarotCards.card1} • {archetypeData.tarotCards.card2}
-                        </div>
-                      </div>
-                      <p className="text-xs text-muted-foreground" data-testid="text-tarot-interpretation">
-                        {archetypeData.tarotCards.interpretation}
-                      </p>
-                    </CardContent>
-                  </Card>
-                )}
-              </div>
-
-              {/* Archetype Details */}
-              {archetypeData && (
-                <div className="grid md:grid-cols-2 gap-6">
-                  <Card className="glassmorphism">
-                    <CardHeader>
-                      <CardTitle className="flex items-center space-x-2">
-                        <Zap className="h-5 w-5 text-primary" />
-                        <span>Strengths & Gifts</span>
-                      </CardTitle>
-                    </CardHeader>
-                    <CardContent>
-                      <ul className="space-y-2">
-                        {archetypeData.strengths?.map((strength: string, index: number) => (
-                          <li key={index} className="flex items-center space-x-2">
-                            <div className="w-2 h-2 bg-accent rounded-full"></div>
-                            <span>{strength}</span>
-                          </li>
-                        ))}
-                      </ul>
-                    </CardContent>
-                  </Card>
-
-                  <Card className="glassmorphism">
-                    <CardHeader>
-                      <CardTitle className="flex items-center space-x-2">
-                        <Target className="h-5 w-5 text-primary" />
-                        <span>Growth Areas</span>
-                      </CardTitle>
-                    </CardHeader>
-                    <CardContent>
-                      <ul className="space-y-2">
-                        {archetypeData.shadows?.map((shadow: string, index: number) => (
-                          <li key={index} className="flex items-center space-x-2">
-                            <div className="w-2 h-2 bg-muted-foreground rounded-full"></div>
-                            <span>{shadow}</span>
-                          </li>
-                        ))}
-                      </ul>
-                    </CardContent>
-                  </Card>
-                </div>
-              )}
-            </TabsContent>
-
-            {/* Astrology Tab */}
-            <TabsContent value="astrology" className="space-y-6">
-              <div className="grid lg:grid-cols-2 gap-6">
-                <Card className="glassmorphism">
-                  <CardHeader>
-                    <CardTitle className="flex items-center space-x-2">
-                      <ChartPie className="h-5 w-5 text-primary" />
-                      <span>Birth Chart</span>
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <CosmicChart 
-                      astrologyData={astrologyData}
-                      size={300}
-                    />
-                  </CardContent>
-                </Card>
-
-                <div className="space-y-6">
-                  {/* Planetary Positions */}
-                  <Card className="glassmorphism">
-                    <CardHeader>
-                      <CardTitle>Planetary Positions</CardTitle>
-                    </CardHeader>
-                    <CardContent className="space-y-3">
-                      {astrologyData?.planets && Object.entries(astrologyData.planets).map(([planet, data]: [string, any]) => (
-                        <div key={planet} className="flex justify-between items-center">
-                          <span className="capitalize">{planet}</span>
-                          <Badge variant="outline" data-testid={`text-planet-${planet}`}>
-                            {data.sign} {data.house}H
-                          </Badge>
-                        </div>
-                      ))}
-                    </CardContent>
-                  </Card>
-
-                  {/* Nodes & Chiron */}
-                  <Card className="glassmorphism">
-                    <CardHeader>
-                      <CardTitle>Karmic Points</CardTitle>
-                    </CardHeader>
-                    <CardContent className="space-y-3">
-                      <div className="flex justify-between items-center">
-                        <span>North Node</span>
-                        <Badge variant="outline" data-testid="text-north-node">
-                          {astrologyData?.northNode?.sign} {astrologyData?.northNode?.house}H
-                        </Badge>
-                      </div>
-                      <div className="flex justify-between items-center">
-                        <span>South Node</span>
-                        <Badge variant="outline" data-testid="text-south-node">
-                          {astrologyData?.southNode?.sign} {astrologyData?.southNode?.house}H
-                        </Badge>
-                      </div>
-                      <div className="flex justify-between items-center">
-                        <span>Chiron</span>
-                        <Badge variant="outline" data-testid="text-chiron">
-                          {astrologyData?.chiron?.sign} {astrologyData?.chiron?.house}H
-                        </Badge>
-                      </div>
-                    </CardContent>
-                  </Card>
-                </div>
-              </div>
-            </TabsContent>
-
-            {/* Numerology Tab */}
-            <TabsContent value="numerology" className="space-y-6">
-              <div className="grid md:grid-cols-2 gap-6">
-                <Card className="glassmorphism">
-                  <CardHeader>
-                    <CardTitle>Core Numbers</CardTitle>
-                  </CardHeader>
-                  <CardContent className="space-y-4">
-                    <div className="space-y-3">
-                      <div>
-                        <div className="flex justify-between items-center mb-2">
-                          <span className="font-medium">Life Path Number</span>
-                          <Badge className="bg-primary text-primary-foreground">
-                            {numerologyData?.lifePath}
-                          </Badge>
-                        </div>
-                        <p className="text-sm text-muted-foreground" data-testid="text-life-path-interpretation">
-                          {numerologyData?.interpretations?.lifePath}
-                        </p>
-                      </div>
-                      
-                      <div>
-                        <div className="flex justify-between items-center mb-2">
-                          <span className="font-medium">Expression Number</span>
-                          <Badge variant="secondary">
-                            {numerologyData?.expression}
-                          </Badge>
-                        </div>
-                        <p className="text-sm text-muted-foreground" data-testid="text-expression-interpretation">
-                          {numerologyData?.interpretations?.expression}
-                        </p>
-                      </div>
-                    </div>
-                  </CardContent>
-                </Card>
-
-                <Card className="glassmorphism">
-                  <CardHeader>
-                    <CardTitle>Soul & Personality</CardTitle>
-                  </CardHeader>
-                  <CardContent className="space-y-4">
-                    <div className="space-y-3">
-                      <div>
-                        <div className="flex justify-between items-center mb-2">
-                          <span className="font-medium">Soul Urge</span>
-                          <Badge variant="secondary">
-                            {numerologyData?.soulUrge}
-                          </Badge>
-                        </div>
-                        <p className="text-sm text-muted-foreground" data-testid="text-soul-urge-interpretation">
-                          {numerologyData?.interpretations?.soulUrge}
-                        </p>
-                      </div>
-                      
-                      <div>
-                        <div className="flex justify-between items-center mb-2">
-                          <span className="font-medium">Personality Number</span>
-                          <Badge variant="secondary">
-                            {numerologyData?.personality}
-                          </Badge>
-                        </div>
-                        <p className="text-sm text-muted-foreground" data-testid="text-personality-interpretation">
-                          {numerologyData?.interpretations?.personality}
-                        </p>
-                      </div>
-                    </div>
-                  </CardContent>
-                </Card>
-              </div>
-
-              <Card className="glassmorphism">
-                <CardHeader>
-                  <CardTitle className="flex items-center space-x-2">
-                    <Calendar className="h-5 w-5 text-primary" />
-                    <span>Current Year Cycle</span>
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <div className="flex items-center space-x-4 mb-3">
-                    <span className="font-medium">Personal Year</span>
-                    <Badge className="bg-accent text-accent-foreground">
-                      {numerologyData?.personalYear}
-                    </Badge>
-                  </div>
-                  <p className="text-muted-foreground" data-testid="text-personal-year-interpretation">
-                    {numerologyData?.interpretations?.personalYear}
-                  </p>
-                </CardContent>
-              </Card>
-            </TabsContent>
-
-            {/* Personality Tab */}
-            <TabsContent value="personality" className="space-y-6">
-              <div className="grid md:grid-cols-2 gap-6">
-                {/* Enneagram */}
-                {personalityData?.enneagram ? (
-                  <Card className="glassmorphism">
-                    <CardHeader>
-                      <CardTitle className="flex items-center space-x-2">
-                        <Heart className="h-5 w-5 text-primary" />
-                        <span>Enneagram Type {personalityData.enneagram.type}</span>
-                      </CardTitle>
-                    </CardHeader>
-                    <CardContent className="space-y-4">
-                      <p className="text-sm" data-testid="text-enneagram-description">
-                        {personalityData.enneagram.description}
-                      </p>
-                      <div>
-                        <h4 className="font-medium mb-2">Core Motivation</h4>
-                        <p className="text-sm text-muted-foreground" data-testid="text-enneagram-motivation">
-                          {personalityData.enneagram.motivation}
-                        </p>
-                      </div>
-                      <div>
-                        <h4 className="font-medium mb-2">Basic Fear</h4>
-                        <p className="text-sm text-muted-foreground" data-testid="text-enneagram-fear">
-                          {personalityData.enneagram.fear}
-                        </p>
-                      </div>
-                    </CardContent>
-                  </Card>
-                ) : (
-                  <Card className="glassmorphism">
-                    <CardHeader>
-                      <CardTitle>Enneagram Assessment</CardTitle>
-                    </CardHeader>
-                    <CardContent>
-                      <p className="text-muted-foreground mb-4">
-                        Complete the Enneagram assessment to unlock deeper personality insights.
-                      </p>
-                      <Button variant="outline" data-testid="button-take-enneagram">
-                        Take Assessment
-                      </Button>
-                    </CardContent>
-                  </Card>
-                )}
-
-                {/* MBTI */}
-                {personalityData?.mbti ? (
-                  <Card className="glassmorphism">
-                    <CardHeader>
-                      <CardTitle className="flex items-center space-x-2">
-                        <Brain className="h-5 w-5 text-primary" />
-                        <span>MBTI - {personalityData.mbti.type}</span>
-                      </CardTitle>
-                    </CardHeader>
-                    <CardContent className="space-y-4">
-                      <p className="text-sm" data-testid="text-mbti-description">
-                        {personalityData.mbti.description}
-                      </p>
-                      <div>
-                        <h4 className="font-medium mb-2">Cognitive Functions</h4>
-                        <div className="flex flex-wrap gap-2">
-                          {personalityData.mbti.functions?.map((func: string, index: number) => (
-                            <Badge key={index} variant="outline">
-                              {func}
-                            </Badge>
-                          ))}
-                        </div>
-                      </div>
-                    </CardContent>
-                  </Card>
-                ) : (
-                  <Card className="glassmorphism">
-                    <CardHeader>
-                      <CardTitle>MBTI Assessment</CardTitle>
-                    </CardHeader>
-                    <CardContent>
-                      <p className="text-muted-foreground mb-4">
-                        Complete the MBTI assessment to discover your cognitive preferences.
-                      </p>
-                      <Button variant="outline" data-testid="button-take-mbti">
-                        Take Assessment
-                      </Button>
-                    </CardContent>
-                  </Card>
-                )}
-              </div>
-            </TabsContent>
-
-            {/* Guidance Tab */}
-            <TabsContent value="guidance" className="space-y-6">
-              {/* Daily Guidance */}
-              {profile.dailyGuidance && (
-                <Card className="glassmorphism">
-                  <CardHeader>
-                    <CardTitle className="flex items-center space-x-2">
-                      <Compass className="h-5 w-5 text-primary" />
-                      <span>Today's Cosmic Guidance</span>
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <p className="text-lg leading-relaxed" data-testid="text-daily-guidance">
-                      {profile.dailyGuidance}
-                    </p>
-                  </CardContent>
-                </Card>
-              )}
-
-              {/* Archetype Guidance */}
-              {archetypeData?.guidance && (
-                <Card className="glassmorphism">
-                  <CardHeader>
-                    <CardTitle className="flex items-center space-x-2">
-                      <BookOpen className="h-5 w-5 text-primary" />
-                      <span>Your Soul Path Guidance</span>
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <p className="text-lg leading-relaxed" data-testid="text-archetype-guidance">
-                      {archetypeData.guidance}
-                    </p>
-                  </CardContent>
-                </Card>
-              )}
-
-              {/* Upgrade to Premium */}
-              {!profile.isPremium && (
-                <Card className="cosmic-border mystical-glow bg-transparent border-0">
-                  <div className="cosmic-border-inner">
-                    <CardContent className="p-8 text-center">
-                      <Crown className="h-12 w-12 text-accent mx-auto mb-4" />
-                      <h3 className="text-2xl font-bold mb-4">Unlock Your Complete Codex</h3>
-                      <p className="text-muted-foreground mb-6 max-w-2xl mx-auto">
-                        Access your full 30-40 page PDF dossier, astrocartography map, palmistry analysis,
-                        and 12+ additional mystical systems for deeper self-understanding.
-                      </p>
-                      <Button
-                        onClick={() => setShowUpgradeModal(true)}
-                        className="bg-primary text-primary-foreground px-8 py-3 font-semibold"
-                        data-testid="button-upgrade-premium"
-                      >
-                        Upgrade to Premium - $47
-                      </Button>
-                    </CardContent>
-                  </div>
-                </Card>
-              )}
-            </TabsContent>
-
-            {/* Astrocartography Tab */}
-            {profile.isPremium && (
-              <TabsContent value="astrocartography" className="space-y-6">
-                <Card className="glassmorphism">
-                  <CardHeader>
-                    <CardTitle>Astrocartography Map</CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <p className="text-muted-foreground mb-6">
-                      Discover your power places worldwide. This interactive map shows locations optimized for love, career, healing, and transformation based on your natal chart.
-                    </p>
-                    <Link href={`/astrocartography/${id}`}>
-                      <Button className="w-full">
-                        View Full Astrocartography Map →
-                      </Button>
-                    </Link>
-                  </CardContent>
-                </Card>
-              </TabsContent>
-            )}
-
-            {/* Palmistry Tab */}
-            {profile.isPremium && (
-              <TabsContent value="palmistry" className="space-y-6">
-                <Card className="glassmorphism">
-                  <CardHeader>
-                    <CardTitle>AI Palmistry Analysis</CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <p className="text-muted-foreground mb-6">
-                      Upload a palm photo for computer vision analysis of your life, heart, head, and fate lines. Get insights into your vitality, emotional patterns, mental abilities, and destiny path.
-                    </p>
-                    <Link href={`/palmistry/${id}`}>
-                      <Button className="w-full">
-                        Analyze Your Palm →
-                      </Button>
-                    </Link>
-                  </CardContent>
-                </Card>
-              </TabsContent>
-            )}
-          </Tabs>
-
-          {/* Actions */}
-          <div className="mt-12 flex flex-col sm:flex-row gap-4 justify-center">
-            <Button
-              variant="outline"
-              data-testid="button-share-profile"
-              onClick={() => setShowShareModal(true)}
-            >
-              <Star className="mr-2 h-4 w-4" />
-              Share Profile
-            </Button>
-            <Button
-              variant="outline"
-              data-testid="button-download-pdf"
-              onClick={handleDownloadPdf}
-              disabled={isDownloadingPdf}
-            >
-              <Download className="mr-2 h-4 w-4" />
-              {isDownloadingPdf ? "Downloading..." : "Download PDF"}
-            </Button>
-            {!profile.isPremium && (
-              <Button
-                onClick={() => setShowUpgradeModal(true)}
-                className="bg-primary text-primary-foreground"
-                data-testid="button-upgrade-main"
-              >
-                <Crown className="mr-2 h-4 w-4" />
-                Upgrade to Premium
-              </Button>
-            )}
-          </div>
+        <div className="mb-7 rounded-2xl border border-teal-300/15 bg-teal-300/[0.035] p-5">
+          <div className="flex items-start gap-3"><Sparkles className="mt-1 h-5 w-5 text-teal-300" /><div><h2 className="font-semibold text-teal-100">One profile, one explanation standard</h2><p className="mt-1 leading-7 text-white/60">Astrology, numerology, personality, archetype, biography, and guidance are integrated below. Evidence labels stay separate from interpretation, and your feedback corrects the explanation rather than rewriting calculated data.</p></div></div>
         </div>
-      </div>
 
-      {showUpgradeModal && (
-        <PremiumUpgradeModal
-          profileId={id!}
-          onClose={() => setShowUpgradeModal(false)}
-        />
-      )}
+        <HumanDepthSurface profileId={String(id)} heading="How these patterns may live in you" intro="Read for recognition, contradiction, cost, context, and usable action. Reject anything that does not fit your lived experience." items={items} />
 
-      {showShareModal && profile && (
-        <ShareModal
-          profileId={id!}
-          profileName={profile.name}
-          onClose={() => setShowShareModal(false)}
-        />
-      )}
+        <div className="mt-8 flex justify-center"><Link href={`/profile/${id}/reading`}><Button size="lg">Open full Quick / Standard / Deep Dive reading</Button></Link></div>
+      </main>
     </div>
   );
 }

--- a/tests/human-depth-surfaces.test.ts
+++ b/tests/human-depth-surfaces.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+
+const read = (path: string) => fs.readFileSync(path, "utf8");
+
+describe("Human Depth interpretation surfaces", () => {
+  it("provides one reusable explanation and correction contract", () => {
+    const component = read("client/src/components/HumanDepthSurface.tsx");
+    expect(component).toContain("What this may look like in real life");
+    expect(component).toContain("What this gives you");
+    expect(component).toContain("What it may cost");
+    expect(component).toContain("How this may be misunderstood");
+    expect(component).toContain("In relationships");
+    expect(component).toContain("What to do with this insight");
+    expect(component).toContain("Does this fit your experience?");
+    expect(component).toContain("Very much");
+    expect(component).toContain("Partly");
+    expect(component).toContain("Not really");
+  });
+
+  it("replaces disconnected profile tabs with one integrated human story", () => {
+    const profile = read("client/src/pages/profile.tsx");
+    expect(profile).toContain("HumanDepthSurface");
+    expect(profile).toContain("One profile, one explanation standard");
+    expect(profile).toContain("How the Big Three may divide the work");
+    expect(profile).toContain("What your core numbers are trying to describe");
+    expect(profile).toContain("How assessed personality may show up under pressure");
+    expect(profile).toContain("Turn guidance into an observable experiment");
+    expect(profile).not.toContain("Strengths & Gifts");
+    expect(profile).not.toContain("Growth Areas");
+  });
+
+  it("makes compatibility explain interaction instead of terminating at a score", () => {
+    const compatibility = read("client/src/pages/CompatibilityExperience.tsx");
+    expect(compatibility).toContain("HumanDepthSurface");
+    expect(compatibility).toContain("Explain the relationship, not just the score");
+    expect(compatibility).toContain("Stress and repair");
+    expect(compatibility).toContain("Values in practice");
+    expect(compatibility).toContain("Decision pace and style");
+    expect(compatibility).toContain("Where misunderstanding may repeat");
+    expect(compatibility).toContain("What this relationship may ask you to practice");
+  });
+});


### PR DESCRIPTION
## Purpose

Extend the Human Depth standard beyond the dedicated reading route so the main profile and compatibility experience explain lived patterns instead of displaying disconnected labels and scores.

## Changes

- Adds a reusable `HumanDepthSurface` component with real-life examples, benefit, tradeoff, misunderstanding, relationship context, practical action, evidence, and user fit feedback
- Replaces the legacy seven-tab profile report with one integrated explanation across biography, archetype strengths and growth areas, astrology, numerology, assessed personality, and guidance
- Replaces score-first compatibility output with explanations of identity, stress and repair, values in practice, decision style, synergy, recurring friction, and growth work
- Keeps user corrections local and confined to the interpretation layer
- Adds regression coverage for the shared surface contract and both integrations

## Trust boundaries

- Calculated and verified values remain separate from interpretation
- Scores navigate the compatibility report but do not define the relationship
- Symbolic language remains testable against lived experience
- User feedback never rewrites birth data or calculated results

## Validation

Run the documented Google Cloud Shell validation sequence before merge while hosted Actions remain billing-blocked.