### PR TITLE
Release: align native distributable identity with V4 RC

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     implementation project(':capacitor-android')
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
-    androidTestImplementation "androidx.test.espresso:espresso-core:$espressoCoreVersion"
+    androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
     implementation project(':capacitor-cordova-android-plugins')
 }
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "app.soulcodex.main"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.0"
+        versionCode 4000001
+        versionName "4.0.0-rc.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.
@@ -54,7 +54,7 @@ dependencies {
     implementation project(':capacitor-android')
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
-    androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
+    androidTestImplementation "androidx.test.espresso:espresso-core:$espressoCoreVersion"
     implementation project(':capacitor-cordova-android-plugins')
 }
 

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>4.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<string>4000001</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/tests/release-toolchain-contract.test.ts
+++ b/tests/release-toolchain-contract.test.ts
@@ -7,7 +7,10 @@ const androidWorkflowPath = ".github/workflows/build-android.yml";
 const gate5WorkflowPath = ".github/workflows/gate5-release-preflight.yml";
 const validatorPath = "scripts/validate-mobile-release.mjs";
 const iosProjectPath = "ios/App/App.xcodeproj/project.pbxproj";
+const iosInfoPlistPath = "ios/App/App/Info.plist";
 const iosExportOptionsPath = "ios/App/ExportOptions.plist";
+const androidBuildGradlePath = "android/app/build.gradle";
+const v4ManifestPath = "client/src/lib/v4ReleaseManifest.ts";
 
 async function text(path: string): Promise<string> {
   return readFile(path, "utf8");
@@ -75,4 +78,16 @@ test("Android Play workflow requires signing material and a real AAB", async () 
   assert.match(workflow, /ANDROID_KEY_PASSWORD/);
   assert.match(workflow, /\.\/gradlew bundleRelease/);
   assert.match(workflow, /test -f app\/build\/outputs\/bundle\/release\/app-release\.aab|if \[ ! -f "app\/build\/outputs\/bundle\/release\/app-release\.aab" \]/);
+});
+
+test("native distributable identity matches the canonical V4 release candidate", async () => {
+  const manifest = await text(v4ManifestPath);
+  const iosInfo = await text(iosInfoPlistPath);
+  const androidGradle = await text(androidBuildGradlePath);
+
+  assert.match(manifest, /releaseVersion:\s*"4\.0\.0-rc\.1"/);
+  assert.match(iosInfo, /<key>CFBundleShortVersionString<\/key>\s*<string>4\.0\.0<\/string>/);
+  assert.match(iosInfo, /<key>CFBundleVersion<\/key>\s*<string>4000001<\/string>/);
+  assert.match(androidGradle, /versionCode\s+4000001/);
+  assert.match(androidGradle, /versionName\s+"4\.0\.0-rc\.1"/);
 });


### PR DESCRIPTION
## Purpose
Align the native distributable artifacts with the canonical Soul Codex V4 release candidate identity without changing Foundation product behavior.

Canonical app release: `4.0.0-rc.1`.

## Native store identity
- iOS `CFBundleShortVersionString`: `4.0.0` (App Store-compatible three-integer marketing version)
- iOS `CFBundleVersion`: `4000001`
- Android `versionName`: `4.0.0-rc.1`
- Android `versionCode`: `4000001`

## Guardrail
Extends `tests/release-toolchain-contract.test.ts` so Gate 5 fails if the V4 manifest and native distributable identities drift apart.

This is release metadata only. It does not reopen the validated Foundation Web RC or the native Swift package repair from #208.