### PR TITLE
Gate 2: add native Android/iOS smoke validation

### DIFF
--- a/.github/workflows/mobile-native-smoke.yml
+++ b/.github/workflows/mobile-native-smoke.yml
@@ -114,11 +114,11 @@ jobs:
             -derivedDataPath build \
             CODE_SIGNING_ALLOWED=NO \
             build
-          test -d "build/Build/Products/Debug-iphonesimulator/App.app"
+          test -d "build/Build/Products/Debug-iphonesimulator/Ultimate Soul Codex.app"
 
       - name: Upload iOS simulator artifact
         uses: actions/upload-artifact@v4
         with:
           name: gate2-ios-simulator-app
-          path: ios/App/build/Build/Products/Debug-iphonesimulator/App.app
+          path: ios/App/build/Build/Products/Debug-iphonesimulator/Ultimate Soul Codex.app
           retention-days: 7

--- a/.github/workflows/mobile-native-smoke.yml
+++ b/.github/workflows/mobile-native-smoke.yml
@@ -27,11 +27,17 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Setup Node.js
+      # Native Capacitor 8.4.2 requires Node >=22. The legacy server lane remains pinned separately.
+      - name: Setup Node.js for Capacitor 8
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
+
+      - name: Verify native Node toolchain
+        run: |
+          node --version
+          node -e 'const major=Number(process.versions.node.split(".")[0]); if (major < 22) process.exit(1)'
 
       - name: Setup Java
         uses: actions/setup-java@v4
@@ -87,11 +93,17 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Setup Node.js
+      # Native Capacitor 8.4.2 requires Node >=22. The legacy server lane remains pinned separately.
+      - name: Setup Node.js for Capacitor 8
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
+
+      - name: Verify native Node toolchain
+        run: |
+          node --version
+          node -e 'const major=Number(process.versions.node.split(".")[0]); if (major < 22) process.exit(1)'
 
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/mobile-native-smoke.yml
+++ b/.github/workflows/mobile-native-smoke.yml
@@ -1,0 +1,124 @@
+name: Mobile Native Smoke
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mobile-native-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  VITE_API_URL: ${{ vars.VITE_API_URL }}
+
+jobs:
+  android-debug:
+    name: Android debug build
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: gradle
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Build canonical workspaces
+        run: |
+          npm run build -w @soulcodex/db
+          npm run build -w @soulcodex/core
+
+      - name: Validate Android release configuration
+        run: npm run mobile:validate:android
+
+      - name: Build web application
+        run: npm run build
+
+      - name: Sync Capacitor Android project
+        run: npx cap sync android
+
+      - name: Build Android debug APK
+        run: |
+          cd android
+          chmod +x gradlew
+          ./gradlew assembleDebug --stacktrace
+          test -f app/build/outputs/apk/debug/app-debug.apk
+
+      - name: Upload Android smoke artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: gate2-android-debug-apk
+          path: android/app/build/outputs/apk/debug/app-debug.apk
+          retention-days: 7
+
+  ios-simulator:
+    name: iOS Simulator build
+    runs-on: macos-14
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Bootstrap JavaScript and local Swift packages
+        env:
+          CI_PRIMARY_REPOSITORY_PATH: ${{ github.workspace }}
+        run: sh ios/App/ci_scripts/ci_post_clone.sh
+
+      - name: Validate iOS release configuration
+        run: npm run mobile:validate:ios
+
+      - name: Resolve Swift package dependencies
+        run: |
+          cd ios/App
+          xcodebuild -workspace App.xcodeproj/project.xcworkspace \
+            -scheme "Soul Codex" \
+            -resolvePackageDependencies
+
+      - name: Build iOS Simulator application
+        run: |
+          cd ios/App
+          xcodebuild -workspace App.xcodeproj/project.xcworkspace \
+            -scheme "Soul Codex" \
+            -configuration Debug \
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath build \
+            CODE_SIGNING_ALLOWED=NO \
+            build
+          test -d "build/Build/Products/Debug-iphonesimulator/App.app"
+
+      - name: Upload iOS simulator artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: gate2-ios-simulator-app
+          path: ios/App/build/Build/Products/Debug-iphonesimulator/App.app
+          retention-days: 7

