### PR TITLE
Release: activate consumer Apple authentication and session ownership

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
           tests/active-profile-contract.test.ts
           tests/ui-backend-consistency-contract.test.ts
           tests/billing-security.test.ts
+          tests/active-consumer-auth.test.ts
 
       - name: Run Foundation Web RC Invariant Audit
         run: node scripts/verify-foundation-web-rc.mjs

--- a/.github/workflows/gate4-lifecycle-validation.yml
+++ b/.github/workflows/gate4-lifecycle-validation.yml
@@ -10,11 +10,15 @@ on:
       - "client/src/lib/ActiveProfileRepository.ts"
       - "client/src/lib/offlineProfileStore.ts"
       - "client/src/lib/__tests__/ActiveProfileRepository.test.ts"
+      - "server/auth/**"
+      - "server/routes/consumer-auth.ts"
       - "server/routes.ts"
       - "server/storage.ts"
       - "server/session.ts"
       - "server/db.ts"
       - "shared/schema.ts"
+      - "tests/active-consumer-auth.test.ts"
+      - "tests/active-consumer-auth-postgres.test.ts"
       - "tests/gate4-profile-lifecycle.test.ts"
       - "tests/account-deletion.test.ts"
       - "tests/gate4-production-deletion.test.ts"
@@ -32,7 +36,7 @@ concurrency:
 
 jobs:
   lifecycle-contracts:
-    name: Profile and deletion contracts
+    name: Profile, auth, and deletion contracts
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -84,6 +88,9 @@ jobs:
 
       - name: Run Gate 4 profile lifecycle contracts
         run: node --import tsx --test tests/gate4-profile-lifecycle.test.ts
+
+      - name: Run active consumer auth contract against PostgreSQL
+        run: node --import tsx --test tests/active-consumer-auth-postgres.test.ts
 
       - name: Run account deletion storage contracts
         shell: bash

--- a/client/src/components/AppleSignInButton.tsx
+++ b/client/src/components/AppleSignInButton.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import { Capacitor } from "@capacitor/core";
 import { AppleSignIn } from "@capawesome/capacitor-apple-sign-in";
 import { apiRequest, queryClient } from "../lib/queryClient";
