### PR TITLE
Gate 4: final consumer deletion restart validation

### DIFF
--- a/.github/workflows/gate4-lifecycle-validation.yml
+++ b/.github/workflows/gate4-lifecycle-validation.yml
@@ -4,7 +4,11 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - "client/src/App.tsx"
+      - "client/src/pages/SettingsPage.tsx"
+      - "client/src/pages/AccountDeletionPage.tsx"
       - "client/src/lib/ActiveProfileRepository.ts"
+      - "client/src/lib/offlineProfileStore.ts"
       - "client/src/lib/__tests__/ActiveProfileRepository.test.ts"
       - "tests/gate4-profile-lifecycle.test.ts"
       - "tests/account-deletion.test.ts"
@@ -27,8 +31,15 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - name: Checkout
+      - name: Checkout exact candidate head
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Record exact candidate SHA
+        run: |
+          echo "candidate_sha=$(git rev-parse HEAD)"
+          test "$(git rev-parse HEAD)" = "${{ github.event.pull_request.head.sha || github.sha }}"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -61,13 +72,20 @@ jobs:
           retention-days: 7
 
   persistent-offline-browser:
-    name: Chromium and WebKit persistent/offline journey
+    name: Chromium and WebKit lifecycle journeys
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 30
 
     steps:
-      - name: Checkout
+      - name: Checkout exact candidate head
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Record exact candidate SHA
+        run: |
+          echo "candidate_sha=$(git rev-parse HEAD)"
+          test "$(git rev-parse HEAD)" = "${{ github.event.pull_request.head.sha || github.sha }}"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -90,8 +108,12 @@ jobs:
       - name: Build production application and PWA assets
         run: npm run build
 
-      - name: Run persistent profile and offline restart journey
-        run: npx playwright test tests/pwa/foundation-profile-journey.spec.mjs --config=tests/pwa/playwright.config.mjs
+      - name: Run persistent profile, offline restart, and account deletion restart journeys
+        run: >-
+          npx playwright test
+          tests/pwa/foundation-profile-journey.spec.mjs
+          tests/pwa/account-deletion-restart.spec.mjs
+          --config=tests/pwa/playwright.config.mjs
 
       - name: Upload browser evidence on failure
         if: failure()

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -24,6 +24,7 @@ import PrivacyPage from "./pages/PrivacyPage";
 import TermsPage from "./pages/TermsPage";
 import SupportPage from "./pages/SupportPage";
 import SettingsPage from "./pages/SettingsPage";
+import AccountDeletionPage from "./pages/AccountDeletionPage";
 import PricingPage from "./pages/PricingPage";
 import type { Profile as ProfileType } from "@shared/schema";
 
@@ -108,6 +109,7 @@ function Router() {
       <Route path="/terms" component={TermsPage} />
       <Route path="/support" component={SupportPage} />
       <Route path="/settings" component={SettingsPage} />
+      <Route path="/delete-account" component={AccountDeletionPage} />
       <Route path="/pricing" component={PricingPage} />
       <Route component={NotFound} />
     </Switch>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -110,6 +110,7 @@ function Router() {
       <Route path="/support" component={SupportPage} />
       <Route path="/settings" component={SettingsPage} />
       <Route path="/delete-account" component={AccountDeletionPage} />
+      <Route path="/account-deletion" component={AccountDeletionPage} />
       <Route path="/pricing" component={PricingPage} />
       <Route component={NotFound} />
     </Switch>

--- a/client/src/lib/offlineProfileStore.ts
+++ b/client/src/lib/offlineProfileStore.ts
@@ -97,3 +97,26 @@ export async function deleteOfflineProfile(id: string): Promise<void> {
     console.warn("[offlineProfileStore] IndexedDB delete failed", error);
   }
 }
+
+/**
+ * Remove every locally persisted offline profile for account/data deletion.
+ * This intentionally clears both the IndexedDB authority and localStorage
+ * fallbacks so a deleted profile cannot reappear from a bookmarked local URL.
+ */
+export async function clearOfflineProfiles(): Promise<void> {
+  try {
+    for (let index = localStorage.length - 1; index >= 0; index -= 1) {
+      const key = localStorage.key(index);
+      if (key?.startsWith(FALLBACK_PREFIX)) localStorage.removeItem(key);
+    }
+  } catch {}
+
+  if (!hasIndexedDb()) return;
+
+  await new Promise<void>((resolve, reject) => {
+    const request = indexedDB.deleteDatabase(DB_NAME);
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error ?? new Error("Unable to delete offline profile database"));
+    request.onblocked = () => reject(new Error("Offline profile database deletion was blocked"));
+  });
+}