--- a/.github/workflows/mobile-native-smoke.yml
+++ b/.github/workflows/mobile-native-smoke.yml
@@ -105,16 +105,28 @@ jobs:
             -resolvePackageDependencies
 
       - name: Build iOS Simulator application
+        shell: bash
         run: |
+          set -o pipefail
           cd ios/App
+          mkdir -p build
           xcodebuild -workspace App.xcodeproj/project.xcworkspace \
             -scheme "Soul Codex" \
             -configuration Debug \
             -destination 'generic/platform=iOS Simulator' \
             -derivedDataPath build \
             CODE_SIGNING_ALLOWED=NO \
-            build
+            build 2>&1 | tee build/xcodebuild.log
           test -d "build/Build/Products/Debug-iphonesimulator/Ultimate Soul Codex.app"
+
+      - name: Upload iOS build diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gate2-ios-xcodebuild-log
+          path: ios/App/build/xcodebuild.log
+          if-no-files-found: warn
+          retention-days: 7
 
       - name: Upload iOS simulator artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/mobile-native-smoke.yml
+++ b/.github/workflows/mobile-native-smoke.yml
@@ -22,13 +22,15 @@ jobs:
     timeout-minutes: 45
 
     steps:
-      - name: Checkout
+      - name: Checkout exact candidate head
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 20
           cache: npm
 
       - name: Setup Java
@@ -40,6 +42,11 @@ jobs:
 
       - name: Install dependencies
         run: npm ci --ignore-scripts
+
+      - name: Record exact candidate SHA
+        run: |
+          echo "candidate_sha=$(git rev-parse HEAD)"
+          test "$(git rev-parse HEAD)" = "${{ github.event.pull_request.head.sha || github.sha }}"
 
       - name: Build canonical workspaces
         run: |
@@ -75,13 +82,15 @@ jobs:
     timeout-minutes: 45
 
     steps:
-      - name: Checkout
+      - name: Checkout exact candidate head
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 20
           cache: npm
 
       - name: Setup Xcode
@@ -94,6 +103,11 @@ jobs:
           xcodebuild -version
           XCODE_MAJOR=$(xcodebuild -version | awk '/Xcode/{split($2,v,"."); print v[1]}')
           test "$XCODE_MAJOR" -ge 26
+
+      - name: Record exact candidate SHA
+        run: |
+          echo "candidate_sha=$(git rev-parse HEAD)"
+          test "$(git rev-parse HEAD)" = "${{ github.event.pull_request.head.sha || github.sha }}"
 
       - name: Bootstrap JavaScript and local Swift packages
         env:

--- a/.github/workflows/mobile-native-smoke.yml
+++ b/.github/workflows/mobile-native-smoke.yml
@@ -71,7 +71,7 @@ jobs:
 
   ios-simulator:
     name: iOS Simulator build
-    runs-on: macos-14
+    runs-on: macos-26
     timeout-minutes: 45
 
     steps:
@@ -88,6 +88,12 @@ jobs:
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
+
+      - name: Verify supported Xcode toolchain
+        run: |
+          xcodebuild -version
+          XCODE_MAJOR=$(xcodebuild -version | awk '/Xcode/{split($2,v,"."); print v[1]}')
+          test "$XCODE_MAJOR" -ge 26
 
       - name: Bootstrap JavaScript and local Swift packages
         env:

--- a/governance/release-audits/GATE-2-NATIVE-MOBILE-VALIDATION.md
+++ b/governance/release-audits/GATE-2-NATIVE-MOBILE-VALIDATION.md
@@ -1,7 +1,8 @@
 # Gate 2 — Native Mobile Platform Validation
 
 **Base:** `main@b5cdcc25665fb1d9c1cc7a087252e69c02b49624`  
-**Status:** **IN PROGRESS**
+**Candidate:** `f97c37ca024009b0c9eb6ece0e7bdf32635f405f`  
+**Status:** **SIMULATOR / EMULATOR VALIDATED — SIGNED, HARDWARE, AND STORE VALIDATION OPEN**
 
 ## Purpose
 
