### PR TITLE
Gate 5: harden signed release toolchain

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -17,25 +17,42 @@ permissions:
 
 jobs:
   build-ios:
-    runs-on: macos-14
-    timeout-minutes: 40
+    # Capacitor 8 requires the Xcode 26 / Swift 6.2 generation.
+    runs-on: macos-26
+    timeout-minutes: 45
     env:
       VITE_API_URL: ${{ vars.VITE_API_URL || 'https://soulcodex.up.railway.app' }}
 
     steps:
-      - name: Checkout
+      - name: Checkout requested release candidate
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
+      - name: Record candidate identity
+        run: |
+          echo "candidate_sha=$(git rev-parse HEAD)"
+          git rev-parse HEAD > release-candidate-sha.txt
+
+      - name: Setup Node.js for Capacitor 8
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm
 
+      - name: Verify native Node toolchain
+        run: |
+          node --version
+          node -e 'const major=Number(process.versions.node.split(".")[0]); if (major < 22) process.exit(1)'
+
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
+
+      - name: Verify supported Xcode toolchain
+        run: |
+          xcodebuild -version
+          XCODE_MAJOR=$(xcodebuild -version | awk '/Xcode/{split($2,v,"."); print v[1]}')
+          test "$XCODE_MAJOR" -ge 26
 
       - name: Bootstrap JavaScript and local Swift packages
         env:
@@ -43,8 +60,6 @@ jobs:
         run: sh ios/App/ci_scripts/ci_post_clone.sh
 
       - name: Validate mobile release configuration
-        env:
-          VITE_API_URL: ${{ vars.VITE_API_URL || 'https://soulcodex.up.railway.app' }}
         run: npm run mobile:validate:ios
 
       - name: Resolve Xcode package dependencies
@@ -57,7 +72,9 @@ jobs:
 
       - name: Build iOS (Development)
         if: inputs.build_type == 'development'
+        shell: bash
         run: |
+          set -euo pipefail
           cd ios/App
           echo "Building for iOS Simulator..."
           xcodebuild -workspace App.xcodeproj/project.xcworkspace \
@@ -66,7 +83,8 @@ jobs:
             -destination 'generic/platform=iOS Simulator' \
             -derivedDataPath build \
             CODE_SIGNING_ALLOWED=NO \
-            build
+            build 2>&1 | tee build-development.log
+          test -d "build/Build/Products/Debug-iphonesimulator/Ultimate Soul Codex.app"
 
       - name: Verify signing secrets
         if: inputs.build_type == 'app-store'
@@ -75,21 +93,12 @@ jobs:
           IOS_CERTIFICATE_PASSWORD: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
           IOS_PROVISIONING_PROFILE: ${{ secrets.IOS_PROVISIONING_PROFILE }}
         run: |
-          echo "Checking for required secrets..."
-          if [ -z "$IOS_CERTIFICATE_P12" ]; then
-            echo "❌ Error: IOS_CERTIFICATE_P12 secret is not set"
-            echo "Please configure GitHub Secrets: https://github.com/Bboy9090/Ultimate-SoulCodex/settings/secrets/actions"
-            exit 1
-          fi
-          if [ -z "$IOS_CERTIFICATE_PASSWORD" ]; then
-            echo "❌ Error: IOS_CERTIFICATE_PASSWORD secret is not set"
-            exit 1
-          fi
-          if [ -z "$IOS_PROVISIONING_PROFILE" ]; then
-            echo "❌ Error: IOS_PROVISIONING_PROFILE secret is not set"
-            exit 1
-          fi
-          echo "✅ All signing secrets are configured"
+          set -euo pipefail
+          echo "Checking for required signing material..."
+          test -n "$IOS_CERTIFICATE_P12" || { echo "IOS_CERTIFICATE_P12 is not set"; exit 1; }
+          test -n "$IOS_CERTIFICATE_PASSWORD" || { echo "IOS_CERTIFICATE_PASSWORD is not set"; exit 1; }
+          test -n "$IOS_PROVISIONING_PROFILE" || { echo "IOS_PROVISIONING_PROFILE is not set"; exit 1; }
+          echo "Signing material is configured"
 
       - name: Import signing certificate
         if: inputs.build_type == 'app-store'
