### PR TITLE
Release: route native API traffic to production backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,9 +5,8 @@
 # DEMO MODE NOTE:
 #   Omitting DATABASE_URL runs the active Foundation server with MemStorage.
 #   Server-side profiles will be lost on restart. Local-first browser profiles
-#   remain on the user's device. Billing stays disabled in this mode because a
-#   paid entitlement must survive a process restart. Humanity has invented
-#   enough ways to lose receipts already.
+#   remain on the user's device. Billing and durable authenticated ownership
+#   require PostgreSQL in production.
 #
 
 # Server Configuration
@@ -20,16 +19,18 @@ APP_NAME=Soul Codex
 # Must be HTTPS in production. Localhost HTTP is accepted for development.
 PUBLIC_APP_URL=http://localhost:5000
 # VITE_APP_NAME=Soul Codex
+# Required when building the bundled iOS/Android apps. The client uses this
+# HTTPS origin for /api requests instead of the Capacitor localhost origin.
 # VITE_API_URL=https://api.your-production-domain.com
 # CAPACITOR_SERVER_URL=https://your-production-domain.com
 
 # Session
-# The active Foundation web server does not initialize cookie sessions.
-# Keep this only for legacy authenticated-route development until that route
-# stack is deliberately reconciled with the active server.
-# SESSION_SECRET=generate_a_strong_random_value
+# Required by the active production server. Use a long, random secret and keep
+# it stable across deploys so authenticated sessions do not disappear on every
+# restart. Production sessions are stored in PostgreSQL when DATABASE_URL is set.
+# SESSION_SECRET=generate_a_long_random_value
 
-# Database (PostgreSQL - required before secure billing can be enabled)
+# Database (PostgreSQL - required for durable accounts, profiles, and billing)
 # DATABASE_URL=postgresql://user:password@host:port/database
 
 # ------------------------------------------------------------------
@@ -48,7 +49,9 @@ PUBLIC_APP_URL=http://localhost:5000
 # Obtain a key from https://aistudio.google.com/
 GOOGLE_API_KEY=your_google_api_key_here
 
-# Apple Sign-In (paused until the native lane resumes)
+# Apple Sign-In
+# Native iOS identity tokens use the Xcode bundle/App ID as their audience.
+# This must match ios/App/App.xcodeproj: app.soulcodex.ios.
 # APPLE_CLIENT_ID=app.soulcodex.ios
 
 # ------------------------------------------------------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
           tests/ui-backend-consistency-contract.test.ts
           tests/billing-security.test.ts
           tests/active-consumer-auth.test.ts
+          tests/native-api-routing.test.ts
 
       - name: Run Foundation Web RC Invariant Audit
         run: node scripts/verify-foundation-web-rc.mjs

--- a/.github/workflows/gate4-lifecycle-validation.yml
+++ b/.github/workflows/gate4-lifecycle-validation.yml
@@ -7,18 +7,24 @@ on:
       - "client/src/App.tsx"
       - "client/src/pages/SettingsPage.tsx"
       - "client/src/pages/AccountDeletionPage.tsx"
+      - "client/src/pages/CompatibilityExplorerPage.tsx"
+      - "client/src/pages/offline-profile.tsx"
+      - "client/src/lib/queryClient.ts"
+      - "client/src/lib/api-url.ts"
       - "client/src/lib/ActiveProfileRepository.ts"
       - "client/src/lib/offlineProfileStore.ts"
       - "client/src/lib/__tests__/ActiveProfileRepository.test.ts"
       - "server/auth/**"
       - "server/routes/consumer-auth.ts"
       - "server/routes.ts"
+      - "server/index.ts"
       - "server/storage.ts"
       - "server/session.ts"
       - "server/db.ts"
       - "shared/schema.ts"
       - "tests/active-consumer-auth.test.ts"
       - "tests/active-consumer-auth-postgres.test.ts"
+      - "tests/native-api-routing.test.ts"
       - "tests/gate4-profile-lifecycle.test.ts"
       - "tests/account-deletion.test.ts"
       - "tests/gate4-production-deletion.test.ts"
@@ -91,6 +97,9 @@ jobs:
 
       - name: Run active consumer auth contract against PostgreSQL
         run: node --import tsx --test tests/active-consumer-auth-postgres.test.ts
+
+      - name: Run native API routing contract
+        run: node --import tsx --test tests/native-api-routing.test.ts
 
       - name: Run account deletion storage contracts
         shell: bash

--- a/client/src/lib/api-url.ts
+++ b/client/src/lib/api-url.ts
@@ -1,0 +1,9 @@
+export function normalizeApiBase(base: string | undefined): string {
+  return (base || "").trim().replace(/\/+$/, "");
+}
+
+export function resolveApiUrlWithBase(url: string, base: string | undefined): string {
+  if (!url.startsWith("/api/")) return url;
+  const normalizedBase = normalizeApiBase(base);
+  return normalizedBase ? `${normalizedBase}${url}` : url;
+}

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -1,10 +1,10 @@
 import { QueryClient, QueryFunction } from "@tanstack/react-query";