@@ -19,47 +20,84 @@ Gate 2 separates native mobile implementation from actual validation. It proves 
 - Manual iOS workflow supports simulator development build and signed App Store archive/export.
 - Release builds require a public HTTPS `VITE_API_URL` and reject localhost.
 
-## New Gate 2 CI Evidence
+## Exact-Head Native CI Evidence
 
-This branch adds `.github/workflows/mobile-native-smoke.yml` with two PR-triggered jobs:
+Candidate `f97c37ca024009b0c9eb6ece0e7bdf32635f405f` completed Mobile Native Smoke run `31576839055` successfully.
 
-1. **Android debug build**
-   - installs exact npm dependencies;
-   - builds canonical workspaces;
-   - validates Android release configuration;
-   - builds the production web bundle;
-   - syncs Capacitor;
-   - runs Gradle `assembleDebug`;
-   - verifies and uploads the APK.
+### Android debug build — PASS
 
-2. **iOS Simulator build**
-   - bootstraps JavaScript and local Swift packages;
-   - validates iOS release configuration;
-   - resolves Swift packages;
-   - builds the checked-in `Soul Codex` scheme for generic iOS Simulator with signing disabled;
-   - verifies and uploads the `.app` bundle.
+The PR-triggered Android job:
 
-The workflow intentionally uses repository variable `VITE_API_URL` with no hidden localhost/default substitution. Missing production API configuration must fail closed.
+- installed exact npm dependencies;
+- built canonical workspaces;
+- passed Android release configuration validation;
+- built the production web bundle;
+- synced Capacitor Android;
+- completed Gradle `assembleDebug`;
+- verified and uploaded the debug APK.
+
+Artifact:
+
+- name: `gate2-android-debug-apk`
+- artifact id: `9133532842`
+- digest: `sha256:2212df5fea67520233c0ebb1bec9efc4cb86eeca98c2983ea7c16d3138149288`
+
+### iOS Simulator build — PASS
+
+The PR-triggered iOS job:
+
+- runs on GitHub `macos-26`;
+- explicitly verifies Xcode major version 26 or newer because Capacitor 8 requires the Xcode 26 / Swift 6.2 toolchain;
+- bootstraps JavaScript and local Swift packages;
+- passes iOS release configuration validation;
+- resolves Swift package dependencies;
+- builds the checked-in `Soul Codex` scheme for generic iOS Simulator with signing disabled;
+- verifies and uploads `Ultimate Soul Codex.app`;
+- retains the Xcode build log as a diagnostic artifact.
+
+Artifacts:
+
+- app name: `gate2-ios-simulator-app`
+- app artifact id: `9133559275`
+- app digest: `sha256:68afd4aab73e52fdf7f89ccce2e2814964367f734ae329f3f85c242e8dba0a96`
+- diagnostic name: `gate2-ios-xcodebuild-log`
+- diagnostic artifact id: `9133557914`
+- diagnostic digest: `sha256:8d863595261e2ae78bda822ccd3a1197a092b38cfed97b0582601b963348c2aa`
+
+## Toolchain Failure Resolved During Gate 2
+
+Earlier Gate 2 runs used `macos-14`, which selected Xcode 16.2. The build reached Swift compilation but failed in Capacitor 8 plugin source with missing `PluginConfig.getString` and incompatible color API signatures. This was not treated as an application-source defect. The workflow was moved to the supported Xcode 26 toolchain and an explicit toolchain guard was added so future runner-image drift fails clearly. The next exact-head native run passed Android and iOS.
+
+## Companion Exact-Head Checks
+
+On candidate `f97c37ca024009b0c9eb6ece0e7bdf32635f405f`:
+
+- `Ultimate SoulCodex CI` — **PASS** (`31576839098`)
+- `CI Tests` — **PASS** (`31576839121`)
+- `Mobile Native Smoke` — **PASS** (`31576839055`)
+- `Live Ephemeris Evidence` — **FAIL** (`31576839086`) because the external NASA/JPL Horizons service remains unavailable to the live evidence job. This failure is not reclassified or waived here.
+
+The JPL condition prevents claiming an all-green repository release candidate, but it does not erase the native build evidence recorded above.
 
 ## Validation Ladder
 
