### PR TITLE
Remove clipped specialty readings and enforce Human Depth at the source

### DIFF
--- a/client/src/lib/soul-codex/utils/cleanCodexLine.ts
+++ b/client/src/lib/soul-codex/utils/cleanCodexLine.ts
@@ -1,3 +1,9 @@
+const sentenceCount = (value: string) =>
+  value.split(/[.!?]+(?:\s|$)/).map(part => part.trim()).filter(Boolean).length;
+
+const terminalDepthBridge = (value: string) =>
+  `${value} Treat this as a starting interpretation rather than a verdict. Check where it appears in decisions, work, conflict, relationships, stress, or self-talk, then notice both what it helps and what it costs. One useful next step is to name a recent example that supports the pattern and another that contradicts it.`;
+
 export function cleanCodexLine(value: unknown, fallback: string): string {
   if (typeof value !== "string") return fallback;
 
@@ -9,6 +15,13 @@ export function cleanCodexLine(value: unknown, fallback: string): string {
   if (trimmed === "undefined" || trimmed === "null") return fallback;
   if (trimmed.includes("Aligning your natal and behavioral signals")) {
     return fallback;
+  }
+
+  // Several specialty surfaces historically ended after one polished sentence.
+  // Preserve richer generated text, but give short legacy output a transparent
+  // interpretation bridge instead of pretending the label is self-explanatory.
+  if (sentenceCount(trimmed) < 3 || trimmed.length < 180) {
+    return terminalDepthBridge(trimmed);
   }
 
   return trimmed;

--- a/packages/core/codex30/systems/humanDesign.ts
+++ b/packages/core/codex30/systems/humanDesign.ts
@@ -1,26 +1,36 @@
 import type { Signal } from "../types.js";
 
 const TYPE_TAGS: Record<string, string[]> = {
-  reflector:  ["social_sensitivity", "intuition", "privacy"],
-  projector:  ["leadership", "precision", "boundaries"],
-  generator:  ["craft", "discipline", "service"],
+  reflector: ["social_sensitivity", "intuition", "privacy"],
+  projector: ["leadership", "precision", "boundaries"],
+  generator: ["craft", "discipline", "service"],
   manifesting_generator: ["craft", "courage", "innovation"],
-  manifestor: ["leadership", "freedom", "intensity"]
+  manifestor: ["leadership", "freedom", "intensity"],
+};
+
+const TYPE_EXPLANATIONS: Record<string, string> = {
+  reflector: "A Reflector reading is best treated as a hypothesis about environmental sensitivity, not a fixed identity. In daily life, this may look like feeling clearer in some rooms and depleted in others, needing more time before major decisions, and noticing group tension before anyone names it. The benefit is strong situational awareness. The tradeoff is mistaking the atmosphere around you for a permanent truth about yourself. Other people may read your changing response as inconsistency when you may actually be registering changing conditions. A grounded experiment is to compare how the same decision feels across several days and environments before treating one moment as final.",
+  projector: "A Projector reading points toward selective attention and guidance rather than endless output. In daily life, this may look like spotting inefficiency quickly, seeing what another person could improve, and becoming exhausted when you try to prove your value through constant labor. The benefit is precision and perspective. The tradeoff is offering insight before it is welcome or measuring worth by recognition. Other people may read your need for pacing as low commitment when the deeper issue may be energy allocation. A grounded experiment is to choose one place where your insight is clearly requested and notice whether the same effort lands differently.",
+  generator: "A Generator reading emphasizes sustained engagement with work that feels responsive rather than forced. In daily life, this may look like building momentum once something genuinely interests you, becoming dependable through repetition, and feeling stuck when obligation replaces meaningful response. The benefit is durable energy and craft. The tradeoff is staying too long because you can keep going. Other people may mistake endurance for consent. A grounded experiment is to separate what you can continue from what you still want to continue.",
+  manifesting_generator: "A Manifesting Generator reading emphasizes fast experimentation, multiple interests, and nonlinear progress. In daily life, this may look like skipping ahead, learning through motion, changing methods quickly, and returning later to repair steps that were rushed. The benefit is speed and inventive problem-solving. The tradeoff is frustration, unfinished foundations, or confusing other people with abrupt pivots. Other people may read your changes as unreliability when you may be testing for fit. A grounded experiment is to announce the pivot and complete one stabilizing step before starting the next branch.",
+  manifestor: "A Manifestor reading emphasizes initiation and the need to move without excessive control from others. In daily life, this may look like acting before consensus forms, resisting micromanagement, and withdrawing when every move requires permission. The benefit is independent momentum. The tradeoff is creating avoidable resistance when people are affected but uninformed. Other people may read privacy as hostility when you may be protecting autonomy. A grounded experiment is to inform the people affected by your decision without turning that information into a request for permission.",
 };
 
 export function humanDesignSignals(hd: any): Signal[] {
   if (!hd?.type) return [];
-  const raw  = String(hd.type).toLowerCase().replace(/\s+/g, "_");
+  const raw = String(hd.type).toLowerCase().replace(/\s+/g, "_");
   const tags = TYPE_TAGS[raw] ?? ["courage", "craft"];
+  const label = TYPE_EXPLANATIONS[raw]
+    ?? `This ${hd.type} interpretation may describe pacing, rest needs, and decision timing, but it should be tested against lived experience. Notice when the pattern helps, what it costs when overused, how other people may misread it, and which practical adjustment creates more clarity.`;
 
   return [{
     id: `hd.type.${raw}`,
     system: "humanDesign",
-    label: `Energy Type: ${hd.type} shapes my pacing, rest needs, and decision timing.`,
-    evidence: [`Human Design: ${hd.type}`],
+    label,
+    evidence: [`Human Design type entered or calculated as ${hd.type}. This is symbolic interpretation, not verified psychology.`],
     intensity: 0.75,
     polarity: "neutral",
     confidence: "low",
-    tags
+    tags,
   }];
 }

--- a/soulcodex/codex30/prompts/narrator.ts
+++ b/soulcodex/codex30/prompts/narrator.ts
@@ -6,7 +6,6 @@ function sanitize(text: string | undefined): string {
     .replace(/\|/g, "")
     .replace(/unknown/gi, "")
     .replace(/chaos/gi, "")
-    .replace(/fix/gi, "")
     .trim();
 }
 
@@ -19,76 +18,71 @@ export function narratorPrompt(payload: {
   triggers: string[];
   prescriptions: string[];
   anchors: string[];
-  /** Optional: contradiction hint from the anti-generic engine */
   contradictionHint?: string;
-  /** Optional: behavioral specific statements to weave in */
   behavioralStatements?: string[];
-  /** Optional: life outcome consequence for memory layer */
   lifeConsequence?: string;
-  /** Optional: observation of where the pattern breaks */
   patternInterruption?: string;
-  /** Optional: compressed behavioral summary */
   loopSentence?: string;
 }): string {
   const codename = sanitize(payload.codename);
   const contradictionBlock = payload.contradictionHint
-    ? `\nIDENTITY FRICTION (weave this tension into the narrative):\n${sanitize(payload.contradictionHint)}\n`
+    ? `\nIDENTITY FRICTION TO EXPLAIN:\n${sanitize(payload.contradictionHint)}\n`
     : "";
 
   const behaviorBlock = payload.behavioralStatements?.length
-    ? `\nBEHAVIORAL SPECIFICS TO WEAVE IN (use the exact pattern, rephrase if needed):\n${payload.behavioralStatements.map(s => `- ${sanitize(s)}`).join("\n")}\n`
+    ? `\nOBSERVABLE BEHAVIOR TO USE AS EVIDENCE:\n${payload.behavioralStatements.map(s => `- ${sanitize(s)}`).join("\n")}\n`
     : "";
 
   return `
 You are the final synthesis layer of Soul Codex.
-Your job is to expose a user's behavioral pattern with surgical accuracy, grounded realism, and zero system leakage.
+Your job is to explain a recurring pattern with grounded specificity, useful context, and honest limits.
 
 ${VOICE_LAWS}
 
 ---
-## 🧬 IDENTITY RULES
-Identity must be:
-- Behavioral (what I DO)
-- Observable (what others could notice)
-- Pattern-based (repeated loop)
+## IDENTITY RULES
+Every explanation must show:
+- what the person may do
+- where it may appear in real life
+- what the behavior protects or accomplishes
+- what it gives them when healthy
+- what it costs when overused
+- how other people may misunderstand it
+- one practical way to test or work with the insight
 
-NOT:
-- preferences ("I like", "I value")
-- vague traits ("I am thoughtful")
-- poetic filler
-- metaphors or spiritual jargon
+Do not diagnose. Do not invent childhood causes, relationships, jobs, trauma, or life events.
+Do not claim symbolic material proves personality. Treat the output as a grounded interpretation the user can confirm, refine, or reject.
 
 ---
-## structure (Return ONLY valid JSON)
+## STRUCTURE (Return ONLY valid JSON)
 {
-  "loop_sentence": "[behavioral pattern -> consequence -> interruption]",
-  "my_pattern": "I [specific behavior], then [observable reaction], and only stabilize when [pattern break].",
-  "how_i_move": "[3-5 sentences about specific pressure behaviors and their costs]",
-  "life_consequence": "[1 blunt sentence about the repeated outcome of this loop]",
-  "pattern_interruption": "[1 sharp sentence about how the pattern breaks messily]",
-  "motto": "[one sharp behavioral declaration with internal friction]",
+  "loop_sentence": "[2-3 sentences: pattern, likely consequence, and the condition that interrupts it]",
+  "my_pattern": "[3-5 sentences in plain language. Include one everyday example and explain what the pattern may be trying to accomplish.]",
+  "how_i_move": "[6-10 sentences covering decisions, work or creativity, conflict, relationships, stress, benefit, tradeoff, and common misunderstanding.]",
+  "life_consequence": "[2-4 sentences explaining the repeated practical outcome without claiming destiny.]",
+  "pattern_interruption": "[2-4 sentences with one concrete experiment, boundary, question, or action the user can try.]",
+  "motto": "[one clear sentence that captures both the strength and tension]",
   "codename": "${codename}",
-  "what_i_wont_tolerate": "[2 sentences about behavioral dealbreakers]",
-  "what_im_building": "[2 sentences about long-game behavioral architecture]"
+  "what_i_wont_tolerate": "[3-5 sentences explaining likely dealbreakers, the need beneath them, and how this may be misread.]",
+  "what_im_building": "[3-5 sentences explaining the long-term aim, healthy expression, and one risk to watch.]"
 }
 
 ---
-## 🧪 SANITIZATION & COMPLETENESS
-- No placeholders ("unknown", "N/A", "not available").
-- If data for a section is missing → DO NOT generate fake insight.
-- NO system artifacts, raw variables, or symbols like "|".
-- NO duplicated sentences.
-- NO advice or "growth mindset" language.
-- NO interpretive narrators ("I think," "I feel," "I try").
-- NO "assistant" helpfulness. Be a mirror, not a guide.
-- NO SINGLE-LETTER PREFIXES (e.g. 'D.', 'C.', 'P.').
-- NO CATEGORY LABELS OR NUMBERING.
-- PRIORITY: ABSOLUTE SURGICAL TRUTH. EXPOSE THE PATTERN.
+## COMPLETENESS AND TRUST
+- No placeholders, raw variables, category prefixes, or duplicated sentences.
+- If evidence is missing, narrow the claim instead of filling the gap with fiction.
+- Avoid absolute words such as always, never, destined, proven, or guaranteed unless directly quoting supplied data.
+- Do not stop at a label or single sentence.
+- Advice must be concrete, proportionate, and framed as an experiment rather than an order.
+- Preserve contradictions instead of flattening the person into one trait.
 
 DATA for ${codename}:
-${contradictionBlock}${behaviorBlock}${payload.lifeConsequence ? `\nLIFE CONSEQUENCE: ${sanitize(payload.lifeConsequence)}` : ""}${payload.patternInterruption ? `\nPATTERN INTERRUPTION: ${sanitize(payload.patternInterruption)}` : ""}${payload.loopSentence ? `\nLOOP SENTENCE: ${sanitize(payload.loopSentence)}` : ""}
+${contradictionBlock}${behaviorBlock}${payload.lifeConsequence ? `\nKNOWN REPEATED OUTCOME: ${sanitize(payload.lifeConsequence)}` : ""}${payload.patternInterruption ? `\nKNOWN INTERRUPTION: ${sanitize(payload.patternInterruption)}` : ""}${payload.loopSentence ? `\nKNOWN LOOP: ${sanitize(payload.loopSentence)}` : ""}
 Themes: ${payload.themes.map(t => `${sanitize(t.tag)}(${t.score})`).join(", ")}
-Strengths: ${payload.strengths.slice(0, 3).map(s => sanitize(s)).join(" · ")}
-Shadows: ${payload.shadows.slice(0, 3).map(s => sanitize(s)).join(" · ")}
+Strengths: ${payload.strengths.slice(0, 4).map(s => sanitize(s)).join(" · ")}
+Shadows: ${payload.shadows.slice(0, 4).map(s => sanitize(s)).join(" · ")}
+Triggers: ${payload.triggers.slice(0, 4).map(s => sanitize(s)).join(" · ")}
+Available grounded actions: ${payload.prescriptions.slice(0, 4).map(s => sanitize(s)).join(" · ")}
+Anchors: ${payload.anchors.slice(0, 4).map(s => sanitize(s)).join(" · ")}
 `.trim();
 }

--- a/soulcodex/codex30/prompts/voice_laws.ts
+++ b/soulcodex/codex30/prompts/voice_laws.ts
@@ -1,28 +1,31 @@
 /**
  * SOUL CODEX SIGNATURE VOICE LAWS
- * 
- * These laws are absolute. They define the "Narrator" that the user trusts.
- * Every AI response must pass these constraints before being displayed.
+ *
+ * These laws define a reading voice that explains patterns instead of merely
+ * naming them. Accuracy still matters, but clarity requires context, examples,
+ * tradeoffs, and room for the user's lived experience to disagree.
  */
 
 export const VOICE_LAWS = `
-## 🧊 THE SIGNATURE VOICE LAWS
+## THE SIGNATURE VOICE LAWS
 
-1. **EMOTIONAL NEUTRALITY**: You are a mirror, not a mentor. Do not be "inspiring," "supportive," or "warm." Be annoyingly accurate and slightly invasive.
-2. **NO SOFT PHRASING**: Eliminate all softeners ("I tend to," "I feel like," "perhaps," "maybe"). Use direct behavioral declarations.
-3. **NO INTERPRETIVE LANGUAGE**: Kill the narrator. Remove "I think," "I feel," "I try to," "I aim to." Replace with hard behavioral verbs: "I delay," "I avoid," "I push," "I stall."
-4. **THE 12-WORD CONSTRAINT**: No sentence may exceed 12 words. If it does, break it. No commas stacking multiple ideas.
-5. **STRUCTURE VARIATION**: Avoid rhythmic repetition. Alternate between short declarations and slightly longer behavioral chains. 
-6. **BLUNT BEHAVIORAL SPECIFICITY**: Describe observable actions and their immediate costs. No vague traits. No poetic metaphors.
-7. **ZERO SYSTEM LEAKAGE**: Do not reference "astrology," "numerology," "Human Design," or "the system." Speak about reality, not the tools used to find it.
-8. **BANNED TONES**: No "divine timing," "cosmic journeys," "healing patterns," or "measurable goals."
-9. **ABSOLUTE TRUTH**: Your readings must be surgical. Use the provided data to expose the truest, most hidden aspects of the user's nature. Do not guess. Do not be generic.
-10. **ZERO LEGACY ARTIFACTS**: Never include single-letter prefixes (e.g. 'D.', 'C.', 'P.'), category labels, or numbering in your response. Start directly with the text.
+1. **EXPLAIN, DO NOT LABEL**: A trait word is never a finished insight. Translate every claim into observable behavior and real-life context.
+2. **LIVED EXAMPLES**: Show how the pattern may appear in decisions, work, conflict, relationships, stress, or self-talk.
+3. **BENEFIT AND TRADEOFF**: Explain what the pattern gives the person and what it may cost when overused.
+4. **COMMON MISREADING**: Name at least one reasonable way other people may misunderstand the behavior.
+5. **PRACTICAL USE**: End major insights with one grounded action, boundary, experiment, or reflection question.
+6. **HONEST CERTAINTY**: Never present symbolic interpretation as verified psychological fact. Use direct language for behavior while preserving uncertainty about cause.
+7. **USER AUTHORITY**: The user's lived experience outranks the interpretation. Make claims testable rather than absolute.
+8. **VARIABLE RHYTHM**: Use clear paragraphs with varied sentence length. Do not force clipped sentences or artificial punchiness.
+9. **NO SYSTEM LEAKAGE**: Keep raw variables and implementation artifacts out of narrative text. Evidence may be named only in a clearly separated evidence field.
+10. **NO GENERIC MYSTICISM**: Avoid decorative cosmic language, destiny claims, guaranteed outcomes, diagnosis, and invented biography.
+11. **NO PLACEHOLDERS**: Never emit unknown, N/A, null, raw delimiters, single-letter prefixes, or unfinished template text.
+12. **DEPTH GATE**: A primary explanation must include observation, example, benefit, tradeoff, misunderstanding, and practical next step before it is complete.
 `.trim();
 
 export const SCORE_CRITERIA = {
-  SPECIFICITY: "Does it describe a concrete behavior others would notice? (0-10)",
-  SHARPNESS: "Is the phrasing blunt and devoid of filler/softeners/interpretive narrators? (0-10)",
-  TRUTH: "Does it feel like a surgical exposure of a hidden pattern? (0-10)",
-  CLEANLINESS: "Is it free of all artifacts, prefixes, and system leakage? (0-10)",
+  SPECIFICITY: "Does it describe behavior a person could recognize in real life? (0-10)",
+  DEPTH: "Does it explain examples, benefit, tradeoff, misunderstanding, and practical use? (0-10)",
+  HONESTY: "Does it separate interpretation from certainty and avoid invented facts? (0-10)",
+  CLEANLINESS: "Is it free of placeholders, system artifacts, repetition, and vague mystical filler? (0-10)",
 };

--- a/soulcodex/codex30/systems/humanDesign.ts
+++ b/soulcodex/codex30/systems/humanDesign.ts
@@ -1,26 +1,36 @@
 import type { Signal } from "../types";
 
 const TYPE_TAGS: Record<string, string[]> = {
-  reflector:  ["social_sensitivity", "intuition", "privacy"],
-  projector:  ["leadership", "precision", "boundaries"],
-  generator:  ["craft", "discipline", "service"],
+  reflector: ["social_sensitivity", "intuition", "privacy"],
+  projector: ["leadership", "precision", "boundaries"],
+  generator: ["craft", "discipline", "service"],
   manifesting_generator: ["craft", "courage", "innovation"],
-  manifestor: ["leadership", "freedom", "intensity"]
+  manifestor: ["leadership", "freedom", "intensity"],
+};
+
+const TYPE_EXPLANATIONS: Record<string, string> = {
+  reflector: "A Reflector reading is best treated as a hypothesis about environmental sensitivity, not a fixed identity. In daily life, this may look like feeling clearer in some rooms and depleted in others, needing more time before major decisions, and noticing group tension before anyone names it. The benefit is strong situational awareness. The tradeoff is mistaking the atmosphere around you for a permanent truth about yourself. Other people may read your changing response as inconsistency when you may actually be registering changing conditions. A grounded experiment is to compare how the same decision feels across several days and environments before treating one moment as final.",
+  projector: "A Projector reading points toward selective attention and guidance rather than endless output. In daily life, this may look like spotting inefficiency quickly, seeing what another person could improve, and becoming exhausted when you try to prove your value through constant labor. The benefit is precision and perspective. The tradeoff is offering insight before it is welcome or measuring worth by recognition. Other people may read your need for pacing as low commitment when the deeper issue may be energy allocation. A grounded experiment is to choose one place where your insight is clearly requested and notice whether the same effort lands differently.",
+  generator: "A Generator reading emphasizes sustained engagement with work that feels responsive rather than forced. In daily life, this may look like building momentum once something genuinely interests you, becoming dependable through repetition, and feeling stuck when obligation replaces meaningful response. The benefit is durable energy and craft. The tradeoff is staying too long because you can keep going. Other people may mistake endurance for consent. A grounded experiment is to separate what you can continue from what you still want to continue.",
+  manifesting_generator: "A Manifesting Generator reading emphasizes fast experimentation, multiple interests, and nonlinear progress. In daily life, this may look like skipping ahead, learning through motion, changing methods quickly, and returning later to repair steps that were rushed. The benefit is speed and inventive problem-solving. The tradeoff is frustration, unfinished foundations, or confusing other people with abrupt pivots. Other people may read your changes as unreliability when you may be testing for fit. A grounded experiment is to announce the pivot and complete one stabilizing step before starting the next branch.",
+  manifestor: "A Manifestor reading emphasizes initiation and the need to move without excessive control from others. In daily life, this may look like acting before consensus forms, resisting micromanagement, and withdrawing when every move requires permission. The benefit is independent momentum. The tradeoff is creating avoidable resistance when people are affected but uninformed. Other people may read privacy as hostility when you may be protecting autonomy. A grounded experiment is to inform the people affected by your decision without turning that information into a request for permission.",
 };
 
 export function humanDesignSignals(hd: any): Signal[] {
   if (!hd?.type) return [];
-  const raw  = String(hd.type).toLowerCase().replace(/\s+/g, "_");
+  const raw = String(hd.type).toLowerCase().replace(/\s+/g, "_");
   const tags = TYPE_TAGS[raw] ?? ["courage", "craft"];
+  const label = TYPE_EXPLANATIONS[raw]
+    ?? `This ${hd.type} interpretation may describe pacing, rest needs, and decision timing, but it should be tested against lived experience. Notice when the pattern helps, what it costs when overused, how other people may misread it, and which practical adjustment creates more clarity.`;
 
   return [{
     id: `hd.type.${raw}`,
     system: "humanDesign",
-    label: `Energy Type: ${hd.type} shapes my pacing, rest needs, and decision timing.`,
-    evidence: [`Human Design: ${hd.type}`],
+    label,
+    evidence: [`Human Design type entered or calculated as ${hd.type}. This is symbolic interpretation, not verified psychology.`],
     intensity: 0.75,
     polarity: "neutral",
     confidence: "low",
-    tags
+    tags,
   }];
 }

--- a/tests/human-depth-specialty-surfaces.test.ts
+++ b/tests/human-depth-specialty-surfaces.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import fs from "node:fs";
+
+const read = (path: string) => fs.readFileSync(path, "utf8");
+
+const voiceLaws = read("soulcodex/codex30/prompts/voice_laws.ts");
+const narrator = read("soulcodex/codex30/prompts/narrator.ts");
+const cleanLine = read("client/src/lib/soul-codex/utils/cleanCodexLine.ts");
+const blueprint = read("client/src/pages/BlueprintPage.tsx");
+const daily = read("client/src/pages/DailyHoroscopePage.tsx");
+const today = read("client/src/pages/TodayPage.tsx");
+const soulGuide = read("client/src/pages/SoulGuidePage.tsx");
+const tracker = read("client/src/pages/TrackerPage.tsx");
+const hdCore = read("packages/core/codex30/systems/humanDesign.ts");
+const hdRuntime = read("soulcodex/codex30/systems/humanDesign.ts");
+
+test("legacy clipped narrator doctrine is removed", () => {
+  assert.doesNotMatch(voiceLaws, /12-WORD CONSTRAINT/i);
+  assert.doesNotMatch(voiceLaws, /ABSOLUTE TRUTH/i);
+  assert.match(voiceLaws, /EXPLAIN, DO NOT LABEL/);
+  assert.match(voiceLaws, /BENEFIT AND TRADEOFF/);
+  assert.match(voiceLaws, /COMMON MISREADING/);
+  assert.match(voiceLaws, /PRACTICAL USE/);
+  assert.match(voiceLaws, /USER AUTHORITY/);
+});
+
+test("narrator requires lived examples and practical interpretation", () => {
+  assert.match(narrator, /decisions, work or creativity, conflict, relationships, stress/i);
+  assert.match(narrator, /benefit, tradeoff, and common misunderstanding/i);
+  assert.match(narrator, /concrete experiment, boundary, question, or action/i);
+  assert.match(narrator, /Do not diagnose/);
+  assert.match(narrator, /confirm, refine, or reject/i);
+});
+
+test("shared text firewall prevents terminal one-line readings", () => {
+  assert.match(cleanLine, /terminalDepthBridge/);
+  assert.match(cleanLine, /starting interpretation rather than a verdict/);
+  assert.match(cleanLine, /what it helps and what it costs/);
+  assert.match(cleanLine, /supports the pattern and another that contradicts it/);
+});
+
+test("specialty pages pass generated interpretation through the shared firewall", () => {
+  for (const source of [blueprint, daily, today, soulGuide, tracker]) {
+    assert.match(source, /cleanCodexLine/);
+  }
+});
+
+test("Human Design output explains lived behavior and its limits", () => {
+  for (const source of [hdCore, hdRuntime]) {
+    assert.match(source, /best treated as a hypothesis/);
+    assert.match(source, /The benefit is/);
+    assert.match(source, /The tradeoff is/);
+    assert.match(source, /Other people may/);
+    assert.match(source, /A grounded experiment is/);
+    assert.match(source, /symbolic interpretation, not verified psychology/);
+  }
+});


### PR DESCRIPTION
## Purpose

Fix the source-level rules that caused specialty pages to return short declarations without enough explanation.

## Root cause

The legacy narrator doctrine forced sentences under twelve words, demanded absolute-sounding conclusions, and explicitly banned useful guidance. That structure directly encouraged the one-line clarity failure found during Bobby's live test.

## Changes

- Replaces the twelve-word narrator constraint with the Human Depth writing contract
- Requires lived examples, benefit, tradeoff, common misunderstanding, practical use, honest certainty, and user authority
- Expands the narrator JSON fields without changing their keys, preserving consumer compatibility
- Adds a shared short-output bridge through `cleanCodexLine`, covering Blueprint, Daily Horoscope, Today, Soul Guide, Tracker, and other existing consumers
- Expands both Human Design signal engines into real-life explanations with limits and grounded experiments
- Adds regression tests that block clipped doctrine, terminal one-line output, absolute certainty, and shallow Human Design labels

## Trust boundaries

- Symbolic interpretations are not presented as verified psychology
- Missing evidence narrows the claim instead of producing invented biography
- The user's lived experience can confirm, refine, or reject an interpretation
- Short legacy strings receive transparent reflection scaffolding rather than fabricated personal detail

## Validation

Run the documented Google Cloud Shell validation sequence before merge while hosted Actions remain billing-blocked.