-import { useLocation } from "wouter";
 
 interface Props {
   onSuccess?: (user: any) => void;
@@ -12,45 +11,34 @@ interface Props {
 
 export default function AppleSignInButton({ onSuccess, text = "Sign in with Apple", className = "" }: Props) {
   const [loading, setLoading] = useState(false);
-  const [, navigate] = useLocation();
 
   const handleAppleSignIn = async () => {
     setLoading(true);
     try {
       if (Capacitor.isNativePlatform()) {
-        // ── NATIVE FLOW (Capacitor) ──────────────────────────────────────
         const result = await AppleSignIn.signIn({
           state: "soul_codex_auth",
           scopes: ["email", "name"],
         });
 
-        if (result.identityToken) {
-          const loginData = await apiRequest("/api/auth/apple", {
-            method: "POST",
-            body: JSON.stringify({
-              identityToken: result.identityToken,
-              user: {
-                email: result.email,
-                name: result.givenName ? { firstName: result.givenName, lastName: result.familyName } : undefined,
-              },
-            }),
-          });
-
-          queryClient.setQueryData(["/api/user"], loginData.user);
-          if (onSuccess) onSuccess(loginData.user);
+        if (!result.identityToken) {
+          throw new Error("Apple did not return an identity token");
         }
+
+        const response = await apiRequest("POST", "/api/auth/apple", {
+          identityToken: result.identityToken,
+        });
+        const loginData = await response.json() as { user: any };
+
+        queryClient.setQueryData(["/api/user"], loginData.user);
+        queryClient.setQueryData(["/api/auth/user"], loginData.user);
+        if (onSuccess) onSuccess(loginData.user);
       } else {
-        // ── WEB FLOW (Fallback/Mock) ─────────────────────────────────────
-        // In a real production web app, you'd use the Apple JS SDK or a redirect.
-        // For Soul Codex, since it's a mobile-first Capacitor project, 
-        // we'll advise the user or provide a mock for local dev.
-        console.warn("[AppleAuth] Web logic not implemented. Use native for Apple Sign-In.");
-        alert("Apple Sign-In is optimized for our mobile app. Please use your email/password on web for now.");
+        alert("Sign in with Apple is available in the iPhone and iPad app.");
       }
     } catch (err: any) {
       console.error("[AppleAuth] Sign-in failed:", err);
-      // Don't alert on cancel
-      if (err.message && !err.message.includes("cancel")) {
+      if (err?.message && !String(err.message).toLowerCase().includes("cancel")) {
         alert("Apple Sign-In failed. Please try again.");
       }
     } finally {
@@ -60,6 +48,8 @@ export default function AppleSignInButton({ onSuccess, text = "Sign in with Appl
 
   return (
     <button
+      type="button"
+      data-testid="button-sign-in-with-apple"
       onClick={handleAppleSignIn}
       disabled={loading}
       className={`apple-signin-btn ${className}`}
@@ -83,7 +73,7 @@ export default function AppleSignInButton({ onSuccess, text = "Sign in with Appl
         boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
       }}
     >
-      <svg width="18" height="22" viewBox="0 0 18 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <svg width="18" height="22" viewBox="0 0 18 22" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
         <path d="M15.4243 11.458C15.4086 8.52841 17.8486 7.10659 17.9621 7.03295C16.5925 5.03409 14.4754 4.7571 13.7275 4.72443C11.9547 4.54489 10.2311 5.76989 9.32932 5.76989C8.42318 5.76989 7.03159 4.77344 5.54523 4.80284C3.60159 4.83139 1.82114 5.93736 0.822501 7.67457C-1.20932 11.1896 0.301592 16.3774 2.27091 19.2237C3.23864 20.6135 4.3725 22.1803 5.86796 22.124C7.31023 22.0676 7.85409 21.1963 9.61068 21.1963C11.3632 21.1963 11.8673 22.124 13.3857 22.0963C14.9407 22.0676 15.9309 20.669 16.8905 19.2793C17.9941 17.671 18.4552 16.1132 18.4773 16.0355C18.4418 16.0216 15.4416 14.8727 15.4243 11.458ZM12.7566 3.1206C13.5516 2.15582 14.1032 0.824858 13.9536 -0.5C12.8091 -0.450994 11.4116 0.272159 10.5891 1.23366C9.85182 2.08835 9.20659 3.44759 9.37841 4.74489C10.6552 4.84375 11.9702 4.07685 12.7566 3.1206Z" fill="white"/>
       </svg>
       <span>{loading ? "Connecting..." : text}</span>

--- a/client/src/components/AppleSignInButton.tsx
+++ b/client/src/components/AppleSignInButton.tsx
@@ -1,12 +1,18 @@
 import { useState } from "react";
 import { Capacitor } from "@capacitor/core";
-import { AppleSignIn } from "@capawesome/capacitor-apple-sign-in";
+import { AppleSignIn, SignInScope } from "@capawesome/capacitor-apple-sign-in";
 import { apiRequest, queryClient } from "../lib/queryClient";
 
 interface Props {
   onSuccess?: (user: any) => void;
   text?: string;
   className?: string;
+}
+
+function randomState(): string {
+  const bytes = new Uint8Array(16);
+  globalThis.crypto.getRandomValues(bytes);
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
 export default function AppleSignInButton({ onSuccess, text = "Sign in with Apple", className = "" }: Props) {
@@ -16,17 +22,21 @@ export default function AppleSignInButton({ onSuccess, text = "Sign in with Appl
     setLoading(true);
     try {
       if (Capacitor.isNativePlatform()) {
+        const state = randomState();
         const result = await AppleSignIn.signIn({
-          state: "soul_codex_auth",
-          scopes: ["email", "name"],
+          state,
+          scopes: [SignInScope.Email, SignInScope.FullName],
         });
 
-        if (!result.identityToken) {
-          throw new Error("Apple did not return an identity token");
+        if (result.state && result.state !== state) {
+          throw new Error("Apple Sign-In state validation failed");
+        }
+        if (!result.idToken) {
+          throw new Error("Apple did not return an ID token");
         }
 
         const response = await apiRequest("POST", "/api/auth/apple", {
-          identityToken: result.identityToken,
+          identityToken: result.idToken,
         });
         const loginData = await response.json() as { user: any };
 

--- a/client/src/pages/SettingsPage.tsx
+++ b/client/src/pages/SettingsPage.tsx
@@ -1,9 +1,23 @@
 import { useLocation } from "wouter";
+import { useQuery } from "@tanstack/react-query";
 import Navigation from "@/components/navigation";
+import AppleSignInButton from "@/components/AppleSignInButton";
 import { IconAlert, IconInfo, IconLock } from "../components/Icons";
+import { apiRequest, queryClient } from "../lib/queryClient";
+
+type CurrentUser = {
+  id: string;
+  username: string;
+  email?: string | null;
+  authProvider?: string;
+};
 
 export default function SettingsPage() {
   const [, navigate] = useLocation();
+  const { data: currentUser, isLoading: userLoading } = useQuery<CurrentUser | null>({
+    queryKey: ["/api/auth/user"],
+    refetchOnMount: true,
+  });
 
   const clearLocalData = () => {
     const confirmed = window.confirm(
@@ -14,6 +28,12 @@ export default function SettingsPage() {
 
     localStorage.clear();
     window.location.href = "/";
+  };
+
+  const logout = async () => {
+    await apiRequest("POST", "/api/auth/logout");
+    queryClient.setQueryData(["/api/auth/user"], null);
+    queryClient.setQueryData(["/api/user"], null);
   };
 
   return (
@@ -34,11 +54,66 @@ export default function SettingsPage() {
             Settings
           </h1>
           <p style={{ color: "var(--sc-stone)", lineHeight: 1.7 }}>
-            Manage local data, privacy information, and support access.
+            Manage your account, local data, privacy information, and support access.
           </p>
         </div>
 
         <div className="stagger">
+          <section
+            className="glassmorphism"
+            style={{
+              padding: "clamp(1.25rem, 5vw, 2rem)",
+              borderRadius: 24,
+              marginBottom: "1.5rem",
+            }}
+          >
+            <h2 className="section-label" style={{ marginBottom: "1rem" }}>
+              Account
+            </h2>
+            {userLoading ? (
+              <p style={{ color: "var(--sc-stone)", margin: 0 }}>Checking account status...</p>
+            ) : currentUser ? (
+              <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+                <div>
+                  <p style={{ margin: 0, color: "var(--sc-ivory)", fontWeight: 600 }}>
+                    Signed in with {currentUser.authProvider === "apple" ? "Apple" : "your account"}
+                  </p>
+                  <p style={{ margin: "0.35rem 0 0", color: "var(--sc-stone)", fontSize: "0.9rem" }}>
+                    {currentUser.email || "Private Apple account"}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  data-testid="button-logout"
+                  onClick={logout}
+                  style={{
+                    width: "100%",
+                    padding: "0.9rem 1rem",
+                    borderRadius: 12,
+                    border: "1px solid rgba(255,255,255,0.14)",
+                    background: "rgba(255,255,255,0.04)",
+                    color: "var(--sc-ivory)",
+                    cursor: "pointer",
+                    fontWeight: 600,
+                  }}
+                >
+                  Sign Out
+                </button>
+              </div>
+            ) : (
+              <div>
+                <p style={{ color: "var(--sc-stone)", lineHeight: 1.65, fontSize: "0.9rem" }}>
+                  Sign in on iPhone or iPad to attach this device's Soul Codex profile to your account and keep server-backed data under one identity.
+                </p>
+                <AppleSignInButton
+                  onSuccess={(user) => {
+                    queryClient.setQueryData(["/api/auth/user"], { ...user, authProvider: "apple" });
+                  }}
+                />
+              </div>
+            )}
+          </section>
+
           <section
             className="glassmorphism"
             style={{

--- a/server/auth/apple.ts
+++ b/server/auth/apple.ts
@@ -8,14 +8,22 @@ export type AppleIdentity = {
 export class AppleAuthConfigurationError extends Error {}
 export class AppleAuthVerificationError extends Error {}
 
+type AppleTokenClaims = {
+  sub?: unknown;
+  email?: unknown;
+};
+
 type VerifyAppleToken = (
   token: string,
   options: { audience: string; ignoreExpiration: boolean },
-) => Promise<Record<string, unknown>>;
+) => Promise<AppleTokenClaims>;
+
+const defaultAppleVerifier: VerifyAppleToken = (token, options) =>
+  appleSignin.verifyIdToken(token, options);
 
 export async function verifyAppleIdentityToken(
   identityToken: string,
-  verifier: VerifyAppleToken = appleSignin.verifyIdToken as VerifyAppleToken,
+  verifier: VerifyAppleToken = defaultAppleVerifier,
 ): Promise<AppleIdentity> {
   const audience = process.env.APPLE_CLIENT_ID?.trim();
   if (!audience) {
@@ -25,7 +33,7 @@ export async function verifyAppleIdentityToken(
     throw new AppleAuthVerificationError("identityToken is required");
   }
 
-  let claims: Record<string, unknown>;
+  let claims: AppleTokenClaims;
   try {
     claims = await verifier(identityToken, { audience, ignoreExpiration: false });
   } catch {

--- a/server/auth/apple.ts
+++ b/server/auth/apple.ts
@@ -1,0 +1,44 @@
+import appleSignin from "apple-signin-auth";
+
+export type AppleIdentity = {
+  subject: string;
+  email: string | null;
+};
+
+export class AppleAuthConfigurationError extends Error {}
+export class AppleAuthVerificationError extends Error {}
+
+type VerifyAppleToken = (
+  token: string,
+  options: { audience: string; ignoreExpiration: boolean },
+) => Promise<Record<string, unknown>>;
+
+export async function verifyAppleIdentityToken(
+  identityToken: string,
+  verifier: VerifyAppleToken = appleSignin.verifyIdToken as VerifyAppleToken,
+): Promise<AppleIdentity> {
+  const audience = process.env.APPLE_CLIENT_ID?.trim();
+  if (!audience) {
+    throw new AppleAuthConfigurationError("APPLE_CLIENT_ID is not configured");
+  }
+  if (!identityToken?.trim()) {
+    throw new AppleAuthVerificationError("identityToken is required");
+  }
+
+  let claims: Record<string, unknown>;
+  try {
+    claims = await verifier(identityToken, { audience, ignoreExpiration: false });
+  } catch {
+    throw new AppleAuthVerificationError("Apple identity token verification failed");
+  }
+
+  const subject = typeof claims.sub === "string" ? claims.sub.trim() : "";
+  if (!subject) {
+    throw new AppleAuthVerificationError("Apple identity token is missing subject");
+  }
+
+  return {
+    subject,
+    email: typeof claims.email === "string" && claims.email.trim() ? claims.email.trim() : null,
+  };
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2,6 +2,7 @@ import type { Express } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
 import { setupSession } from "./session";
+import { registerConsumerAuthRoutes } from "./routes/consumer-auth";
 import {
   birthDataSchema,
   enneagramAssessmentSchema,
@@ -44,10 +45,11 @@ function withVerifiedLegacyAliases(astrologyData: AstrologyData) {
 
 export async function registerRoutes(app: Express): Promise<Server> {
   setupSession(app);
+  registerConsumerAuthRoutes(app);
 
   app.delete("/api/auth/account", async (req: any, res) => {
     try {
-      const userId = req.user?.id || req.user?.claims?.sub || null;
+      const userId = req.session?.userId ?? null;
       const sessionId = req.sessionID || null;
       if (userId) await storage.deleteUserAccount(userId);
       else if (sessionId) await storage.deleteSessionData(sessionId);
@@ -99,9 +101,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
         archetype: archetypeData,
       });
 
+      const authenticatedUserId = req.session?.userId ?? null;
       const profile = await storage.createProfile({
-        userId: req.user?.id ?? null,
-        sessionId: req.user?.id ? null : (req.sessionID ?? null),
+        userId: authenticatedUserId,
+        sessionId: authenticatedUserId ? null : (req.sessionID ?? null),
         name: birthData.name,
         birthDate: new Date(birthData.birthDate),
         birthTime: birthData.birthTime,
@@ -117,7 +120,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         biography,
         dailyGuidance,
       });
-      if (!req.user && req.session) req.session.profileCreated = true;
+      if (!authenticatedUserId && req.session) req.session.profileCreated = true;
       res.status(201).json(profile);
     } catch (error) {
       console.error("Error creating profile:", error);

--- a/server/routes/consumer-auth.ts
+++ b/server/routes/consumer-auth.ts
@@ -1,0 +1,105 @@
+import type { Express } from "express";
+import { storage, type IStorage } from "../storage";
+import {
+  AppleAuthConfigurationError,
+  AppleAuthVerificationError,
+  verifyAppleIdentityToken,
+  type AppleIdentity,
+} from "../auth/apple";
+
+type AppleVerifier = (identityToken: string) => Promise<AppleIdentity>;
+
+type ConsumerAuthDependencies = {
+  storage: IStorage;
+  verifyApple: AppleVerifier;
+};
+
+function publicUser(user: Awaited<ReturnType<IStorage["getUser"]>>) {
+  if (!user) return null;
+  const { password: _password, ...safe } = user;
+  return safe;
+}
+
+function regenerateSession(req: any): Promise<void> {
+  return new Promise((resolve, reject) => {
+    req.session.regenerate((error: unknown) => error ? reject(error) : resolve());
+  });
+}
+
+function saveSession(req: any): Promise<void> {
+  return new Promise((resolve, reject) => {
+    req.session.save((error: unknown) => error ? reject(error) : resolve());
+  });
+}
+
+function destroySession(req: any): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (!req.session) return resolve();
+    req.session.destroy((error: unknown) => error ? reject(error) : resolve());
+  });
+}
+
+export function registerConsumerAuthRoutes(
+  app: Express,
+  deps: ConsumerAuthDependencies = { storage, verifyApple: verifyAppleIdentityToken },
+) {
+  app.post("/api/auth/apple", async (req: any, res) => {
+    try {
+      const identityToken = typeof req.body?.identityToken === "string" ? req.body.identityToken : "";
+      const identity = await deps.verifyApple(identityToken);
+      const previousSessionId = req.sessionID;
+      const user = await deps.storage.getOrCreateAppleUser(identity.subject, identity.email);
+
+      if (previousSessionId) {
+        await deps.storage.migrateSessionOwnershipToUser(previousSessionId, user.id);
+      }
+
+      await regenerateSession(req);
+      req.session.userId = user.id;
+      req.session.authProvider = "apple";
+      await saveSession(req);
+
+      return res.json({ user: publicUser(user), message: "Successfully authenticated with Apple" });
+    } catch (error) {
+      if (error instanceof AppleAuthConfigurationError) {
+        return res.status(503).json({ message: "Apple Sign-In is not configured on the server" });
+      }
+      if (error instanceof AppleAuthVerificationError) {
+        return res.status(401).json({ message: "Apple identity token could not be verified" });
+      }
+      console.error("[AppleAuth] Failed:", error);
+      return res.status(500).json({ message: "Apple Sign-In failed" });
+    }
+  });
+
+  const currentUser = async (req: any, res: any) => {
+    try {
+      const userId = req.session?.userId;
+      if (!userId) return res.json(null);
+      const user = await deps.storage.getUser(userId);
+      if (!user) {
+        await destroySession(req).catch(() => undefined);
+        res.clearCookie("connect.sid");
+        return res.json(null);
+      }
+      return res.json({ ...publicUser(user), authProvider: req.session?.authProvider ?? "apple" });
+    } catch (error) {
+      console.error("[CurrentUser] Failed:", error);
+      return res.status(500).json({ message: "Failed to fetch user" });
+    }
+  };
+
+  app.get("/api/auth/user", currentUser);
+  app.get("/api/user", currentUser);
+
+  app.post("/api/auth/logout", async (req: any, res) => {
+    try {
+      await destroySession(req);
+      res.clearCookie("connect.sid");
+      return res.json({ message: "Logged out successfully" });
+    } catch (error) {
+      console.error("[Logout] Failed:", error);
+      return res.status(500).json({ message: "Failed to logout" });
+    }
+  });
+}

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -210,9 +210,7 @@ class PostgresStorage implements IStorage {
   async getOrCreateAppleUser(subject: string, email?: string | null, firstName?: string | null, lastName?: string | null): Promise<User> {
     const db = await this.db();
     const username = appleUsername(subject);
-    const existing = (await db.select().from(users).where(eq(users.username, username)).limit(1))[0];
-    if (existing) return existing;
-    return (await db.insert(users).values({
+    const inserted = await db.insert(users).values({
       username,
       password: `apple-disabled:${randomUUID()}:${randomUUID()}`,
       email: email ?? null,
@@ -220,7 +218,11 @@ class PostgresStorage implements IStorage {
       lastName: lastName ?? null,
       subscriptionStatus: "free",
       isPremium: false,
-    }).returning())[0];
+    }).onConflictDoNothing({ target: users.username }).returning();
+    if (inserted[0]) return inserted[0];
+    const existing = (await db.select().from(users).where(eq(users.username, username)).limit(1))[0];
+    if (!existing) throw new Error("Apple user could not be resolved after concurrent creation");
+    return existing;
   }
   async migrateSessionOwnershipToUser(sessionId: string, userId: string): Promise<void> {
     const db = await this.db();

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "crypto";
-import { eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, isNull } from "drizzle-orm";
 import {
   users,
   profiles,
@@ -14,10 +14,16 @@ import {
   type InsertAssessment,
 } from "@shared/schema";
 
+function appleUsername(subject: string) {
+  return `apple:${subject}`;
+}
+
 export interface IStorage {
   getUser(id: string): Promise<User | undefined>;
   getUserByUsername(username: string): Promise<User | undefined>;
   createUser(user: InsertUser): Promise<User>;
+  getOrCreateAppleUser(subject: string, email?: string | null, firstName?: string | null, lastName?: string | null): Promise<User>;
+  migrateSessionOwnershipToUser(sessionId: string, userId: string): Promise<void>;
   getProfile(id: string): Promise<Profile | undefined>;
   getProfileByUserId(userId: string): Promise<Profile | undefined>;
   createProfile(profile: InsertProfile): Promise<Profile>;
@@ -58,6 +64,38 @@ export class MemStorage implements IStorage {
     } satisfies User;
     this.users.set(user.id, user);
     return user;
+  }
+  async getOrCreateAppleUser(subject: string, email?: string | null, firstName?: string | null, lastName?: string | null): Promise<User> {
+    const username = appleUsername(subject);
+    const existing = await this.getUserByUsername(username);
+    if (existing) return existing;
+    const now = new Date();
+    const user = {
+      id: randomUUID(),
+      username,
+      password: `apple-disabled:${randomUUID()}:${randomUUID()}`,
+      email: email ?? null,
+      firstName: firstName ?? null,
+      lastName: lastName ?? null,
+      profileImageUrl: null,
+      stripeCustomerId: null,
+      stripeSubscriptionId: null,
+      subscriptionStatus: "free",
+      subscriptionPlan: null,
+      subscriptionEndsAt: null,
+      isPremium: false,
+      createdAt: now,
+      updatedAt: now,
+    } satisfies User;
+    this.users.set(user.id, user);
+    return user;
+  }
+  async migrateSessionOwnershipToUser(sessionId: string, userId: string): Promise<void> {
+    for (const [id, profile] of this.profiles) {
+      if (profile.sessionId === sessionId && !profile.userId) {
+        this.profiles.set(id, { ...profile, userId, sessionId: null, updatedAt: new Date() });
+      }
+    }
   }
   async getProfile(id: string) { return this.profiles.get(id); }
   async getProfileByUserId(userId: string) {
@@ -168,6 +206,30 @@ class PostgresStorage implements IStorage {
   async createUser(insertUser: InsertUser): Promise<User> {
     const db = await this.db();
     return (await db.insert(users).values(insertUser).returning())[0];
+  }
+  async getOrCreateAppleUser(subject: string, email?: string | null, firstName?: string | null, lastName?: string | null): Promise<User> {
+    const db = await this.db();
+    const username = appleUsername(subject);
+    const existing = (await db.select().from(users).where(eq(users.username, username)).limit(1))[0];
+    if (existing) return existing;
+    return (await db.insert(users).values({
+      username,
+      password: `apple-disabled:${randomUUID()}:${randomUUID()}`,
+      email: email ?? null,
+      firstName: firstName ?? null,
+      lastName: lastName ?? null,
+      subscriptionStatus: "free",
+      isPremium: false,
+    }).returning())[0];
+  }
+  async migrateSessionOwnershipToUser(sessionId: string, userId: string): Promise<void> {
+    const db = await this.db();
+    await db.update(profiles)
+      .set({ userId, sessionId: null, updatedAt: new Date() })
+      .where(and(eq(profiles.sessionId, sessionId), isNull(profiles.userId)));
+    await db.update(accessCodeRedemptions)
+      .set({ userId, sessionId: null })
+      .where(and(eq(accessCodeRedemptions.sessionId, sessionId), isNull(accessCodeRedemptions.userId)));
   }
   async getProfile(id: string) {
     const db = await this.db();

--- a/tests/active-consumer-auth-postgres.test.ts
+++ b/tests/active-consumer-auth-postgres.test.ts
@@ -58,8 +58,9 @@ test("PostgreSQL active auth migrates session profile into canonical Apple user"
       headers: { "content-type": "application/json", Cookie: bootstrapCookie },
       body: JSON.stringify({ identityToken: "ci-injected-verified-token" }),
     });
-    assert.equal(login.status, 200, await login.text());
-    const loginBody = await login.json() as any;
+    const loginText = await login.text();
+    assert.equal(login.status, 200, loginText);
+    const loginBody = JSON.parse(loginText) as any;
     const authCookie = cookieFrom(login);
 
     const migrated = await storage.getProfile(profile.id);

--- a/tests/active-consumer-auth-postgres.test.ts
+++ b/tests/active-consumer-auth-postgres.test.ts
@@ -24,6 +24,19 @@ function cookieFrom(response: Response) {
   return (response.headers.get("set-cookie") || "").split(";")[0];
 }
 
+test("PostgreSQL Apple user resolution is concurrency-safe", async () => {
+  assert.ok(process.env.DATABASE_URL, "DATABASE_URL is required");
+  const subject = `concurrent-subject-${Date.now()}`;
+  const users = await Promise.all([
+    storage.getOrCreateAppleUser(subject, "race@example.com"),
+    storage.getOrCreateAppleUser(subject, "race@example.com"),
+    storage.getOrCreateAppleUser(subject, "race@example.com"),
+    storage.getOrCreateAppleUser(subject, "race@example.com"),
+  ]);
+  assert.equal(new Set(users.map((user) => user.id)).size, 1);
+  await storage.deleteUserAccount(users[0].id);
+});
+
 test("PostgreSQL active auth migrates session profile into canonical Apple user", async () => {
   assert.ok(process.env.DATABASE_URL, "DATABASE_URL is required");
   assert.ok(process.env.SESSION_SECRET, "SESSION_SECRET is required");

--- a/tests/active-consumer-auth-postgres.test.ts
+++ b/tests/active-consumer-auth-postgres.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import express from "express";
+import { setupSession } from "../server/session";
+import { registerConsumerAuthRoutes } from "../server/routes/consumer-auth";
+import { storage } from "../server/storage";
+
+async function withServer(app: express.Express, run: (baseUrl: string) => Promise<void>) {
+  const server = app.listen(0, "127.0.0.1");
+  await new Promise<void>((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("test server did not bind");
+  try {
+    await run(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  }
+}
+
+function cookieFrom(response: Response) {
+  return (response.headers.get("set-cookie") || "").split(";")[0];
+}
+
+test("PostgreSQL active auth migrates session profile into canonical Apple user", async () => {
+  assert.ok(process.env.DATABASE_URL, "DATABASE_URL is required");
+  assert.ok(process.env.SESSION_SECRET, "SESSION_SECRET is required");
+
+  const app = express();
+  app.use(express.json());
+  setupSession(app);
+  app.post("/__auth/session", (req: any, res) => {
+    req.session.started = true;
+    res.json({ sessionId: req.sessionID });
+  });
+  registerConsumerAuthRoutes(app, {
+    storage,
+    verifyApple: async () => ({ subject: `postgres-subject-${Date.now()}`, email: "postgres-auth@example.com" }),
+  });
+
+  await withServer(app, async (baseUrl) => {
+    const bootstrap = await fetch(`${baseUrl}/__auth/session`, { method: "POST" });
+    assert.equal(bootstrap.status, 200);
+    const bootstrapCookie = cookieFrom(bootstrap);
+    const { sessionId } = await bootstrap.json() as { sessionId: string };
+
+    const profile = await storage.createProfile({
+      sessionId,
+      userId: null,
+      name: "Postgres Auth Profile",
+      birthDate: new Date("1990-09-17T00:00:00.000Z"),
+    });
+
+    const login = await fetch(`${baseUrl}/api/auth/apple`, {
+      method: "POST",
+      headers: { "content-type": "application/json", Cookie: bootstrapCookie },
+      body: JSON.stringify({ identityToken: "ci-injected-verified-token" }),
+    });
+    assert.equal(login.status, 200, await login.text());
+    const loginBody = await login.json() as any;
+    const authCookie = cookieFrom(login);
+
+    const migrated = await storage.getProfile(profile.id);
+    assert.equal(migrated?.userId, loginBody.user.id);
+    assert.equal(migrated?.sessionId, null);
+
+    const current = await fetch(`${baseUrl}/api/auth/user`, { headers: { Cookie: authCookie } });
+    assert.equal(current.status, 200);
+    const currentBody = await current.json() as any;
+    assert.equal(currentBody.id, loginBody.user.id);
+    assert.equal(currentBody.authProvider, "apple");
+    assert.equal("password" in currentBody, false);
+
+    await storage.deleteUserAccount(loginBody.user.id);
+  });
+});

--- a/tests/active-consumer-auth.test.ts
+++ b/tests/active-consumer-auth.test.ts
@@ -117,8 +117,9 @@ test("active Apple auth rotates session, migrates anonymous profile, exposes saf
       headers: { "content-type": "application/json", Cookie: firstCookie },
       body: JSON.stringify({ identityToken: "verified-apple-token" }),
     });
-    assert.equal(login.status, 200, await login.text());
-    const loginBody = await login.json() as any;
+    const loginText = await login.text();
+    assert.equal(login.status, 200, loginText);
+    const loginBody = JSON.parse(loginText) as any;
     assert.equal(loginBody.user.email, "verified@example.com");
     assert.equal("password" in loginBody.user, false);
     assert.equal(loginBody.user.username, "apple:apple-subject-42");

--- a/tests/active-consumer-auth.test.ts
+++ b/tests/active-consumer-auth.test.ts
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import express from "express";
+import session from "express-session";
+import { MemStorage } from "../server/storage";
+import { registerConsumerAuthRoutes } from "../server/routes/consumer-auth";
+import {
+  AppleAuthConfigurationError,
+  AppleAuthVerificationError,
+  verifyAppleIdentityToken,
+} from "../server/auth/apple";
+
+async function withServer(app: express.Express, run: (baseUrl: string) => Promise<void>) {
+  const server = app.listen(0, "127.0.0.1");
+  await new Promise<void>((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("test server did not bind");
+  try {
+    await run(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  }
+}
+
+function cookieFrom(response: Response) {
+  const raw = response.headers.get("set-cookie") || "";
+  return raw.split(";")[0];
+}
+
+test("Apple verifier is fail-closed when server audience is missing", async () => {
+  const previous = process.env.APPLE_CLIENT_ID;
+  delete process.env.APPLE_CLIENT_ID;
+  try {
+    await assert.rejects(
+      () => verifyAppleIdentityToken("token", async () => ({ sub: "apple-subject" })),
+      AppleAuthConfigurationError,
+    );
+  } finally {
+    if (previous === undefined) delete process.env.APPLE_CLIENT_ID;
+    else process.env.APPLE_CLIENT_ID = previous;
+  }
+});
+
+test("Apple verifier normalizes verified subject and email", async () => {
+  const previous = process.env.APPLE_CLIENT_ID;
+  process.env.APPLE_CLIENT_ID = "com.soulcodex.app";
+  try {
+    const identity = await verifyAppleIdentityToken("token", async (_token, options) => {
+      assert.equal(options.audience, "com.soulcodex.app");
+      assert.equal(options.ignoreExpiration, false);
+      return { sub: "apple-subject-1", email: "person@example.com" };
+    });
+    assert.deepEqual(identity, { subject: "apple-subject-1", email: "person@example.com" });
+  } finally {
+    if (previous === undefined) delete process.env.APPLE_CLIENT_ID;
+    else process.env.APPLE_CLIENT_ID = previous;
+  }
+});
+
+test("Apple verifier rejects claims without a stable subject", async () => {
+  const previous = process.env.APPLE_CLIENT_ID;
+  process.env.APPLE_CLIENT_ID = "com.soulcodex.app";
+  try {
+    await assert.rejects(
+      () => verifyAppleIdentityToken("token", async () => ({ email: "person@example.com" })),
+      AppleAuthVerificationError,
+    );
+  } finally {
+    if (previous === undefined) delete process.env.APPLE_CLIENT_ID;
+    else process.env.APPLE_CLIENT_ID = previous;
+  }
+});
+
+test("active Apple auth rotates session, migrates anonymous profile, exposes safe current user, and logs out", async () => {
+  const storage = new MemStorage();
+  const app = express();
+  app.use(express.json());
+  app.use(session({
+    secret: "active-auth-contract-secret",
+    resave: false,
+    saveUninitialized: true,
+    cookie: { httpOnly: true, sameSite: "lax" },
+  }));
+
+  app.post("/__test/session", (req: any, res) => {
+    req.session.started = true;
+    res.json({ sessionId: req.sessionID });
+  });
+
+  registerConsumerAuthRoutes(app, {
+    storage,
+    verifyApple: async (token) => {
+      assert.equal(token, "verified-apple-token");
+      return { subject: "apple-subject-42", email: "verified@example.com" };
+    },
+  });
+
+  await withServer(app, async (baseUrl) => {
+    const bootstrap = await fetch(`${baseUrl}/__test/session`, { method: "POST" });
+    assert.equal(bootstrap.status, 200);
+    const firstCookie = cookieFrom(bootstrap);
+    assert.match(firstCookie, /^connect\.sid=/);
+    const { sessionId } = await bootstrap.json() as { sessionId: string };
+
+    const anonymousProfile = await storage.createProfile({
+      sessionId,
+      userId: null,
+      name: "Persistent Soul",
+      birthDate: new Date("1990-09-17T00:00:00.000Z"),
+    });
+
+    const login = await fetch(`${baseUrl}/api/auth/apple`, {
+      method: "POST",
+      headers: { "content-type": "application/json", Cookie: firstCookie },
+      body: JSON.stringify({ identityToken: "verified-apple-token" }),
+    });
+    assert.equal(login.status, 200, await login.text());
+    const loginBody = await login.json() as any;
+    assert.equal(loginBody.user.email, "verified@example.com");
+    assert.equal("password" in loginBody.user, false);
+    assert.equal(loginBody.user.username, "apple:apple-subject-42");
+
+    const authenticatedCookie = cookieFrom(login);
+    assert.match(authenticatedCookie, /^connect\.sid=/);
+    assert.notEqual(authenticatedCookie, firstCookie, "session id must rotate after authentication");
+
+    const migrated = await storage.getProfile(anonymousProfile.id);
+    assert.equal(migrated?.userId, loginBody.user.id);
+    assert.equal(migrated?.sessionId, null);
+
+    const current = await fetch(`${baseUrl}/api/auth/user`, { headers: { Cookie: authenticatedCookie } });
+    assert.equal(current.status, 200);
+    const currentBody = await current.json() as any;
+    assert.equal(currentBody.id, loginBody.user.id);
+    assert.equal(currentBody.authProvider, "apple");
+    assert.equal("password" in currentBody, false);
+
+    const alias = await fetch(`${baseUrl}/api/user`, { headers: { Cookie: authenticatedCookie } });
+    assert.equal((await alias.json() as any).id, loginBody.user.id);
+
+    const logout = await fetch(`${baseUrl}/api/auth/logout`, {
+      method: "POST",
+      headers: { Cookie: authenticatedCookie },
+    });
+    assert.equal(logout.status, 200);
+
+    const afterLogout = await fetch(`${baseUrl}/api/auth/user`, { headers: { Cookie: authenticatedCookie } });
+    assert.equal(afterLogout.status, 200);
+    assert.equal(await afterLogout.json(), null);
+  });
+});


### PR DESCRIPTION
## Summary
Activate the authentication surface the native client actually calls, on the production `server/routes.ts` stack.

## Runtime repair
- Add fail-closed Apple identity-token verification using `APPLE_CLIENT_ID`.
- Add active `POST /api/auth/apple`.
- Use canonical server session state (`req.session.userId`) rather than legacy Passport-only `req.user` assumptions.
- Rotate the session after authentication to prevent fixation.
- Reuse one canonical user per Apple subject via stable `apple:<subject>` username binding.
- Never expose the stored password/sentinel in API responses.
- Add active `GET /api/auth/user` and `/api/user` compatibility alias.
- Add active `POST /api/auth/logout`.
- Migrate anonymous session-owned profile/redemption data to the authenticated user.
- Update active profile creation and account deletion to honor authenticated session ownership.

## Evidence
- Fast auth contract proves fail-closed config, normalized verified claims, stable-subject enforcement, session rotation, anonymous-profile migration, safe current-user response, alias behavior, and logout.
- PostgreSQL contract runs against the real Postgres storage + Postgres session stack with injected verified Apple identity claims.
- Real Apple signature verification is intentionally not fabricated in CI; production uses `apple-signin-auth` by default and requires `APPLE_CLIENT_ID`.

## CI
- Register auth contract in the standard trust/security suite.
- Register PostgreSQL auth contract in Gate 4's DB-backed lifecycle job.
- Expand Gate 4 paths so future auth/session/storage changes cannot skip the persistent contract.

## Non-claims
This PR does not claim physical-device Apple Sign-In validation, App Store credential configuration, TestFlight validation, production deployment, or store submission.