-Gate 2 evidence must be classified explicitly:
+Gate 2 evidence is classified explicitly:
 
-- **Implemented:** native projects/workflows/configuration exist.
-- **Integrated:** Capacitor sync and native dependency paths connect to the production web build.
-- **Simulator/emulator validated:** Android debug APK and iOS Simulator app build successfully in CI.
-- **Signed-artifact validated:** release AAB and App Store IPA are produced with the configured signing identities.
-- **Hardware validated:** signed candidate is exercised on identified physical Android/iPhone/iPad hardware.
-- **Store validation:** App Store/Play pre-submission validation accepts the candidate artifact.
+- **Implemented:** PASS — native projects, workflows, and configuration exist.
+- **Integrated:** PASS — Capacitor sync and native dependency paths connect to the production web build.
+- **Simulator/emulator validated:** PASS — Android debug APK and iOS Simulator app build successfully in exact-head CI.
+- **Signed-artifact validated:** OPEN — release AAB and App Store IPA still require configured signing identities/secrets.
+- **Hardware validated:** OPEN — signed candidate has not yet been recorded as exercised on identified physical Android/iPhone/iPad hardware.
+- **Store validation:** OPEN — App Store/Play pre-submission validation has not yet been recorded for this candidate.
 
 No lower class is promoted into a higher class.
 
 ## Gate 2 Pass Criteria
 
-- [ ] PR-triggered Android debug build passes on the exact candidate head.
-- [ ] PR-triggered iOS Simulator build passes on the exact candidate head.
-- [ ] Production `VITE_API_URL` is configured and passes both mobile validators.
-- [ ] Android release keystore/secrets are configured.
+- [x] PR-triggered Android debug build passes on the exact candidate head.
+- [x] PR-triggered iOS Simulator build passes on the exact candidate head.
+- [x] Production `VITE_API_URL` passes both mobile validators in exact-head CI.
+- [ ] Android release keystore/secrets are configured for this release lane.
 - [ ] Signed Android AAB is produced and artifact identity recorded.
 - [ ] Apple distribution certificate/provisioning profile match Team ID and bundle ID.
 - [ ] Signed iOS archive exports a valid IPA and artifact identity is recorded.
@@ -68,14 +106,14 @@ No lower class is promoted into a higher class.
 
 ## Account-Bound Actions
 
-The following cannot be fabricated by repository automation and require the owner account:
+The following cannot be fabricated by repository automation and require release-account material or owner-console access:
 
-- GitHub Actions repository variable `VITE_API_URL` if not already configured;
 - Android keystore and signing secrets;
 - Apple distribution certificate `.p12` and password;
 - Apple App Store provisioning profile;
-- App Store Connect/TestFlight and Google Play Console upload/testing actions.
+- App Store Connect/TestFlight upload/testing;
+- Google Play Console upload/testing.
 
-## Current External Signal
+## Current Classification
 
-GitHub currently reports an external Apple/Xcode status failure on `main@b5cdcc...`. The target points to App Store Connect/Xcode Cloud, whose private job details are not available through the repository connector. Gate 2 remains open until native CI and signed-artifact evidence establish the current failure's relevance or supersede it with a successful exact-candidate build.
+Gate 2 is **simulator/emulator validated**. Code-side native reproducibility has been demonstrated on the exact candidate head for both platforms. Full Gate 2 PASS remains intentionally open until signed-artifact and hardware/store evidence is recorded.

--- a/governance/release-audits/GATE-2-NATIVE-MOBILE-VALIDATION.md
+++ b/governance/release-audits/GATE-2-NATIVE-MOBILE-VALIDATION.md
@@ -1,7 +1,7 @@
 # Gate 2 — Native Mobile Platform Validation
 
 **Base:** `main@b5cdcc25665fb1d9c1cc7a087252e69c02b49624`  