+import { resolveApiUrlWithBase } from "./api-url";
 
-const configuredApiBase = (import.meta.env.VITE_API_URL || "").trim().replace(/\/+$/, "");
+const configuredApiBase = import.meta.env.VITE_API_URL || "";
 
 export function resolveApiUrl(url: string): string {
-  if (!url.startsWith("/api/")) return url;
-  return configuredApiBase ? `${configuredApiBase}${url}` : url;
+  return resolveApiUrlWithBase(url, configuredApiBase);
 }
 
 export async function apiFetch(url: string, init: RequestInit = {}): Promise<Response> {

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -1,5 +1,19 @@
 import { QueryClient, QueryFunction } from "@tanstack/react-query";
 
+const configuredApiBase = (import.meta.env.VITE_API_URL || "").trim().replace(/\/+$/, "");
+
+export function resolveApiUrl(url: string): string {
+  if (!url.startsWith("/api/")) return url;
+  return configuredApiBase ? `${configuredApiBase}${url}` : url;
+}
+
+export async function apiFetch(url: string, init: RequestInit = {}): Promise<Response> {
+  return fetch(resolveApiUrl(url), {
+    ...init,
+    credentials: init.credentials ?? "include",
+  });
+}
+
 async function throwIfResNotOk(res: Response) {
   if (!res.ok) {
     const text = (await res.text()) || res.statusText;
@@ -12,11 +26,10 @@ export async function apiRequest(
   url: string,
   data?: unknown | undefined,
 ): Promise<Response> {
-  const res = await fetch(url, {
+  const res = await apiFetch(url, {
     method,
     headers: data ? { "Content-Type": "application/json" } : {},
     body: data ? JSON.stringify(data) : undefined,
-    credentials: "include",
   });
 
   await throwIfResNotOk(res);
@@ -29,9 +42,7 @@ export const getQueryFn: <T>(options: {
 }) => QueryFunction<T> =
   ({ on401: unauthorizedBehavior }) =>
   async ({ queryKey }) => {
-    const res = await fetch(queryKey.join("/") as string, {
-      credentials: "include",
-    });
+    const res = await apiFetch(queryKey.join("/") as string);
 
     if (unauthorizedBehavior === "returnNull" && res.status === 401) {
       return null;

--- a/client/src/pages/CompatibilityExplorerPage.tsx
+++ b/client/src/pages/CompatibilityExplorerPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import Navigation from "../components/navigation";
 import { loadActiveProfile } from "../lib/ActiveProfileRepository";
 import { getVerifiedPlacement, placementDisplayStatus } from "../lib/placementVerification";
+import { apiFetch } from "../lib/queryClient";
 
 type Mode = "love" | "attraction" | "friendship" | "growth";
 
@@ -78,10 +79,9 @@ export default function CompatibilityExplorerPage() {
       setLoading(true);
       setError("");
       try {
-        const response = await fetch("/api/compatibility/archetype-matches", {
+        const response = await apiFetch("/api/compatibility/archetype-matches", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          credentials: "include",
           body: JSON.stringify({ profile, mode }),
         });
         const payload = await response.json();

--- a/client/src/pages/offline-profile.tsx
+++ b/client/src/pages/offline-profile.tsx
@@ -24,6 +24,7 @@ import {
   reconcileOfflineProfile,
   type ReconciledOfflineProfile,
 } from "@/lib/profileVerificationReconciliation";
+import { apiFetch } from "@/lib/queryClient";
 
 type VerificationAttempt = "idle" | "running" | "complete" | "deferred";
 
@@ -60,10 +61,9 @@ export default function OfflineProfilePage() {
 
     async function refreshVerification() {
       try {
-        const response = await fetch("/api/profiles", {
+        const response = await apiFetch("/api/profiles", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          credentials: "include",
           body: JSON.stringify({
             name: currentProfile.name,
             birthDate: currentProfile.birthDate,

--- a/server/index.ts
+++ b/server/index.ts
@@ -33,6 +33,9 @@ app.use(
 const allowedOrigins = [
   "soulcodex://localhost",
   "capacitor://localhost",
+  // capacitor.config.ts sets androidScheme=https, making Android's shell origin
+  // https://localhost for bundled store builds.
+  "https://localhost",
   "http://localhost:3000",
   "http://localhost:5000",
   "https://soulcodex.up.railway.app",

--- a/server/session.ts
+++ b/server/session.ts
@@ -11,6 +11,7 @@ export function setupSession(app: Express) {
   if (!secret) throw new Error("SESSION_SECRET must be set before starting the server");
 
   const usePostgres = Boolean(process.env.DATABASE_URL) && process.env.DEMO_MODE !== "true";
+  const isProduction = process.env.NODE_ENV === "production";
   const store = usePostgres
     ? new PgSession({
         conString: process.env.DATABASE_URL,
@@ -30,8 +31,10 @@ export function setupSession(app: Express) {
     saveUninitialized: false,
     cookie: {
       httpOnly: true,
-      secure: process.env.NODE_ENV === "production",
-      sameSite: "lax",
+      secure: isProduction,
+      // Native Capacitor shells call the HTTPS API from a different origin.
+      // Store builds therefore require a Secure + SameSite=None session cookie.
+      sameSite: isProduction ? "none" : "lax",
       maxAge: 1000 * 60 * 60 * 24 * 7,
     },
   }));

--- a/tests/native-api-routing.test.ts
+++ b/tests/native-api-routing.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { resolveApiUrlWithBase } from "../client/src/lib/api-url";
+
+test("native API resolver prefixes /api calls with configured HTTPS origin", () => {
+  assert.equal(
+    resolveApiUrlWithBase("/api/auth/apple", "https://api.soulcodex.app"),
+    "https://api.soulcodex.app/api/auth/apple",
+  );
+  assert.equal(
+    resolveApiUrlWithBase("/api/profiles", "https://api.soulcodex.app/"),
+    "https://api.soulcodex.app/api/profiles",
+  );
+});
+
+test("web fallback preserves same-origin API paths when no base is configured", () => {
+  assert.equal(resolveApiUrlWithBase("/api/profiles/123", ""), "/api/profiles/123");
+  assert.equal(resolveApiUrlWithBase("/api/profiles/123", undefined), "/api/profiles/123");
+});
+
+test("resolver never rewrites non-API application routes or absolute URLs", () => {
+  assert.equal(resolveApiUrlWithBase("/settings", "https://api.soulcodex.app"), "/settings");
+  assert.equal(
+    resolveApiUrlWithBase("https://example.com/file.pdf", "https://api.soulcodex.app"),
+    "https://example.com/file.pdf",
+  );
+});
+
+test("active native server permits both Capacitor shell origins with credentialed CORS", () => {
+  const server = readFileSync("server/index.ts", "utf8");
+  assert.match(server, /"capacitor:\/\/localhost"/);
+  assert.match(server, /"https:\/\/localhost"/);
+  assert.match(server, /credentials:\s*true/);
+});
+
+test("production sessions use Secure SameSite=None cookies for native cross-origin API calls", () => {
+  const session = readFileSync("server/session.ts", "utf8");
+  assert.match(session, /secure:\s*isProduction/);
+  assert.match(session, /sameSite:\s*isProduction\s*\?\s*"none"\s*:\s*"lax"/);
+});
+
+test("reachable compatibility and offline verification paths use the centralized API fetcher", () => {
+  const compatibility = readFileSync("client/src/pages/CompatibilityExplorerPage.tsx", "utf8");
+  const offline = readFileSync("client/src/pages/offline-profile.tsx", "utf8");
+  assert.match(compatibility, /apiFetch\("\/api\/compatibility\/archetype-matches"/);
+  assert.doesNotMatch(compatibility, /fetch\("\/api\//);
+  assert.match(offline, /apiFetch\("\/api\/profiles"/);
+  assert.doesNotMatch(offline, /fetch\("\/api\//);
+});


### PR DESCRIPTION
## Summary
Close the last repo-owned native release gap: store builds validated `VITE_API_URL` but the active client still sent relative `/api/...` requests to the Capacitor shell origin.

## Changes
- Centralize API URL resolution using `VITE_API_URL` for `/api/*` requests while preserving same-origin web behavior.
- Add `apiFetch` and move active Compatibility Explorer + offline verification refresh onto the centralized transport.
- Allow Android Capacitor's `https://localhost` origin in production CORS.
- Use Secure + SameSite=None production session cookies for credentialed native-shell API requests.
- Align `.env.example` with the active session/auth architecture and Apple audience `app.soulcodex.ios`.
- Add a pure API URL resolver and focused native routing/cookie/CORS contract tests.
- Register the contract in Ultimate CI and the DB-backed lifecycle gate, and expand Gate 4 triggers for this boundary.

## Why
Without this repair a signed mobile build could pass release validation yet send `/api` traffic to its own Capacitor localhost origin, making authentication/profile verification fail only after installation.

## Non-claims
This PR does not claim Apple Developer credential configuration, physical-device Sign in with Apple validation, TestFlight/App Store Connect upload, Google Play signing/internal testing, or production backup/restore operations. Those require external accounts/devices and remain separate release gates.