### PR TITLE
Gate 1: harden live ephemeris availability evidence

### DIFF
--- a/.github/workflows/live-ephemeris-evidence.yml
+++ b/.github/workflows/live-ephemeris-evidence.yml
@@ -14,10 +14,14 @@ on:
       - "server/services/astrology-evidence-matrix.ts"
       - "server/services/astrology.ts"
       - "server/services/astrology-verification.ts"
+      - "server/services/astrology-engine-compat.ts"
+      - "server/services/ascendant-verification.ts"
       - "tests/jpl-horizons-reference.test.ts"
       - "tests/astrology-evidence-matrix.test.ts"
       - "packages/astrology/**"
       - "packages/core/placement/**"
+      - "package.json"
+      - "package-lock.json"
 
 permissions:
   contents: read

--- a/.github/workflows/live-ephemeris-evidence.yml
+++ b/.github/workflows/live-ephemeris-evidence.yml
@@ -2,12 +2,22 @@ name: Live Ephemeris Evidence
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "17 6 * * *"
   push:
     branches:
-      - chore/live-ephemeris-evidence-receipt
-  pull_request:
-    branches:
       - main
+    paths:
+      - ".github/workflows/live-ephemeris-evidence.yml"
+      - "scripts/run-live-ephemeris-evidence.ts"
+      - "server/services/jpl-horizons-reference.ts"
+      - "server/services/astrology-evidence-matrix.ts"
+      - "server/services/astrology.ts"
+      - "server/services/astrology-verification.ts"
+      - "tests/jpl-horizons-reference.test.ts"
+      - "tests/astrology-evidence-matrix.test.ts"
+      - "packages/astrology/**"
+      - "packages/core/placement/**"
 
 permissions:
   contents: read
@@ -17,8 +27,10 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
-      - name: Checkout repository
+      - name: Checkout exact candidate
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -29,15 +41,23 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Validate Horizons reference adapter contracts
+        run: node --import tsx --test tests/jpl-horizons-reference.test.ts
+
       - name: Generate live NASA/JPL evidence receipt
         run: |
           mkdir -p evidence
           node --import tsx scripts/run-live-ephemeris-evidence.ts evidence/ephemeris-live-receipt.json
 
       - name: Display receipt summary
-        run: node -e "const r=require('./evidence/ephemeris-live-receipt.json'); console.log(JSON.stringify(r.summary,null,2));"
+        if: always()
+        run: >-
+          node -e "const fs=require('fs'); const p='./evidence/ephemeris-live-receipt.json';
+          if (!fs.existsSync(p)) { console.log('No receipt produced'); process.exit(0); }
+          const r=JSON.parse(fs.readFileSync(p,'utf8')); console.log(JSON.stringify(r.summary ?? r.failure ?? r,null,2));"
 
       - name: Upload evidence receipt
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: ephemeris-live-evidence-receipt

--- a/scripts/run-live-ephemeris-evidence.ts
+++ b/scripts/run-live-ephemeris-evidence.ts
@@ -6,22 +6,48 @@ const outputPath = resolve(
   process.argv[2] ?? "artifacts/astrology/ephemeris-evidence-receipt.json",
 );
 