-**Candidate:** `f97c37ca024009b0c9eb6ece0e7bdf32635f405f`  
+**Candidate:** `443c23cfb5fcb19771589721d75132224ab3c65e`  
 **Status:** **SIMULATOR / EMULATOR VALIDATED — SIGNED, HARDWARE, AND STORE VALIDATION OPEN**
 
 ## Purpose
@@ -22,12 +22,16 @@ Gate 2 separates native mobile implementation from actual validation. It proves 
 
 ## Exact-Head Native CI Evidence
 
-Candidate `f97c37ca024009b0c9eb6ece0e7bdf32635f405f` completed Mobile Native Smoke run `31576839055` successfully.
+Candidate `443c23cfb5fcb19771589721d75132224ab3c65e` completed Mobile Native Smoke run `31579821940` successfully.
+
+The workflow explicitly checks out `github.event.pull_request.head.sha` for PR runs and verifies `git rev-parse HEAD` equals the candidate SHA before native build work begins. This prevents GitHub's synthetic PR merge commit from being misreported as exact-head evidence.
 
 ### Android debug build — PASS
 
 The PR-triggered Android job:
 
+- checked out the exact PR head;
+- used Node 22, the minimum generation supported by Capacitor 8.4.2;
 - installed exact npm dependencies;
 - built canonical workspaces;
 - passed Android release configuration validation;
@@ -39,45 +43,52 @@ The PR-triggered Android job:
 Artifact:
 
 - name: `gate2-android-debug-apk`
-- artifact id: `9133532842`
-- digest: `sha256:2212df5fea67520233c0ebb1bec9efc4cb86eeca98c2983ea7c16d3138149288`
+- artifact id: `9134704520`
+- digest: `sha256:f7c3c60385a5dc8b899a3cf87d018e839e2f23fd65e420c4618e269c9a0b84c9`
 
 ### iOS Simulator build — PASS
 
 The PR-triggered iOS job:
 
-- runs on GitHub `macos-26`;
-- explicitly verifies Xcode major version 26 or newer because Capacitor 8 requires the Xcode 26 / Swift 6.2 toolchain;
-- bootstraps JavaScript and local Swift packages;
-- passes iOS release configuration validation;
-- resolves Swift package dependencies;
-- builds the checked-in `Soul Codex` scheme for generic iOS Simulator with signing disabled;
-- verifies and uploads `Ultimate Soul Codex.app`;
-- retains the Xcode build log as a diagnostic artifact.
+- checked out the exact PR head;
+- used Node 22 because Capacitor 8.4.2 declares `node >=22.0.0`;
+- ran on GitHub `macos-26`;
+- explicitly verified Xcode major version 26 or newer;
+- bootstrapped JavaScript and local Swift packages;
+- passed iOS release configuration validation;
+- resolved Swift package dependencies;
+- built the checked-in `Soul Codex` scheme for generic iOS Simulator with signing disabled;
+- verified and uploaded `Ultimate Soul Codex.app`;
+- retained the Xcode build log as a diagnostic artifact.
 
 Artifacts:
 
 - app name: `gate2-ios-simulator-app`
-- app artifact id: `9133559275`
-- app digest: `sha256:68afd4aab73e52fdf7f89ccce2e2814964367f734ae329f3f85c242e8dba0a96`
+- app artifact id: `9134755003`
+- app digest: `sha256:6f9846f91267e2dd15500885ccb47c8bcdb6cd230692645dc39312aca8e45892`
 - diagnostic name: `gate2-ios-xcodebuild-log`
-- diagnostic artifact id: `9133557914`
-- diagnostic digest: `sha256:8d863595261e2ae78bda822ccd3a1197a092b38cfed97b0582601b963348c2aa`
+- diagnostic artifact id: `9134753289`
+- diagnostic digest: `sha256:ba22673c54ddf304c05a292366403dd51011442989d2395b5c392fbd67b4a6d2`
 
-## Toolchain Failure Resolved During Gate 2
+## Toolchain Reconciliation
 