@@ -98,110 +107,81 @@ jobs:
           p12-file-base64: ${{ secrets.IOS_CERTIFICATE_P12 }}
           p12-password: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
 
-      - name: Install provisioning profile
+      - name: Install and inspect provisioning profile
         if: inputs.build_type == 'app-store'
         env:
           IOS_PROVISIONING_PROFILE: ${{ secrets.IOS_PROVISIONING_PROFILE }}
+        shell: bash
         run: |
-          echo "Installing provisioning profile..."
-          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-
-          printf '%s' "$IOS_PROVISIONING_PROFILE" | base64 -D > ~/Library/MobileDevice/Provisioning\ Profiles/profile.mobileprovision
-
-          if [ ! -f ~/Library/MobileDevice/Provisioning\ Profiles/profile.mobileprovision ]; then
-            echo "❌ Failed to install provisioning profile"
-            exit 1
-          fi
-
-          ls -la ~/Library/MobileDevice/Provisioning\ Profiles/
-          echo "✅ Provisioning profile installed"
+          set -euo pipefail
+          PROFILE_PATH="$HOME/Library/MobileDevice/Provisioning Profiles/SoulCodex.mobileprovision"
+          mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
+          printf '%s' "$IOS_PROVISIONING_PROFILE" | base64 -D > "$PROFILE_PATH"
+          test -s "$PROFILE_PATH"
+          security cms -D -i "$PROFILE_PATH" > provisioning-profile.plist
+          /usr/libexec/PlistBuddy -c 'Print :Name' provisioning-profile.plist
+          /usr/libexec/PlistBuddy -c 'Print :TeamIdentifier:0' provisioning-profile.plist
+          /usr/libexec/PlistBuddy -c 'Print :Entitlements:application-identifier' provisioning-profile.plist
+          PROFILE_TEAM=$(/usr/libexec/PlistBuddy -c 'Print :TeamIdentifier:0' provisioning-profile.plist)
+          test "$PROFILE_TEAM" = "86NUJ8M3B8"
+          APP_IDENTIFIER=$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:application-identifier' provisioning-profile.plist)
+          test "$APP_IDENTIFIER" = "86NUJ8M3B8.app.soulcodex.ios"
 
       - name: Build iOS (App Store)
         if: inputs.build_type == 'app-store'
+        shell: bash
         run: |
+          set -euo pipefail
           cd ios/App
-          mkdir -p build
+          mkdir -p build build/export
 
-          echo "Creating archive..."
+          echo "Creating App Store archive..."
           xcodebuild -workspace App.xcodeproj/project.xcworkspace \
             -scheme "Soul Codex" \
             -configuration Release \
             -archivePath build/SoulCodex.xcarchive \
-            -allowProvisioningUpdates \
-            -verbose \
             archive 2>&1 | tee archive.log
 
-          if [ ! -d "build/SoulCodex.xcarchive" ]; then
-            echo "❌ Archive creation failed!"
-            echo ""
-            echo "Last 100 lines of archive log:"
-            tail -100 archive.log
-            exit 1
-          fi
+          test -d "build/SoulCodex.xcarchive"
+          test -f "build/SoulCodex.xcarchive/Info.plist"
 
-          echo "✅ Archive created successfully"
-          ls -lah build/SoulCodex.xcarchive
-
-          echo ""
           echo "Exporting archive..."
-          mkdir -p build/export
           xcodebuild -exportArchive \
             -archivePath build/SoulCodex.xcarchive \
             -exportPath build/export \
             -exportOptionsPlist ExportOptions.plist \
