### PR TITLE
Release: advance V4 identity to rc.2 and reopen native qualification

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "app.soulcodex.main"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 4000001
-        versionName "4.0.0-rc.1"
+        versionCode 4000002
+        versionName "4.0.0-rc.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/client/src/lib/__tests__/v4ReleaseManifest.test.ts
+++ b/client/src/lib/__tests__/v4ReleaseManifest.test.ts
@@ -1,10 +1,30 @@
 import { describe, expect, it } from "vitest";
-import { V4_RELEASE_MANIFEST, canDeclareV4ReleaseCandidate } from "../v4ReleaseManifest";
+import {
+  V4_RELEASE_MANIFEST,
+  canDeclareV4NativeDistributableCandidate,
+  canDeclareV4ReleaseCandidate,
+} from "../v4ReleaseManifest";
+
+const completeWebEvidence = {
+  successfulWorkflows: V4_RELEASE_MANIFEST.requiredWorkflows,
+  mobileVisualReceipt: true,
+  offlineVisualReceipt: true,
+  deploymentReceipt: true,
+  rollbackProcedure: true,
+} as const;
 
 describe("V4 release manifest", () => {
   it("locks the v4.0.0-rc.2 release identity", () => {
     expect(V4_RELEASE_MANIFEST.releaseVersion).toBe("4.0.0-rc.2");
     expect(V4_RELEASE_MANIFEST.classification).toBe("release-candidate");
+    expect(V4_RELEASE_MANIFEST.releaseScope).toBe("foundation-web");
+  });
+
+  it("records the owner-authorized reopening of native distribution without upgrading web evidence", () => {
+    expect(V4_RELEASE_MANIFEST.nativeDistribution.scopeReopenedByOwner).toBe(true);
+    expect(V4_RELEASE_MANIFEST.nativeDistribution.scopeReopenedOn).toBe("2026-08-15");
+    expect(V4_RELEASE_MANIFEST.nativeDistribution.requiresSignedAndroidAab).toBe(true);
+    expect(V4_RELEASE_MANIFEST.nativeDistribution.requiresSignedIosArtifact).toBe(true);
   });
 
   it("locks every required same-SHA workflow", () => {
@@ -21,10 +41,10 @@ describe("V4 release manifest", () => {
     ]);
   });
 
-  it("does not declare a release candidate from CI alone", () => {
+  it("does not declare a web release candidate from CI alone", () => {
     expect(
       canDeclareV4ReleaseCandidate({
-        successfulWorkflows: V4_RELEASE_MANIFEST.requiredWorkflows,
+        ...completeWebEvidence,
         mobileVisualReceipt: false,
         offlineVisualReceipt: false,
         deploymentReceipt: false,
@@ -33,30 +53,41 @@ describe("V4 release manifest", () => {
     ).toBe(false);
   });
 
-  it("requires every workflow and every release receipt", () => {
-    expect(
-      canDeclareV4ReleaseCandidate({
-        successfulWorkflows: V4_RELEASE_MANIFEST.requiredWorkflows,
-        mobileVisualReceipt: true,
-        offlineVisualReceipt: true,
-        deploymentReceipt: true,
-        rollbackProcedure: true,
-      }),
-    ).toBe(true);
+  it("requires every workflow and every web release receipt", () => {
+    expect(canDeclareV4ReleaseCandidate(completeWebEvidence)).toBe(true);
   });
 
   it("fails closed when one required workflow is absent", () => {
     expect(
       canDeclareV4ReleaseCandidate({
+        ...completeWebEvidence,
         successfulWorkflows: V4_RELEASE_MANIFEST.requiredWorkflows.filter(
           (workflow) => workflow !== "Railway Container Smoke",
         ),
-        mobileVisualReceipt: true,
-        offlineVisualReceipt: true,
-        deploymentReceipt: true,
-        rollbackProcedure: true,
       }),
     ).toBe(false);
+  });
+
+  it("refuses native-distributable status without signed store artifacts", () => {
+    expect(
+      canDeclareV4NativeDistributableCandidate({
+        ...completeWebEvidence,
+        xcodeCloudArchive: true,
+        signedIosArtifact: false,
+        signedAndroidAab: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("requires Xcode Cloud plus signed iOS and Android artifacts for native-distributable status", () => {
+    expect(
+      canDeclareV4NativeDistributableCandidate({
+        ...completeWebEvidence,
+        xcodeCloudArchive: true,
+        signedIosArtifact: true,
+        signedAndroidAab: true,
+      }),
+    ).toBe(true);
   });
 
   it("keeps trust, privacy, and journey contracts explicit", () => {

--- a/client/src/lib/__tests__/v4ReleaseManifest.test.ts
+++ b/client/src/lib/__tests__/v4ReleaseManifest.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 import { V4_RELEASE_MANIFEST, canDeclareV4ReleaseCandidate } from "../v4ReleaseManifest";
 
 describe("V4 release manifest", () => {
-  it("locks the v4.0.0-rc.1 release identity", () => {
-    expect(V4_RELEASE_MANIFEST.releaseVersion).toBe("4.0.0-rc.1");
+  it("locks the v4.0.0-rc.2 release identity", () => {
+    expect(V4_RELEASE_MANIFEST.releaseVersion).toBe("4.0.0-rc.2");
     expect(V4_RELEASE_MANIFEST.classification).toBe("release-candidate");
   });
 

--- a/client/src/lib/v4ReleaseManifest.ts
+++ b/client/src/lib/v4ReleaseManifest.ts
@@ -1,7 +1,7 @@
 export const V4_RELEASE_MANIFEST = {
   product: "Ultimate Soul Codex",
   releaseLine: "v4-clarity-first",
-  releaseVersion: "4.0.0-rc.1",
+  releaseVersion: "4.0.0-rc.2",
   classification: "release-candidate",
   requiredWorkflows: [
     "Ultimate SoulCodex CI",

--- a/client/src/lib/v4ReleaseManifest.ts
+++ b/client/src/lib/v4ReleaseManifest.ts
@@ -3,6 +3,14 @@ export const V4_RELEASE_MANIFEST = {
   releaseLine: "v4-clarity-first",
   releaseVersion: "4.0.0-rc.2",
   classification: "release-candidate",
+  releaseScope: "foundation-web",
+  nativeDistribution: {
+    scopeReopenedByOwner: true,
+    scopeReopenedOn: "2026-08-15",
+    requiresXcodeCloudArchive: true,
+    requiresSignedIosArtifact: true,
+    requiresSignedAndroidAab: true,
+  },
   requiredWorkflows: [
     "Ultimate SoulCodex CI",
     "CI Tests",
@@ -53,13 +61,15 @@ export const V4_RELEASE_MANIFEST = {
 
 export type V4ReleaseManifest = typeof V4_RELEASE_MANIFEST;
 
-export function canDeclareV4ReleaseCandidate(evidence: {
+export type V4ReleaseEvidence = {
   successfulWorkflows: readonly string[];
   mobileVisualReceipt: boolean;
   offlineVisualReceipt: boolean;
   deploymentReceipt: boolean;
   rollbackProcedure: boolean;
-}): boolean {
+};
+
+export function canDeclareV4ReleaseCandidate(evidence: V4ReleaseEvidence): boolean {
   const workflowsPass = V4_RELEASE_MANIFEST.requiredWorkflows.every((workflow) =>
     evidence.successfulWorkflows.includes(workflow),
   );
@@ -70,5 +80,21 @@ export function canDeclareV4ReleaseCandidate(evidence: {
     evidence.offlineVisualReceipt &&
     evidence.deploymentReceipt &&
     evidence.rollbackProcedure
+  );
+}
+
+export function canDeclareV4NativeDistributableCandidate(
+  evidence: V4ReleaseEvidence & {
+    xcodeCloudArchive: boolean;
+    signedIosArtifact: boolean;
+    signedAndroidAab: boolean;
+  },
+): boolean {
+  return (
+    V4_RELEASE_MANIFEST.nativeDistribution.scopeReopenedByOwner &&
+    canDeclareV4ReleaseCandidate(evidence) &&
+    evidence.xcodeCloudArchive &&
+    evidence.signedIosArtifact &&
+    evidence.signedAndroidAab
   );
 }

--- a/docs/SOUL_CODEX_V4_RELEASE_READINESS.md
+++ b/docs/SOUL_CODEX_V4_RELEASE_READINESS.md
@@ -2,10 +2,10 @@
 
 ## Proposed release
 
-**Version:** `4.0.0-rc.1`  
+**Version:** `4.0.0-rc.2`  
 **Release line:** `v4-clarity-first`  
-**Target:** Foundation Web Release Candidate  
-**Native stores:** owner-deferred and not a Foundation Web RC blocker
+**Target:** Foundation Web + native distribution Release Candidate  
+**Previous milestone:** `v4.0.0-rc.1` remains pinned to the earlier Foundation Web RC and is not moved.
 
 This declaration branch may merge only after every workflow named in `V4_RELEASE_MANIFEST.requiredWorkflows` passes on the same exact head SHA. Older green runs remain historical evidence only.
 
@@ -61,8 +61,6 @@ Exact-head PWA evidence from candidate `3a4cfd5db2a41650240b7d0a1767bb544d432cdf
 - Chromium desktop `1440x900`
 - WebKit iPhone `390x844`
 
-The captured routes include Identity, Home, Timeline, Compatibility, specific-person comparison, Pricing, Privacy, Terms, Support, and Settings.
-
 Evidence summary:
 
 - [x] No page errors were reported.
@@ -73,7 +71,7 @@ Evidence summary:
 
 ## Engineering and release gates
 
-The formal `4.0.0-rc.1` declaration requires all of these workflows to pass on one exact release-declaration SHA:
+The formal `4.0.0-rc.2` declaration requires all of these workflows to pass on one exact release-declaration SHA:
 
 - [ ] Ultimate SoulCodex CI
 - [ ] CI Tests
@@ -85,11 +83,14 @@ The formal `4.0.0-rc.1` declaration requires all of these workflows to pass on o
 - [ ] Railway Container Smoke
 - [ ] Live Ephemeris Evidence
 
-The three legacy V4 gates are now wired into pull-request and main-branch exact-head validation so they can no longer rely on evidence from an older commit.
+Native distribution additionally requires:
+
+- [ ] Xcode Cloud archive succeeds on the distributable SHA.
+- [ ] Android signed AAB is produced from the distributable SHA.
+- [ ] iOS/TestFlight delivery is backed by a valid Apple signing identity or Xcode Cloud managed signing.
+- [ ] Real-device/store acceptance receipts remain distinct from simulator/build proof.
 
 ## Rollback contract
-
-A release candidate is not publishable without a rollback path.
 
 1. Keep the last known-good main SHA and release tag recorded before deployment.
 2. If production smoke fails, redeploy the last known-good Railway deployment or deploy that exact prior SHA.
@@ -99,13 +100,14 @@ A release candidate is not publishable without a rollback path.
 
 ## Declaration rule
 
-`4.0.0-rc.1` may be called **Foundation Web Release Candidate** only when:
+`4.0.0-rc.2` may be called **Foundation + native distributable Release Candidate** only when:
 
 - every required workflow above is green on the same exact declaration SHA;
 - the responsive/offline visual evidence remains valid;
 - the release receipt records that exact SHA and workflow run IDs;
+- the native package graph and simulator builds remain green;
 - the declaration branch merges without changing runtime behavior after validation.
 
-Publication is a separate state. **Published** requires a production deployment receipt and post-deploy smoke evidence against the deployed commit.
+Publication is a separate state. **Published** requires a production deployment receipt and post-deploy smoke evidence against the deployed commit. Store distribution requires signed artifact / Xcode Cloud and tester/store receipts.
 
 A release candidate is a tested thing, not a mood.

--- a/docs/SOUL_CODEX_V4_RELEASE_READINESS.md
+++ b/docs/SOUL_CODEX_V4_RELEASE_READINESS.md
@@ -2,12 +2,15 @@
 
 ## Proposed release
 
-**Version:** `4.0.0-rc.2`  
+**Version identity under qualification:** `4.0.0-rc.2`  
 **Release line:** `v4-clarity-first`  
-**Target:** Foundation Web + native distribution Release Candidate  
+**Current earned scope:** Foundation Web Release Candidate  
+**Native scope:** explicitly reopened by the owner on 2026-08-15 and now qualifying for native distribution  
 **Previous milestone:** `v4.0.0-rc.1` remains pinned to the earlier Foundation Web RC and is not moved.
 
 This declaration branch may merge only after every workflow named in `V4_RELEASE_MANIFEST.requiredWorkflows` passes on the same exact head SHA. Older green runs remain historical evidence only.
+
+Merging this branch does **not** by itself declare native-distributable status. The native-distributable classification remains fail-closed until signed artifact receipts exist.
 
 ## Product journey gates
 
@@ -54,24 +57,19 @@ This declaration branch may merge only after every workflow named in `V4_RELEASE
 
 ## Accessibility, responsive, and browser evidence
 
-Exact-head PWA evidence from candidate `3a4cfd5db2a41650240b7d0a1767bb544d432cdf` captured 40 screens across:
+Existing exact-head PWA evidence captured 40 screens across Chromium phone, tablet, desktop, and WebKit iPhone. The rc.2 declaration reruns the browser/offline workflow so version qualification does not borrow a stale green check.
 
-- Chromium phone `390x844`
-- Chromium tablet `834x1194`
-- Chromium desktop `1440x900`
-- WebKit iPhone `390x844`
+Evidence requirements:
 
-Evidence summary:
-
-- [x] No page errors were reported.
-- [x] No critical console errors were reported.
-- [x] Primary layouts are readable at phone, tablet, and desktop widths.
-- [x] The repaired Compatibility layout does not horizontally overflow at the tablet breakpoint.
+- [x] No page errors in the locked visual receipt.
+- [x] No critical console errors in the locked visual receipt.
+- [x] Primary layouts readable at phone, tablet, and desktop widths.
+- [x] Compatibility does not horizontally overflow at the tablet breakpoint.
 - [x] Main navigation and consumer hierarchy remain coherent across the captured viewport matrix.
 
-## Engineering and release gates
+## Engineering and web release gates
 
-The formal `4.0.0-rc.2` declaration requires all of these workflows to pass on one exact release-declaration SHA:
+The `4.0.0-rc.2` identity may merge only after all of these workflows pass on one exact release-declaration SHA:
 
 - [ ] Ultimate SoulCodex CI
 - [ ] CI Tests
@@ -83,12 +81,27 @@ The formal `4.0.0-rc.2` declaration requires all of these workflows to pass on o
 - [ ] Railway Container Smoke
 - [ ] Live Ephemeris Evidence
 
-Native distribution additionally requires:
+These gates preserve the already-earned Foundation Web RC and prove that advancing release identity did not regress it.
 
-- [ ] Xcode Cloud archive succeeds on the distributable SHA.
-- [ ] Android signed AAB is produced from the distributable SHA.
-- [ ] iOS/TestFlight delivery is backed by a valid Apple signing identity or Xcode Cloud managed signing.
-- [ ] Real-device/store acceptance receipts remain distinct from simulator/build proof.
+## Native distribution qualification
+
+Owner authorization to resume native release work is recorded in `governance/FOUNDATION-WEB-RELEASE-v1.md`.
+
+Native-distributable status requires all of the following in addition to the web RC evidence:
+
+- [ ] Xcode Cloud archive succeeds for the distributable SHA.
+- [ ] A signed or Apple-managed-signed iOS artifact exists for that SHA.
+- [ ] A signed Android AAB exists for that SHA.
+
+Current known external credential state before rc.2 qualification completes:
+
+- Android engineering/debug build passes, but the repository signing probe found `ANDROID_KEYSTORE` absent.
+- iOS simulator/build integration passes and Apple-managed Xcode Cloud archive is the preferred signing path.
+- GitHub-hosted iOS P12 material exists and contains a private key, but the macOS keychain import path has not produced a usable codesigning identity receipt.
+
+Therefore simulator/debug success alone must never upgrade this release to native-distributable status.
+
+TestFlight, Play internal testing, real-device validation, and store acceptance remain later distribution/publication receipts and must be named separately when earned.
 
 ## Rollback contract
 
@@ -100,14 +113,14 @@ Native distribution additionally requires:
 
 ## Declaration rule
 
-`4.0.0-rc.2` may be called **Foundation + native distributable Release Candidate** only when:
+`4.0.0-rc.2` may be merged as the **next V4 release identity under native qualification** when the same-SHA web/Foundation matrix is green.
 
-- every required workflow above is green on the same exact declaration SHA;
-- the responsive/offline visual evidence remains valid;
-- the release receipt records that exact SHA and workflow run IDs;
-- the native package graph and simulator builds remain green;
-- the declaration branch merges without changing runtime behavior after validation.
+It may be called **native-distributable Release Candidate** only when `canDeclareV4NativeDistributableCandidate(...)` also passes with:
 
-Publication is a separate state. **Published** requires a production deployment receipt and post-deploy smoke evidence against the deployed commit. Store distribution requires signed artifact / Xcode Cloud and tester/store receipts.
+- Xcode Cloud archive receipt;
+- signed iOS artifact receipt;
+- signed Android AAB receipt.
+
+Publication is a separate state. **Published** requires a production deployment receipt and post-deploy smoke evidence against the deployed commit. Store distribution requires tester/store receipts.
 
 A release candidate is a tested thing, not a mood.

--- a/governance/FOUNDATION-WEB-RELEASE-v1.md
+++ b/governance/FOUNDATION-WEB-RELEASE-v1.md
@@ -55,14 +55,22 @@ The following outputs must not be promoted merely because an old or approximate 
 
 These may return only an explicit unresolved or calculated-unverified state until their own independent evidence contract passes.
 
-## Owner-deferred platform scope
+## Native platform scope
 
-The owner has paused these lanes until explicit approval to resume:
+Native store work was originally owner-deferred so it could not block the Foundation Web release.
 
-- iOS App Store packaging, submission, and validation
-- Google Play packaging, submission, and validation
+**Owner authorization recorded 2026-08-15:** native distribution work is explicitly reopened for iOS and Android packaging, signing, archive, tester, and store-validation preparation.
 
-A pending or failed native-store check does not block this web release. Native source work must not be restarted merely because an automated platform integration makes noise in the distance, as automated platform integrations are known to do.
+Reopening the native lane does not weaken or retroactively redefine the Foundation Web RC. Native distribution remains a separate evidence ladder:
+
+- simulator/debug builds prove integration only;
+- Xcode Cloud archive proves Apple archive compatibility;
+- signed IPA / managed-signed Apple artifact proves iOS distributability;
+- signed AAB proves Android distributability;
+- TestFlight / Play internal-test receipts prove tester delivery;
+- store acceptance remains a later publication state.
+
+A pending or failed native-store credential or signing check does not invalidate the already-earned Foundation Web RC. It does block any claim that the same candidate is native-distributable.
 
 ## Release gates
 
@@ -144,12 +152,16 @@ Foundation Web v1 is release-candidate complete when all automated gates pass an
 
 Passing this contract means **Foundation Web Release Candidate**.
 
-It does not mean:
+It does not, by itself, mean:
 
 - the native stores are complete;
+- signed native artifacts exist;
+- TestFlight or Google Play internal testing has occurred;
 - every mystical system is verified;
 - every planned premium feature exists;
 - unresolved houses or Human Design may be quietly reintroduced;
 - enterprise layers are production-ready.
+
+Native-distributable status requires its own signed-artifact receipts after the owner-authorized reopening above.
 
 A narrower release that tells the truth is stronger than a larger release assembled from confident placeholders.

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>4.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>4000001</string>
+	<string>4000002</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/tests/release-toolchain-contract.test.ts
+++ b/tests/release-toolchain-contract.test.ts
@@ -85,9 +85,9 @@ test("native distributable identity matches the canonical V4 release candidate",
   const iosInfo = await text(iosInfoPlistPath);
   const androidGradle = await text(androidBuildGradlePath);
 
-  assert.match(manifest, /releaseVersion:\s*"4\.0\.0-rc\.1"/);
+  assert.match(manifest, /releaseVersion:\s*"4\.0\.0-rc\.2"/);
   assert.match(iosInfo, /<key>CFBundleShortVersionString<\/key>\s*<string>4\.0\.0<\/string>/);
-  assert.match(iosInfo, /<key>CFBundleVersion<\/key>\s*<string>4000001<\/string>/);
-  assert.match(androidGradle, /versionCode\s+4000001/);
-  assert.match(androidGradle, /versionName\s+"4\.0\.0-rc\.1"/);
+  assert.match(iosInfo, /<key>CFBundleVersion<\/key>\s*<string>4000002<\/string>/);
+  assert.match(androidGradle, /versionCode\s+4000002/);
+  assert.match(androidGradle, /versionName\s+"4\.0\.0-rc\.2"/);
 });


### PR DESCRIPTION
## Why rc.2
`v4.0.0-rc.1` already exists as an immutable tag on the earlier Foundation Web RC (`5f68e70a7e3c33a283de6c8bf3ebf52b1259186a`). Native Xcode Cloud and distributable-version fixes landed afterward, so the next qualified identity advances rather than repointing rc.1.

## Release identity
- Canonical manifest: `4.0.0-rc.2`
- Android: `versionName 4.0.0-rc.2`, `versionCode 4000002`
- iOS: marketing `4.0.0`, build `4000002`
- Gate 5 contract enforces the rc.2 mapping
- rc.1 remains immutable as the earlier Foundation Web milestone

## Governance
The owner explicitly reopened native packaging/signing/distribution work on 2026-08-15. That reopening is now recorded in `governance/FOUNDATION-WEB-RELEASE-v1.md` instead of relying on conversational context.

Foundation Web RC remains independently valid. Native distribution is a separate evidence ladder and cannot be declared from simulator/debug smoke.

## Fail-closed native classification
`canDeclareV4NativeDistributableCandidate(...)` now requires all of:
- complete Foundation/Web RC evidence;
- Xcode Cloud archive receipt;
- signed or Apple-managed-signed iOS artifact receipt;
- signed Android AAB receipt.

Current known signing gaps remain explicit: Android is missing `ANDROID_KEYSTORE`; GitHub-hosted iOS P12 import has not produced a usable codesigning identity. Therefore this PR advances and tests the rc.2 identity, but does not by itself claim native-distributable status.

No product logic changes. Merge only after the new exact-head CI/native/web matrix is green.