-Earlier Gate 2 runs used `macos-14`, which selected Xcode 16.2. The build reached Swift compilation but failed in Capacitor 8 plugin source with missing `PluginConfig.getString` and incompatible color API signatures. This was not treated as an application-source defect. The workflow was moved to the supported Xcode 26 toolchain and an explicit toolchain guard was added so future runner-image drift fails clearly. The next exact-head native run passed Android and iOS.
+Two stale assumptions were exposed during this gate.
+
+1. `macos-14` selected Xcode 16.2, which is unsupported by Capacitor 8's current iOS toolchain. The native iOS lane was moved to `macos-26` with an explicit Xcode-major guard.
+2. Repository legacy-development instructions still describe Node 20 for the root server lane, but the installed `@capacitor/cli@8.4.2` package declares `node >=22.0.0`. Native mobile workflows therefore use Node 22 while legacy server instructions remain independently scoped.
+
+The release gate follows the actual dependency contract rather than forcing an unsupported Node/Xcode combination merely to satisfy stale documentation.
 
 ## Companion Exact-Head Checks
 
-On candidate `f97c37ca024009b0c9eb6ece0e7bdf32635f405f`:
+On candidate `443c23cfb5fcb19771589721d75132224ab3c65e`:
 
-- `Ultimate SoulCodex CI` — **PASS** (`31576839098`)
-- `CI Tests` — **PASS** (`31576839121`)
-- `Mobile Native Smoke` — **PASS** (`31576839055`)
-- `Live Ephemeris Evidence` — **FAIL** (`31576839086`) because the external NASA/JPL Horizons service remains unavailable to the live evidence job. This failure is not reclassified or waived here.
+- `Ultimate SoulCodex CI` — **PASS** (`31579821995`)
+- `CI Tests` — **PASS** (`31579821945`)
+- `Mobile Native Smoke` — **PASS** (`31579821940`)
+- `Live Ephemeris Evidence` — **FAIL** (`31579822012`) because the external NASA/JPL Horizons service remains unavailable to the live evidence job. This failure is not reclassified or silently waived by Gate 2.
 
-The JPL condition prevents claiming an all-green repository release candidate, but it does not erase the native build evidence recorded above.
+The JPL condition prevents claiming an all-green repository release candidate, but it does not invalidate the native build evidence recorded above because the failing job exercises an independent external astronomy-verification dependency rather than the native packaging path.
 
 ## Validation Ladder
 