--- a/client/src/lib/offlineProfileStore.ts
+++ b/client/src/lib/offlineProfileStore.ts
@@ -18,7 +18,11 @@ function openDatabase(): Promise<IDBDatabase> {
         database.createObjectStore(PROFILE_STORE, { keyPath: "id" });
       }
     };
-    request.onsuccess = () => resolve(request.result);
+    request.onsuccess = () => {
+      const database = request.result;
+      database.onversionchange = () => database.close();
+      resolve(database);
+    };
     request.onerror = () => reject(request.error ?? new Error("Unable to open offline profile database"));
   });
 }
@@ -100,8 +104,8 @@ export async function deleteOfflineProfile(id: string): Promise<void> {
 
 /**
  * Remove every locally persisted offline profile for account/data deletion.
- * This intentionally clears both the IndexedDB authority and localStorage
- * fallbacks so a deleted profile cannot reappear from a bookmarked local URL.
+ * The object store is cleared before database deletion so profile data is gone
+ * even if another tab temporarily blocks deleteDatabase().
  */
 export async function clearOfflineProfiles(): Promise<void> {
   try {
@@ -113,10 +117,33 @@ export async function clearOfflineProfiles(): Promise<void> {
 
   if (!hasIndexedDb()) return;
 
+  let storeCleared = false;
+  try {
+    await withStore("readwrite", (store) => store.clear());
+    storeCleared = true;
+  } catch (error) {
+    console.warn("[offlineProfileStore] IndexedDB profile-store clear failed", error);
+  }
+
   await new Promise<void>((resolve, reject) => {
     const request = indexedDB.deleteDatabase(DB_NAME);
     request.onsuccess = () => resolve();
-    request.onerror = () => reject(request.error ?? new Error("Unable to delete offline profile database"));
-    request.onblocked = () => reject(new Error("Offline profile database deletion was blocked"));
+    request.onerror = () => {
+      const error = request.error ?? new Error("Unable to delete offline profile database");
+      if (storeCleared) {
+        console.warn("[offlineProfileStore] Database deletion failed after profile store was cleared", error);
+        resolve();
+      } else {
+        reject(error);
+      }
+    };
+    request.onblocked = () => {
+      if (storeCleared) {
+        console.warn("[offlineProfileStore] Database deletion blocked; profile store was already cleared");
+        resolve();
+      } else {
+        reject(new Error("Offline profile database deletion was blocked before profile data could be cleared"));
+      }
+    };
   });
 }

--- a/client/src/pages/AccountDeletionPage.tsx
+++ b/client/src/pages/AccountDeletionPage.tsx
@@ -20,16 +20,30 @@ export default function AccountDeletionPage() {
 
     try {
       await apiRequest("DELETE", "/api/auth/account");
-      await clearOfflineProfiles();
-
-      queryClient.clear();
-      localStorage.clear();
-      sessionStorage.clear();
-      window.location.replace("/?accountDeleted=1");
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : "Deletion failed. Please try again.");
       setIsDeleting(false);
+      return;
     }
+
+    // Server deletion is irreversible. From this point forward local cleanup is
+    // best-effort but unconditional so a blocked IndexedDB connection cannot
+    // leave canonical Web Storage behind or make the app report account deletion
+    // as failed after the server has already removed the account.
+    try {
+      await clearOfflineProfiles();
+    } catch (cause) {
+      console.warn("[AccountDeletion] offline profile cleanup incomplete after server deletion", cause);
+    }
+
+    queryClient.clear();
+    try {
+      localStorage.clear();
+    } catch {}
+    try {
+      sessionStorage.clear();
+    } catch {}
+    window.location.replace("/?accountDeleted=1");
   };
 
   return (

--- a/client/src/pages/AccountDeletionPage.tsx
+++ b/client/src/pages/AccountDeletionPage.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
 import { Link } from "wouter";
 import { IconAlert, IconArrowLeft, IconLock } from "../components/Icons";
-import { apiFetch, queryClient } from "../lib/queryClient";
+import { apiRequest, queryClient } from "../lib/queryClient";
+import { clearOfflineProfiles } from "../lib/offlineProfileStore";
 
 const DELETE_CONFIRMATION = "DELETE";
 
@@ -18,16 +19,13 @@ export default function AccountDeletionPage() {
     setIsDeleting(true);
 
     try {
-      const response = await apiFetch("/api/auth/account", { method: "DELETE" });
-      const body = await response.json().catch(() => null);
-      if (!response.ok) {
-        throw new Error(body?.message || "We could not delete your server data.");
-      }
+      await apiRequest("DELETE", "/api/auth/account");
+      await clearOfflineProfiles();
 
       queryClient.clear();
       localStorage.clear();
       sessionStorage.clear();
-      window.location.replace("/welcome?accountDeleted=1");
+      window.location.replace("/?accountDeleted=1");
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : "Deletion failed. Please try again.");
       setIsDeleting(false);

--- a/client/src/pages/SettingsPage.tsx
+++ b/client/src/pages/SettingsPage.tsx
@@ -120,6 +120,11 @@ export default function SettingsPage() {
                 icon={<IconInfo size={16} />}
                 onClick={() => navigate("/support")}
               />
+              <SettingsLink
+                label="Delete Account & Data"
+                icon={<IconAlert size={16} />}
+                onClick={() => navigate("/delete-account")}
+              />
             </div>
           </section>
 

--- a/tests/pwa/account-deletion-restart.spec.mjs
+++ b/tests/pwa/account-deletion-restart.spec.mjs
@@ -91,7 +91,44 @@ async function readOfflineIndexedDbProfile(page) {
   }, OFFLINE_PROFILE_ID);
 }
 
-async function assertDeviceStorageEmpty(page) {
+async function holdBlockingIndexedDbConnection(page) {
+  await page.goto(`${BASE_URL}/`, { waitUntil: "domcontentloaded" });
+  await page.evaluate(async () => {
+    await new Promise((resolve, reject) => {
+      const request = indexedDB.open("soulcodex-offline", 1);
+      request.onerror = () => reject(request.error ?? new Error("Unable to open blocker IndexedDB connection"));
+      request.onsuccess = () => {
+        // Deliberately keep a second-tab connection open and do not install a
+        // versionchange handler. This reproduces a real multi-tab condition
+        // where deleteDatabase() is blocked after account deletion succeeds.
+        window.__gate4BlockingDb = request.result;
+        resolve();
+      };
+    });
+  });
+}
+
+async function readProfileThroughBlockingConnection(page) {
+  return page.evaluate(async (profileId) => {
+    const database = window.__gate4BlockingDb;
+    if (!database) throw new Error("Gate 4 blocking IndexedDB connection is missing");
+    return new Promise((resolve, reject) => {
+      const transaction = database.transaction("profiles", "readonly");
+      const request = transaction.objectStore("profiles").get(profileId);
+      request.onsuccess = () => resolve(request.result ?? null);
+      request.onerror = () => reject(request.error ?? new Error("Unable to read through blocker connection"));
+    });
+  }, OFFLINE_PROFILE_ID);
+}
+
+async function closeBlockingIndexedDbConnection(page) {
+  await page.evaluate(() => {
+    window.__gate4BlockingDb?.close();
+    delete window.__gate4BlockingDb;
+  }).catch(() => undefined);
+}
+
+async function assertWebStorageEmpty(page) {
   const state = await page.evaluate(({ activeKey, legacyKeys, profileId }) => ({
     activeProfile: localStorage.getItem(activeKey),
     legacyValues: legacyKeys.map((key) => localStorage.getItem(key)),
@@ -105,10 +142,9 @@ async function assertDeviceStorageEmpty(page) {
   expect(state.fallbackProfile).toBeNull();
   expect(state.localCount).toBe(0);
   expect(state.sessionCount).toBe(0);
-  expect(await readOfflineIndexedDbProfile(page)).toBeNull();
 }
 
-test("Settings exposes account deletion and deleted profile cannot resurrect after restart", async ({ browserName }, testInfo) => {
+test("Settings deletion clears Web Storage and offline IndexedDB even when a second tab blocks database deletion", async ({ browserName }, testInfo) => {
   const browserType = BROWSER_TYPES[browserName];
   if (!browserType) throw new Error(`Unsupported browser project: ${browserName}`);
 
@@ -118,10 +154,13 @@ test("Settings exposes account deletion and deleted profile cannot resurrect aft
 
   let context = await browserType.launchPersistentContext(userDataDir, options);
   let page = context.pages()[0] ?? (await context.newPage());
+  let blockerPage = await context.newPage();
 
   try {
     await seedConsumerState(page);
     expect(await readOfflineIndexedDbProfile(page)).toMatchObject({ id: OFFLINE_PROFILE_ID });
+    await holdBlockingIndexedDbConnection(blockerPage);
+    expect(await readProfileThroughBlockingConnection(blockerPage)).toMatchObject({ id: OFFLINE_PROFILE_ID });
 
     await page.goto(`${BASE_URL}/settings`, { waitUntil: "domcontentloaded" });
     await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
@@ -136,8 +175,14 @@ test("Settings exposes account deletion and deleted profile cannot resurrect aft
       page.getByRole("button", { name: /Permanently Delete My Data/i }).click(),
     ]);
 
-    await assertDeviceStorageEmpty(page);
+    // The second tab deliberately prevents deleteDatabase() from completing.
+    // The profile store itself still has to be empty, and canonical Web Storage
+    // must be cleared unconditionally after server deletion succeeds.
+    await assertWebStorageEmpty(page);
+    expect(await readProfileThroughBlockingConnection(blockerPage)).toBeNull();
   } finally {
+    await closeBlockingIndexedDbConnection(blockerPage);
+    await blockerPage.close().catch(() => undefined);
     await context.close();
   }
 
@@ -146,7 +191,8 @@ test("Settings exposes account deletion and deleted profile cannot resurrect aft
 
   try {
     await page.goto(`${BASE_URL}/`, { waitUntil: "domcontentloaded" });
-    await assertDeviceStorageEmpty(page);
+    await assertWebStorageEmpty(page);
+    expect(await readOfflineIndexedDbProfile(page)).toBeNull();
     await expect(page.locator("body")).not.toContainText(OFFLINE_PROFILE_ID);
   } catch (error) {
     const screenshotPath = testInfo.outputPath(`account-deletion-restart-failure-${browserName}.png`);

--- a/tests/pwa/account-deletion-restart.spec.mjs
+++ b/tests/pwa/account-deletion-restart.spec.mjs
@@ -1,0 +1,162 @@
+import { mkdir } from "node:fs/promises";
+import { chromium, devices, expect, test, webkit } from "@playwright/test";
+
+const BASE_URL = "http://127.0.0.1:4173";
+const ACTIVE_PROFILE_KEY = "soulcodex.activeProfile.v1";
+const OFFLINE_PROFILE_ID = "local-delete-contract";
+const LEGACY_PROFILE_KEYS = ["soulProfile", "soulCodexReading", "soulConfidence", "soulGuestProfile", "soulGuestConfidence"];
+const BROWSER_TYPES = { chromium, webkit };
+
+function persistentContextOptions(browserName) {
+  const descriptor = browserName === "webkit" ? devices["iPhone 15"] : devices["Desktop Chrome"];
+  const { defaultBrowserType: _defaultBrowserType, ...deviceOptions } = descriptor;
+  return {
+    ...deviceOptions,
+    headless: true,
+    locale: "en-US",
+    serviceWorkers: "allow",
+  };
+}
+
+async function seedConsumerState(page) {
+  await page.goto(`${BASE_URL}/`, { waitUntil: "domcontentloaded" });
+  await page.evaluate(async ({ activeKey, legacyKeys, profileId }) => {
+    const profile = {
+      id: profileId,
+      birthDate: "1990-09-17",
+      schemaVersion: 1,
+      sunSign: "Virgo",
+      updatedAt: new Date().toISOString(),
+      createdAt: new Date().toISOString(),
+    };
+
+    localStorage.setItem(activeKey, JSON.stringify(profile));
+    for (const key of legacyKeys) localStorage.setItem(key, JSON.stringify(profile));
+    localStorage.setItem(`soulcodex.offlineProfile.v1.${profileId}`, JSON.stringify(profile));
+    localStorage.setItem("unrelated-soulcodex-cache", "delete-me-too");
+    sessionStorage.setItem("session-delete-contract", "present");
+
+    await new Promise((resolve, reject) => {
+      const openRequest = indexedDB.open("soulcodex-offline", 1);
+      openRequest.onupgradeneeded = () => {
+        const database = openRequest.result;
+        if (!database.objectStoreNames.contains("profiles")) {
+          database.createObjectStore("profiles", { keyPath: "id" });
+        }
+      };
+      openRequest.onerror = () => reject(openRequest.error ?? new Error("Unable to seed offline IndexedDB"));
+      openRequest.onsuccess = () => {
+        const database = openRequest.result;
+        const transaction = database.transaction("profiles", "readwrite");
+        transaction.objectStore("profiles").put(profile);
+        transaction.oncomplete = () => {
+          database.close();
+          resolve();
+        };
+        transaction.onerror = () => {
+          database.close();
+          reject(transaction.error ?? new Error("Unable to seed offline profile"));
+        };
+      };
+    });
+  }, { activeKey: ACTIVE_PROFILE_KEY, legacyKeys: LEGACY_PROFILE_KEYS, profileId: OFFLINE_PROFILE_ID });
+}
+
+async function readOfflineIndexedDbProfile(page) {
+  return page.evaluate(async (profileId) => {
+    return new Promise((resolve, reject) => {
+      const openRequest = indexedDB.open("soulcodex-offline", 1);
+      openRequest.onupgradeneeded = () => {
+        const database = openRequest.result;
+        if (!database.objectStoreNames.contains("profiles")) {
+          database.createObjectStore("profiles", { keyPath: "id" });
+        }
+      };
+      openRequest.onerror = () => reject(openRequest.error ?? new Error("Unable to open offline IndexedDB"));
+      openRequest.onsuccess = () => {
+        const database = openRequest.result;
+        const transaction = database.transaction("profiles", "readonly");
+        const request = transaction.objectStore("profiles").get(profileId);
+        request.onsuccess = () => {
+          const result = request.result ?? null;
+          database.close();
+          resolve(result);
+        };
+        request.onerror = () => {
+          database.close();
+          reject(request.error ?? new Error("Unable to read offline profile"));
+        };
+      };
+    });
+  }, OFFLINE_PROFILE_ID);
+}
+
+async function assertDeviceStorageEmpty(page) {
+  const state = await page.evaluate(({ activeKey, legacyKeys, profileId }) => ({
+    activeProfile: localStorage.getItem(activeKey),
+    legacyValues: legacyKeys.map((key) => localStorage.getItem(key)),
+    fallbackProfile: localStorage.getItem(`soulcodex.offlineProfile.v1.${profileId}`),
+    localCount: localStorage.length,
+    sessionCount: sessionStorage.length,
+  }), { activeKey: ACTIVE_PROFILE_KEY, legacyKeys: LEGACY_PROFILE_KEYS, profileId: OFFLINE_PROFILE_ID });
+
+  expect(state.activeProfile).toBeNull();
+  expect(state.legacyValues.every((value) => value === null)).toBe(true);
+  expect(state.fallbackProfile).toBeNull();
+  expect(state.localCount).toBe(0);
+  expect(state.sessionCount).toBe(0);
+  expect(await readOfflineIndexedDbProfile(page)).toBeNull();
+}
+
+test("Settings exposes account deletion and deleted profile cannot resurrect after restart", async ({ browserName }, testInfo) => {
+  const browserType = BROWSER_TYPES[browserName];
+  if (!browserType) throw new Error(`Unsupported browser project: ${browserName}`);
+
+  const userDataDir = testInfo.outputPath(`account-deletion-${browserName}`);
+  await mkdir(userDataDir, { recursive: true });
+  const options = persistentContextOptions(browserName);
+
+  let context = await browserType.launchPersistentContext(userDataDir, options);
+  let page = context.pages()[0] ?? (await context.newPage());
+
+  try {
+    await seedConsumerState(page);
+    expect(await readOfflineIndexedDbProfile(page)).toMatchObject({ id: OFFLINE_PROFILE_ID });
+
+    await page.goto(`${BASE_URL}/settings`, { waitUntil: "domcontentloaded" });
+    await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
+    await page.getByRole("button", { name: /Delete Account & Data/i }).click();
+
+    await expect(page).toHaveURL(/\/delete-account$/);
+    await expect(page.getByRole("heading", { name: /Delete Account & Data/i })).toBeVisible();
+
+    await page.locator("#delete-confirmation").fill("DELETE");
+    await Promise.all([
+      page.waitForURL(/\/\?accountDeleted=1$/),
+      page.getByRole("button", { name: /Permanently Delete My Data/i }).click(),
+    ]);
+
+    await assertDeviceStorageEmpty(page);
+  } finally {
+    await context.close();
+  }
+
+  context = await browserType.launchPersistentContext(userDataDir, options);
+  page = context.pages()[0] ?? (await context.newPage());
+
+  try {
+    await page.goto(`${BASE_URL}/`, { waitUntil: "domcontentloaded" });
+    await assertDeviceStorageEmpty(page);
+    await expect(page.locator("body")).not.toContainText(OFFLINE_PROFILE_ID);
+  } catch (error) {
+    const screenshotPath = testInfo.outputPath(`account-deletion-restart-failure-${browserName}.png`);
+    await page.screenshot({ path: screenshotPath, fullPage: true }).catch(() => undefined);
+    await testInfo.attach("account-deletion-restart-failure", {
+      path: screenshotPath,
+      contentType: "image/png",
+    }).catch(() => undefined);
+    throw error;
+  } finally {
+    await context.close();
+  }
+});

--- a/tests/pwa/playwright.config.mjs
+++ b/tests/pwa/playwright.config.mjs
@@ -3,7 +3,7 @@ import { defineConfig } from "@playwright/test";
 export default defineConfig({
   testDir: ".",
   testMatch:
-    /(offline-shell|project-clarity|foundation-profile-journey|foundation-consumer-responsive)\.spec\.mjs/,
+    /(offline-shell|project-clarity|foundation-profile-journey|foundation-consumer-responsive|account-deletion-restart)\.spec\.mjs/,
   timeout: 180_000,
   expect: { timeout: 20_000 },
   fullyParallel: false,

--- a/tests/pwa/static-server.mjs
+++ b/tests/pwa/static-server.mjs
@@ -59,6 +59,19 @@ const server = http.createServer(async (request, response) => {
   const method = request.method ?? "GET";
   const requestUrl = new URL(request.url ?? "/", `http://${HOST}:${PORT}`);
 
+  // Gate 4 needs one explicit server-backed success path so the real consumer
+  // deletion flow can be exercised through the service-worker/network stack.
+  // All other cloud APIs remain intentionally unavailable in this harness.
+  if (requestUrl.pathname === "/api/auth/account" && method === "DELETE") {
+    request.resume();
+    response.writeHead(200, {
+      "Cache-Control": "no-store",
+      "Content-Type": "application/json; charset=utf-8",
+    });
+    response.end(JSON.stringify({ success: true }));
+    return;
+  }
+
   if (requestUrl.pathname.startsWith("/api/")) {
     request.resume();
     response.writeHead(503, {


### PR DESCRIPTION
## Summary
Final Gate 4 consumer lifecycle candidate rebuilt from current `main` after Gate 5 merged.

## Fixes
- routes `AccountDeletionPage` at `/delete-account`;
- exposes `Delete Account & Data` from Settings;
- uses the real `apiRequest` helper instead of dead `apiFetch` code;
- redirects successful deletion to the valid root route;
- clears canonical Web Storage, legacy keys, offline fallback data, and the `soulcodex-offline` IndexedDB database;
- adds a persistent Chromium/WebKit deletion → restart → no-resurrection contract;
- exercises DELETE through the local HTTP test-server boundary so service-worker-controlled requests follow the real network path;
- checks out and records the exact PR head in both Gate 4 workflow jobs.

## Lineage
Base is current `main@a08b9f7281ccb4ef1b4c6eafad78173f506908ce` with Gate 2, Gate 4 lifecycle hardening, and Gate 5 release-toolchain work already merged. This supersedes PR #193, whose branch diverged while those release changes landed.

## Validation required before merge
- Ultimate SoulCodex CI
- CI Tests
- Gate 4 profile/deletion contracts
- Chromium + WebKit profile/offline/deletion restart journeys
- Mobile Native Smoke

The independent JPL live-evidence workflow remains tracked separately and is not being mislabeled as a Gate 4 lifecycle defect.

## Risk
Moderate privacy/lifecycle risk, low calculation risk. No astrology/numerology/Human Design algorithms are changed.

## Rollback
Revert this PR. No database migration is involved.