-            -allowProvisioningUpdates \
-            -verbose 2>&1 | tee export.log
+            2>&1 | tee export.log
 
-          echo ""
-          echo "Checking for IPA file..."
-          if find build/export -name "*.ipa" -type f; then
-            echo "✅ IPA export successful"
-            ls -lah build/export/
-          else
-            echo "❌ IPA export failed!"
-            echo "Export directory contents:"
-            ls -la build/export/
-            echo ""
-            echo "Last 50 lines of export log:"
-            tail -50 export.log
-            exit 1
-          fi
+          IPA_PATH=$(find build/export -maxdepth 1 -name "*.ipa" -type f -print -quit)
+          test -n "$IPA_PATH"
+          test -s "$IPA_PATH"
+          echo "ipa_path=$IPA_PATH"
+          shasum -a 256 "$IPA_PATH" | tee build/export/IPA-SHA256.txt
 
-      - name: Show build summary
+      - name: Upload build diagnostics
         if: always()
-        run: |
-          echo "=== Build Summary ==="
-          echo "Build type: ${{ inputs.build_type }}"
-          echo ""
-
-          if [ "${{ inputs.build_type }}" == "development" ]; then
-            echo "=== Development Build Artifacts ==="
-            find ios/App/build -type d -name "*.app" 2>/dev/null && echo "✅ App bundle found" || echo "⚠️ No app bundle found"
-          elif [ "${{ inputs.build_type }}" == "app-store" ]; then
-            echo "=== App Store Build Artifacts ==="
-            if find ios/App/build/export -name "*.ipa" -type f 2>/dev/null; then
-              echo "✅ IPA file(s) found"
-              du -sh ios/App/build/export/*.ipa 2>/dev/null | awk '{print "   " $0}'
-            else
-              echo "⚠️ No IPA files found"
-            fi
-            echo ""
-            echo "Export directory contents:"
-            ls -lah ios/App/build/export/ 2>/dev/null || echo "Export directory not found"
-          fi
-
-          echo ""
-          echo "=== Build Logs Available ==="
-          [ -f ios/App/build.log ] && echo "✅ build.log (development)" || true
-          [ -f ios/App/archive.log ] && echo "✅ archive.log (app-store)" || true
-          [ -f ios/App/export.log ] && echo "✅ export.log (app-store)" || true
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-build-diagnostics-${{ github.run_id }}
+          path: |
+            release-candidate-sha.txt
+            provisioning-profile.plist
+            ios/App/build-development.log
+            ios/App/archive.log
+            ios/App/export.log
+          if-no-files-found: ignore
+          retention-days: 30
 
       - name: Upload artifact (App Store)
         if: inputs.build_type == 'app-store'
         uses: actions/upload-artifact@v4
         with:
           name: ios-app-store-build
-          path: ios/App/build/export/
+          path: |
+            ios/App/build/export/*.ipa
+            ios/App/build/export/IPA-SHA256.txt
+            release-candidate-sha.txt
+          if-no-files-found: error
           retention-days: 30
 
       - name: Upload artifact (Development)
@@ -209,6 +189,8 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ios-development-build
-          path: ios/App/build/Build/Products/Debug-iphonesimulator/
-          if-no-files-found: warn
+          path: |
+            ios/App/build/Build/Products/Debug-iphonesimulator/Ultimate Soul Codex.app
+            release-candidate-sha.txt
+          if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/gate5-release-preflight.yml
+++ b/.github/workflows/gate5-release-preflight.yml
@@ -1,0 +1,69 @@
+name: Gate 5 Release Preflight
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/build-ios.yml"
+      - ".github/workflows/build-android.yml"
+      - ".github/workflows/gate5-release-preflight.yml"
+      - "scripts/validate-mobile-release.mjs"
+      - "ios/**"
+      - "android/**"
+      - "tests/release-toolchain-contract.test.ts"
+      - "package.json"
+      - "package-lock.json"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gate5-release-preflight-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release-contracts:
+    name: Release workflow contracts
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      VITE_API_URL: ${{ vars.VITE_API_URL || 'https://soulcodex.up.railway.app' }}
+
+    steps:
+      - name: Checkout exact candidate head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Record exact candidate SHA
+        run: |
+          echo "candidate_sha=$(git rev-parse HEAD)"
+          test "$(git rev-parse HEAD)" = "${{ github.event.pull_request.head.sha || github.sha }}"
+
+      - name: Build canonical workspaces
+        run: npm run build:workspaces
+
+      - name: Run signed-build workflow contracts
+        run: node --import tsx --test tests/release-toolchain-contract.test.ts
+
+      - name: Validate Android release configuration
+        run: npm run mobile:validate:android
+
+      - name: Validate iOS release configuration
+        run: npm run mobile:validate:ios
+
+      - name: Build production application
+        run: npm run build
+
+      - name: Production dependency security audit
+        run: npm audit --omit=dev --audit-level=high

--- a/.github/workflows/gate5-release-preflight.yml
+++ b/.github/workflows/gate5-release-preflight.yml
@@ -7,6 +7,7 @@ on:
       - ".github/workflows/build-ios.yml"
       - ".github/workflows/build-android.yml"
       - ".github/workflows/gate5-release-preflight.yml"
+      - "capacitor.config.ts"
       - "scripts/validate-mobile-release.mjs"
       - "ios/**"
       - "android/**"

--- a/governance/release-audits/GATE-5-RELEASE-READINESS.md
+++ b/governance/release-audits/GATE-5-RELEASE-READINESS.md
@@ -1,0 +1,113 @@
+# Gate 5 — Deployment & Store Release Readiness
+
+**Base:** `main@b5cdcc25665fb1d9c1cc7a087252e69c02b49624`  
+**Branch:** `gate5/release-toolchain-hardening`  
+**Status:** **IN PROGRESS — RELEASE TOOLCHAIN HARDENED; SIGNED/DEPLOYMENT RECEIPTS STILL REQUIRED**
+
+## Purpose
+
+Gate 5 proves that Soul Codex can move from a tested codebase into a reproducible consumer release without turning configuration, signing, deployment, or store submission assumptions into fake success.
+
+## Defects Found
+
+### iOS runner was incompatible with the installed native stack
+
+The manual App Store workflow used `macos-14`. Gate 2 demonstrated that this selects an Xcode 16 generation that cannot compile the current Capacitor 8 native stack. Gate 5 moves the signed iOS workflow to `macos-26` and requires Xcode major version 26 or newer.
+
+### iOS export success check could report success without an IPA
+
+The old workflow used `if find build/export -name "*.ipa" -type f; then`. `find` exits successfully even when it finds no matching file, so the branch could print an IPA success message with an empty export directory. Gate 5 replaces this with an explicit first-match path, `test -n`, `test -s`, and SHA-256 generation.
+
+### `tee` could hide the real xcodebuild exit status
+
+Archive/export commands piped through `tee` did not enable `pipefail`. Gate 5 runs release commands under `set -euo pipefail`, so a failed `xcodebuild` cannot be masked by a successful logging process.
+
+### Signing identity was not structurally reconciled before archive
+
+The iOS release project is bound to Apple Team `86NUJ8M3B8` and bundle ID `app.soulcodex.ios`. Gate 5 decodes the supplied provisioning profile and checks both its TeamIdentifier and `application-identifier` before an App Store archive can proceed.
+
+## Remediation
+
+`.github/workflows/build-ios.yml` now:
+
+- runs on `macos-26`;
+- uses Node 22 for Capacitor 8;
+- fails if Xcode major version is below 26;
+- records the candidate commit SHA;
+- validates mobile release configuration before native packaging;
+- requires all three Apple signing inputs;
+- imports the distribution certificate;
+- decodes and inspects the provisioning profile;
+- requires Team ID `86NUJ8M3B8`;
+- requires application identifier `86NUJ8M3B8.app.soulcodex.ios`;
+- uses strict shell/pipe failure handling;
+- requires a real, non-empty IPA;
+- records an IPA SHA-256 digest;
+- uploads diagnostic logs even when packaging fails.
+
+## Automated Gate 5 Preflight
+
+`.github/workflows/gate5-release-preflight.yml` runs on release-toolchain changes and:
+
+- checks out the exact candidate head;
+- builds canonical workspaces;
+- runs `tests/release-toolchain-contract.test.ts`;
+- validates Android release configuration;
+- validates iOS release configuration;
+- builds the production application;
+- runs the production dependency security audit at high severity.
+
+The contract test locks:
+
+- macOS 26 / Xcode 26+ for iOS release builds;
+- Node 22 for the native Capacitor lane;
+- strict archive/export pipe handling;
+- non-empty IPA verification and digest generation;
+- Apple Team/bundle provisioning identity;
+- Android signing-secret requirements;
+- Android `bundleRelease` and AAB existence checks.
+
+## Validation Ladder
+
+- **Implemented:** signed Android/iOS workflows and release validators exist.
+- **Integrated:** release workflows build the production web bundle and connect it to native packaging.
+- **Preflight validated:** release-toolchain contracts, mobile validators, production build, and high-severity dependency audit pass on exact head.
+- **Signed-artifact validated:** signed Android AAB and signed App Store IPA are produced from an identified candidate SHA.
+- **Staging validated:** server/web candidate is deployed to staging and smoke-tested.
+- **Rollback validated:** a named previous candidate can be restored and smoke-tested.
+- **Store validated:** App Store Connect and Google Play accept the release artifacts for testing/submission.
+- **Consumer release candidate:** all required gates are green or have a narrowly documented external-service exception that does not affect the candidate's release path.
+
+## Gate 5 Pass Criteria
+
+- [ ] Gate 5 exact-head CI passes.
+- [ ] Production build passes on the release candidate.
+- [ ] Production dependency audit has no high/critical vulnerabilities.
+- [ ] Android signing secrets are configured.
+- [ ] Signed Android AAB is produced and its SHA-256 recorded.
+- [ ] Apple distribution certificate is configured.
+- [ ] Apple provisioning profile matches Team `86NUJ8M3B8` and bundle `app.soulcodex.ios`.
+- [ ] Signed App Store IPA is produced and its SHA-256 recorded.
+- [ ] Staging deployment is smoke-tested.
+- [ ] Production health endpoint is verified on the candidate deployment.
+- [ ] Rollback procedure is exercised against a named previous release candidate.
+- [ ] App Store Connect/TestFlight accepts the iOS artifact.
+- [ ] Google Play internal testing accepts the Android artifact.
+- [ ] Store metadata, privacy, support, and account-deletion surfaces are reconciled with actual app behavior.
+
+## Account-Bound / External Actions
+
+Repository automation cannot fabricate:
+
+- Android keystore values;
+- Apple distribution `.p12` and password;
+- Apple provisioning profile;
+- App Store Connect upload acceptance;
+- Google Play Console upload acceptance;
+- identified physical-device installation receipts.
+
+Those remain open until actual account-bound evidence exists.
+
+## Current Classification
+
+Gate 5 is **implementation/preflight work in progress**. This branch improves the truthfulness and reproducibility of release automation but intentionally does not claim signed-artifact, deployment, rollback, physical-device, or store validation yet.

--- a/scripts/validate-mobile-release.mjs
+++ b/scripts/validate-mobile-release.mjs
@@ -37,9 +37,11 @@ requireFile("client/src/pages/AccountDeletionPage.tsx");
 requireFile("client/src/pages/SupportPage.tsx");
 
 if (platform === "ios") {
+  const exportOptionsPath = "ios/App/ExportOptions.plist";
   requireFile("ios/App/App/PrivacyInfo.xcprivacy");
   requireFile("ios/App/App.xcodeproj/xcshareddata/xcschemes/Soul Codex.xcscheme");
-  requireMatch("scripts/ExportOptions.plist", /<string>86NUJ8M3B8<\/string>/, "The iOS export Team ID is missing or incorrect.");
+  requireMatch(exportOptionsPath, /<key>teamID<\/key>\s*<string>86NUJ8M3B8<\/string>/, "The iOS export Team ID is missing or incorrect in ios/App/ExportOptions.plist.");
+  requireMatch(exportOptionsPath, /<key>method<\/key>\s*<string>(app-store|app-store-connect)<\/string>/, "The iOS export method must target App Store distribution.");
   requireMatch("ios/App/App.xcodeproj/project.pbxproj", /PRODUCT_BUNDLE_IDENTIFIER = app\.soulcodex\.ios;/, "The iOS bundle identifier must remain app.soulcodex.ios.");
 }
 

--- a/tests/release-toolchain-contract.test.ts
+++ b/tests/release-toolchain-contract.test.ts
@@ -4,7 +4,10 @@ import test from "node:test";
 
 const iosWorkflowPath = ".github/workflows/build-ios.yml";
 const androidWorkflowPath = ".github/workflows/build-android.yml";
+const gate5WorkflowPath = ".github/workflows/gate5-release-preflight.yml";
+const validatorPath = "scripts/validate-mobile-release.mjs";
 const iosProjectPath = "ios/App/App.xcodeproj/project.pbxproj";
+const iosExportOptionsPath = "ios/App/ExportOptions.plist";
 
 async function text(path: string): Promise<string> {
   return readFile(path, "utf8");
@@ -45,6 +48,22 @@ test("iOS provisioning preflight binds the Apple Team ID to the release bundle I
   assert.match(project, /PRODUCT_BUNDLE_IDENTIFIER = app\.soulcodex\.ios;/);
   assert.match(workflow, /test "\$PROFILE_TEAM" = "86NUJ8M3B8"/);
   assert.match(workflow, /test "\$APP_IDENTIFIER" = "86NUJ8M3B8\.app\.soulcodex\.ios"/);
+});
+
+test("iOS release validator checks the same ExportOptions plist consumed by Xcode", async () => {
+  const workflow = await text(iosWorkflowPath);
+  const validator = await text(validatorPath);
+  const exportOptions = await text(iosExportOptionsPath);
+
+  assert.match(workflow, /-exportOptionsPlist ExportOptions\.plist/);
+  assert.match(validator, /ios\/App\/ExportOptions\.plist/);
+  assert.match(exportOptions, /<key>teamID<\/key>\s*<string>86NUJ8M3B8<\/string>/);
+  assert.match(exportOptions, /<key>method<\/key>\s*<string>(app-store|app-store-connect)<\/string>/);
+});
+
+test("Gate 5 preflight runs when Capacitor package identity configuration changes", async () => {
+  const workflow = await text(gate5WorkflowPath);
+  assert.match(workflow, /- "capacitor\.config\.ts"/);
 });
 
 test("Android Play workflow requires signing material and a real AAB", async () => {

--- a/tests/release-toolchain-contract.test.ts
+++ b/tests/release-toolchain-contract.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const iosWorkflowPath = ".github/workflows/build-ios.yml";
+const androidWorkflowPath = ".github/workflows/build-android.yml";
+const iosProjectPath = "ios/App/App.xcodeproj/project.pbxproj";
+
+async function text(path: string): Promise<string> {
+  return readFile(path, "utf8");
+}
+
+test("iOS release workflow uses the supported Capacitor 8 native toolchain", async () => {
+  const workflow = await text(iosWorkflowPath);
+
+  assert.match(workflow, /runs-on:\s*macos-26/);
+  assert.match(workflow, /node-version:\s*22/);
+  assert.match(workflow, /XCODE_MAJOR/);
+  assert.match(workflow, /test "\$XCODE_MAJOR" -ge 26/);
+});
+
+test("iOS App Store workflow cannot mask archive or export failures", async () => {
+  const workflow = await text(iosWorkflowPath);
+
+  assert.match(workflow, /set -euo pipefail/);
+  assert.match(workflow, /xcodebuild -workspace App\.xcodeproj\/project\.xcworkspace[\s\S]*archive 2>&1 \| tee archive\.log/);
+  assert.match(workflow, /xcodebuild -exportArchive[\s\S]*2>&1 \| tee export\.log/);
+});
+
+test("iOS App Store workflow requires a real non-empty IPA and records its digest", async () => {
+  const workflow = await text(iosWorkflowPath);
+
+  assert.match(workflow, /IPA_PATH=\$\(find build\/export -maxdepth 1 -name "\*\.ipa" -type f -print -quit\)/);
+  assert.match(workflow, /test -n "\$IPA_PATH"/);
+  assert.match(workflow, /test -s "\$IPA_PATH"/);
+  assert.match(workflow, /shasum -a 256 "\$IPA_PATH"/);
+  assert.match(workflow, /if-no-files-found:\s*error/);
+});
+
+test("iOS provisioning preflight binds the Apple Team ID to the release bundle ID", async () => {
+  const workflow = await text(iosWorkflowPath);
+  const project = await text(iosProjectPath);
+
+  assert.match(project, /DEVELOPMENT_TEAM = 86NUJ8M3B8;/);
+  assert.match(project, /PRODUCT_BUNDLE_IDENTIFIER = app\.soulcodex\.ios;/);
+  assert.match(workflow, /test "\$PROFILE_TEAM" = "86NUJ8M3B8"/);
+  assert.match(workflow, /test "\$APP_IDENTIFIER" = "86NUJ8M3B8\.app\.soulcodex\.ios"/);
+});
+
+test("Android Play workflow requires signing material and a real AAB", async () => {
+  const workflow = await text(androidWorkflowPath);
+
+  assert.match(workflow, /ANDROID_KEYSTORE/);
+  assert.match(workflow, /ANDROID_KEYSTORE_PASSWORD/);
+  assert.match(workflow, /ANDROID_KEY_ALIAS/);
+  assert.match(workflow, /ANDROID_KEY_PASSWORD/);
+  assert.match(workflow, /\.\/gradlew bundleRelease/);
+  assert.match(workflow, /test -f app\/build\/outputs\/bundle\/release\/app-release\.aab|if \[ ! -f "app\/build\/outputs\/bundle\/release\/app-release\.aab" \]/);
+});


### PR DESCRIPTION
## Summary
Harden the signed iOS release lane and add an exact-head Gate 5 release preflight. This fixes unsupported Xcode selection, masked archive/export failures, empty-IPA false positives, and missing provisioning identity checks.

## Validation
Gate 5 CI runs exact-head release workflow contracts, Android/iOS release validators, production build, and a high-severity production dependency audit. The signed iOS workflow itself remains manual/account-bound and requires real Apple signing material before App Store artifact claims are allowed.

## Risk Assessment
Moderate release-automation risk, low runtime-application risk. The PR changes CI/release workflows, tests, and governance documentation; it does not alter calculation behavior or user profile data. Primary risk is rejecting previously tolerated but invalid signing/toolchain configurations, which is intentional fail-closed behavior.

## Rollback Plan
Revert this PR to restore the previous release workflows. No database or user-data migration is involved.

## Non-claims
This PR does not claim a signed IPA/AAB, hardware validation, staging/production rollback validation, TestFlight acceptance, or Google Play acceptance until those receipts actually exist.