-async function main(): Promise<void> {
-  const receipt = await runLiveEphemerisEvidenceMatrix();
+async function writeReceipt(receipt: unknown): Promise<void> {
   await mkdir(dirname(outputPath), { recursive: true });
   await writeFile(outputPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf8");
+}
 
-  console.log(`Ephemeris evidence receipt written to ${outputPath}`);
-  console.log(JSON.stringify(receipt.summary, null, 2));
+async function main(): Promise<void> {
+  try {
+    const receipt = await runLiveEphemerisEvidenceMatrix();
+    await writeReceipt(receipt);
 
-  if (receipt.summary.signDisagreements > 0) {
-    process.exitCode = 2;
-    console.error("Sign disagreement detected. No tolerance policy may be approved from this receipt.");
+    console.log(`Ephemeris evidence receipt written to ${outputPath}`);
+    console.log(JSON.stringify(receipt.summary, null, 2));
+
+    if (receipt.summary.signDisagreements > 0) {
+      process.exitCode = 2;
+      console.error("Sign disagreement detected. No tolerance policy may be approved from this receipt.");
+    }
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    const availabilityFailure = /^horizons_http_(429|500|502|503|504)$/.test(message);
+    const failureReceipt = {
+      schemaVersion: "1.0.0",
+      generatedAt: new Date().toISOString(),
+      policyStatus: "evidence_unavailable_fail_closed",
+      status: availabilityFailure ? "reference_service_unavailable" : "evidence_generation_failed",
+      source: "NASA/JPL Horizons API",
+      failure: {
+        code: message,
+        retryPolicy: {
+          maxAttemptsPerRequest: 4,
+          transientHttpStatuses: [429, 500, 502, 503, 504],
+          baseDelayMilliseconds: 500,
+        },
+      },
+    };
+
+    await writeReceipt(failureReceipt);
+    process.exitCode = 1;
+    console.error("Live ephemeris evidence run failed closed.");
+    console.error(message);
+    console.error(`Failure receipt written to ${outputPath}`);
   }
 }
 
-main().catch((error: unknown) => {
-  process.exitCode = 1;
-  console.error("Live ephemeris evidence run failed closed.");
-  console.error(error instanceof Error ? error.message : String(error));
-});
+void main();

--- a/server/services/jpl-horizons-reference.ts
+++ b/server/services/jpl-horizons-reference.ts
@@ -3,6 +3,7 @@ import type { IndependentEphemerisReference } from "./astrology-verification";
 export type SupportedHorizonsBody = "Sun" | "Moon";
 
 type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+type SleepLike = (milliseconds: number) => Promise<void>;
 
 interface HorizonsPayload {
   signature?: {
@@ -20,6 +21,7 @@ const BODY_COMMAND: Record<SupportedHorizonsBody, string> = {
   Sun: "10",
   Moon: "301",
 };
+const TRANSIENT_HTTP_STATUSES = new Set([429, 500, 502, 503, 504]);
 
 const ZODIAC_SIGNS = [
   "Aries",
@@ -54,6 +56,10 @@ function horizonsTime(timestamp: string): string {
   const date = new Date(timestamp);
   if (Number.isNaN(date.getTime())) throw new Error("invalid_input_timestamp");
   return date.toISOString().replace("T", " ").replace(/\.\d{3}Z$/, "");
+}
+
+function sleep(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
 export function buildHorizonsReferenceUrl(body: SupportedHorizonsBody, inputTimestamp: string): string {
@@ -118,37 +124,58 @@ export async function fetchHorizonsReference(
   options: {
     fetchImpl?: FetchLike;
     timeoutMs?: number;
+    maxAttempts?: number;
+    retryBaseDelayMs?: number;
+    sleepImpl?: SleepLike;
   } = {},
 ): Promise<IndependentEphemerisReference> {
   const fetchImpl = options.fetchImpl ?? fetch;
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? 8_000);
+  const maxAttempts = Math.max(1, options.maxAttempts ?? 4);
+  const retryBaseDelayMs = Math.max(0, options.retryBaseDelayMs ?? 500);
+  const sleepImpl = options.sleepImpl ?? sleep;
+  const url = buildHorizonsReferenceUrl(body, inputTimestamp);
 
-  try {
-    const response = await fetchImpl(buildHorizonsReferenceUrl(body, inputTimestamp), {
-      signal: controller.signal,
-      headers: { Accept: "application/json" },
-    });
-    if (!response.ok) throw new Error(`horizons_http_${response.status}`);
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? 8_000);
 
-    const payload = await response.json() as HorizonsPayload;
-    if (payload.error) throw new Error("horizons_api_error");
-    if (!payload.signature?.source?.toLowerCase().includes("jpl")) {
-      throw new Error("horizons_signature_invalid");
+    try {
+      const response = await fetchImpl(url, {
+        signal: controller.signal,
+        headers: { Accept: "application/json" },
+      });
+
+      if (!response.ok) {
+        const error = new Error(`horizons_http_${response.status}`);
+        if (TRANSIENT_HTTP_STATUSES.has(response.status) && attempt < maxAttempts) {
+          clearTimeout(timeout);
+          await sleepImpl(retryBaseDelayMs * 2 ** (attempt - 1));
+          continue;
+        }
+        throw error;
+      }
+
+      const payload = await response.json() as HorizonsPayload;
+      if (payload.error) throw new Error("horizons_api_error");
+      if (!payload.signature?.source?.toLowerCase().includes("jpl")) {
+        throw new Error("horizons_signature_invalid");
+      }
+      if (!payload.result) throw new Error("horizons_result_missing");
+
+      const longitude = parseHorizonsLongitude(payload.result);
+      return {
+        body,
+        sign: signFromLongitude(longitude),
+        longitude,
+        source: HORIZONS_SOURCE,
+        engine: HORIZONS_ENGINE,
+        calculatedAt: new Date().toISOString(),
+        inputTimestamp: new Date(inputTimestamp).toISOString(),
+      };
+    } finally {
+      clearTimeout(timeout);
     }
-    if (!payload.result) throw new Error("horizons_result_missing");
-
-    const longitude = parseHorizonsLongitude(payload.result);
-    return {
-      body,
-      sign: signFromLongitude(longitude),
-      longitude,
-      source: HORIZONS_SOURCE,
-      engine: HORIZONS_ENGINE,
-      calculatedAt: new Date().toISOString(),
-      inputTimestamp: new Date(inputTimestamp).toISOString(),
-    };
-  } finally {
-    clearTimeout(timeout);
   }
+
+  throw new Error("horizons_retry_exhausted");
 }

--- a/tests/jpl-horizons-reference.test.ts
+++ b/tests/jpl-horizons-reference.test.ts
@@ -16,6 +16,11 @@ $$EOE
 *******************************************************************************
 `;
 
+const validPayload = JSON.stringify({
+  signature: { source: "NASA/JPL Horizons API", version: "1.3" },
+  result: sampleResult,
+});
+
 test("builds an official geocentric quantity-31 request for the same UTC instant", () => {
   const url = new URL(buildHorizonsReferenceUrl("Sun", "1990-09-17T15:11:00.000Z"));
 
@@ -34,10 +39,10 @@ test("parses the named Horizons ecliptic-longitude column instead of guessing a 
 });
 
 test("creates an independent Sun reference with provenance but does not promote it", async () => {
-  const fetchImpl = async () => new Response(JSON.stringify({
-    signature: { source: "NASA/JPL Horizons API", version: "1.3" },
-    result: sampleResult,
-  }), { status: 200, headers: { "Content-Type": "application/json" } });
+  const fetchImpl = async () => new Response(validPayload, {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
 
   const reference = await fetchHorizonsReference("Sun", "1990-09-17T15:11:00.000Z", { fetchImpl });
 
@@ -53,6 +58,67 @@ test("creates an independent Sun reference with provenance but does not promote 
 test("uses the Moon major-body command for Moon references", () => {
   const url = new URL(buildHorizonsReferenceUrl("Moon", "1990-09-17T15:11:00.000Z"));
   assert.equal(url.searchParams.get("COMMAND"), "'301'");
+});
+
+test("retries transient Horizons availability failures with bounded exponential backoff", async () => {
+  let calls = 0;
+  const delays: number[] = [];
+  const fetchImpl = async () => {
+    calls += 1;
+    if (calls < 3) return new Response("database unavailable", { status: 500 });
+    return new Response(validPayload, { status: 200, headers: { "Content-Type": "application/json" } });
+  };
+
+  const reference = await fetchHorizonsReference("Sun", "1990-09-17T15:11:00.000Z", {
+    fetchImpl,
+    maxAttempts: 3,
+    retryBaseDelayMs: 10,
+    sleepImpl: async (milliseconds) => { delays.push(milliseconds); },
+  });
+
+  assert.equal(reference.longitude, 174.27);
+  assert.equal(calls, 3);
+  assert.deepEqual(delays, [10, 20]);
+});
+
+test("fails closed after transient Horizons retry budget is exhausted", async () => {
+  let calls = 0;
+  const delays: number[] = [];
+  const fetchImpl = async () => {
+    calls += 1;
+    return new Response("database unavailable", { status: 500 });
+  };
+
+  await assert.rejects(
+    fetchHorizonsReference("Sun", "1990-09-17T15:11:00.000Z", {
+      fetchImpl,
+      maxAttempts: 3,
+      retryBaseDelayMs: 5,
+      sleepImpl: async (milliseconds) => { delays.push(milliseconds); },
+    }),
+    /horizons_http_500/,
+  );
+
+  assert.equal(calls, 3);
+  assert.deepEqual(delays, [5, 10]);
+});
+
+test("does not retry permanent HTTP client errors", async () => {
+  let calls = 0;
+  const fetchImpl = async () => {
+    calls += 1;
+    return new Response("bad request", { status: 400 });
+  };
+
+  await assert.rejects(
+    fetchHorizonsReference("Sun", "1990-09-17T15:11:00.000Z", {
+      fetchImpl,
+      maxAttempts: 4,
+      sleepImpl: async () => undefined,
+    }),
+    /horizons_http_400/,
+  );
+  assert.equal(calls, 1);
 });
 
 test("rejects unsigned, malformed, or incomplete Horizons responses", async () => {


### PR DESCRIPTION
## Summary
Harden the NASA/JPL Horizons independent-reference lane without weakening evidence semantics.

## What changed
- bounded exponential retry for transient HTTP 429/500/502/503/504 responses;
- no retry for permanent 4xx or malformed/unsigned evidence;
- structured fail-closed outage receipt is written before the live job exits non-zero;
- live receipt artifact uploads even when the reference service is unavailable;
- unit tests lock retry, exhaustion, and non-retry behavior;
- live workflow no longer runs on every unrelated PR. It runs manually, daily, and on relevant pushes to main.

## Evidence basis
The repeated CI failure is `horizons_http_500`. NASA/JPL Horizons API documentation defines HTTP 500 as the database being unavailable at the time of the request. The workflow therefore preserves service unavailability as an explicit evidence state instead of treating it as a Soul Codex calculation regression.

## Governance
This does NOT convert an unavailable reference into a PASS. Live evidence still exits non-zero on service outage, parser failure, invalid signature, or sign disagreement. The change only separates external live-reference availability from unrelated application PR validation.

## Validation required
- normal CI/typecheck/test/build green;
- `tests/jpl-horizons-reference.test.ts` green;
- review confirms fail-closed semantics remain intact.

A future successful scheduled/manual live run remains required for a positive independent-reference receipt.