--- a/governance/release-audits/GATE-2-NATIVE-MOBILE-VALIDATION.md
+++ b/governance/release-audits/GATE-2-NATIVE-MOBILE-VALIDATION.md
@@ -1,0 +1,81 @@
+# Gate 2 — Native Mobile Platform Validation
+
+**Base:** `main@b5cdcc25665fb1d9c1cc7a087252e69c02b49624`  
+**Status:** **IN PROGRESS**
+
+## Purpose
+
+Gate 2 separates native mobile implementation from actual validation. It proves that the checked-in Capacitor projects can build reproducibly for Android and iOS, then advances through signing and physical-device evidence without promoting one validation class into another.
+
+## Current Implemented State
+
+- Capacitor app ID: `app.soulcodex.main`.
+- Android application ID: `app.soulcodex.main`.
+- Android compile/target SDK: 36.
+- iOS release bundle ID validated by `scripts/validate-mobile-release.mjs` as `app.soulcodex.ios`.
+- iOS privacy manifest exists and is required by the mobile validator.
+- Public support and account-deletion pages exist and are required by the mobile validator.
+- Manual Android release workflow supports debug APK, release APK, and signed release AAB.
+- Manual iOS workflow supports simulator development build and signed App Store archive/export.
+- Release builds require a public HTTPS `VITE_API_URL` and reject localhost.
+
+## New Gate 2 CI Evidence
+
+This branch adds `.github/workflows/mobile-native-smoke.yml` with two PR-triggered jobs:
+
+1. **Android debug build**
+   - installs exact npm dependencies;
+   - builds canonical workspaces;
+   - validates Android release configuration;
+   - builds the production web bundle;
+   - syncs Capacitor;
+   - runs Gradle `assembleDebug`;
+   - verifies and uploads the APK.
+
+2. **iOS Simulator build**
+   - bootstraps JavaScript and local Swift packages;
+   - validates iOS release configuration;
+   - resolves Swift packages;
+   - builds the checked-in `Soul Codex` scheme for generic iOS Simulator with signing disabled;
+   - verifies and uploads the `.app` bundle.
+
+The workflow intentionally uses repository variable `VITE_API_URL` with no hidden localhost/default substitution. Missing production API configuration must fail closed.
+
+## Validation Ladder
+
+Gate 2 evidence must be classified explicitly:
+
+- **Implemented:** native projects/workflows/configuration exist.
+- **Integrated:** Capacitor sync and native dependency paths connect to the production web build.
+- **Simulator/emulator validated:** Android debug APK and iOS Simulator app build successfully in CI.
+- **Signed-artifact validated:** release AAB and App Store IPA are produced with the configured signing identities.
+- **Hardware validated:** signed candidate is exercised on identified physical Android/iPhone/iPad hardware.
+- **Store validation:** App Store/Play pre-submission validation accepts the candidate artifact.
+
+No lower class is promoted into a higher class.
+
+## Gate 2 Pass Criteria
+
+- [ ] PR-triggered Android debug build passes on the exact candidate head.
+- [ ] PR-triggered iOS Simulator build passes on the exact candidate head.
+- [ ] Production `VITE_API_URL` is configured and passes both mobile validators.
+- [ ] Android release keystore/secrets are configured.
+- [ ] Signed Android AAB is produced and artifact identity recorded.
+- [ ] Apple distribution certificate/provisioning profile match Team ID and bundle ID.
+- [ ] Signed iOS archive exports a valid IPA and artifact identity is recorded.
+- [ ] Release candidate is installed/tested on identified physical devices.
+- [ ] Any Xcode Cloud/App Store Connect build failure on the release candidate is resolved or explicitly superseded by a successful signed archive from the same candidate.
+
+## Account-Bound Actions
+
+The following cannot be fabricated by repository automation and require the owner account:
+
+- GitHub Actions repository variable `VITE_API_URL` if not already configured;
+- Android keystore and signing secrets;
+- Apple distribution certificate `.p12` and password;
+- Apple App Store provisioning profile;
+- App Store Connect/TestFlight and Google Play Console upload/testing actions.
+
+## Current External Signal
+
+GitHub currently reports an external Apple/Xcode status failure on `main@b5cdcc...`. The target points to App Store Connect/Xcode Cloud, whose private job details are not available through the repository connector. Gate 2 remains open until native CI and signed-artifact evidence establish the current failure's relevance or supersede it with a successful exact-candidate build.


### PR DESCRIPTION
## Summary
Add a PR-triggered native mobile smoke gate for Android and iOS, and record the Gate 2 evidence ladder without overstating simulator evidence as signed/hardware/store validation.

## Validation
Candidate lineage is validated by exact PR-head checkout plus `git rev-parse HEAD` equality checks. Native jobs use the supported Capacitor 8 toolchain: Node 22+ and Xcode 26+ for iOS. Previous exact-head candidate `443c23cf...` passed `Ultimate SoulCodex CI`, `CI Tests`, Android debug APK build, and iOS Simulator app build. The final documentation-only head is being revalidated before merge.

`Live Ephemeris Evidence` remains red because the external NASA/JPL Horizons dependency is unavailable; Gate 2 does not reclassify or hide that independent failure.

## Risk Assessment
Low-to-moderate CI/release risk. This PR changes workflow behavior and governance documentation, not application calculation logic. Primary risks are runner/toolchain drift and false evidence classification; explicit Node/Xcode guards, exact-head checkout, artifact assertions, and retained diagnostics mitigate them.

## Rollback Plan
Revert this PR. That removes `.github/workflows/mobile-native-smoke.yml` and the Gate 2 receipt without changing runtime application code or stored user data.

## Current Classification
**Simulator/emulator validated.** Signed AAB/IPA, physical-device validation, and App Store/Play validation remain open and require release-account material.