### PR TITLE
Governance: lock rc.2 store ingestion and hardware validation contracts

### DIFF
--- a/governance/release-audits/PRIORITY-2-HARDWARE-VALIDATION-PROCEDURES.md
+++ b/governance/release-audits/PRIORITY-2-HARDWARE-VALIDATION-PROCEDURES.md
@@ -1,0 +1,289 @@
+# Priority 2: Physical Hardware Validation Procedures
+
+**Status**: PREPARED — execution pending store-delivered rc.2 builds  
+**Release version**: `v4.0.0-rc.2`  
+**Release SHA**: `2e02d1023ddeb4e453236c34f2d4d2b7f6948957`  
+**Android AAB SHA-256**: `14a07d97b27eb581471e57d83069f9eb60b4c6d05553b7f077c70dc662052fcd`  
+**iOS IPA SHA-256**: `8a8e33beb7931e2c0459129eebecff8cf0e457458867cfdb3b3a39826b8522f0`
+
+## Governing rule
+
+Physical hardware validation proves that the **store-delivered** rc.2 build installs, launches, preserves local state, reaches the supported online boundaries, survives offline/restart/lifecycle transitions, and completes the bounded core journey on real hardware.
+
+It does **not** prove broad device compatibility, long-term performance, store acceptance, or production release. Signed artifacts, store ingestion, physical hardware, deployment proof, store acceptance, and production release remain separate evidence classes.
+
+Priority 2 execution begins only after the corresponding Priority 1 store-ingestion path provides an installable TestFlight or Google Play internal-testing build. A failed store upload is handled as Priority 1 evidence, not bypassed by sideloading and then relabeled as store-delivered hardware validation.
+
+## Test matrix
+
+### iOS validation device
+
+- Real iPhone or iPad, not Simulator
+- Validation floor: iOS 15 or later
+- Exact model: record in receipt
+- Exact OS version: record in receipt
+- Distribution source: TestFlight
+- Expected app identity: `4.0.0 (4000002)`
+- Tester must have access to the TestFlight build
+
+### Android validation device
+
+- Real Android phone or tablet, not emulator
+- Validation floor: Android 11 / API 30 or later
+- Exact model: record in receipt
+- Exact OS/API version: record in receipt
+- Distribution source: Google Play internal testing
+- Expected app identity: `4.0.0-rc.2 (4000002)`
+- Tester Google account must be enrolled in the internal test
+
+The validation floors above are coverage choices for this release receipt. They are not claims about the absolute minimum supported OS unless separately established by the application manifest/project settings.
+
+## Pre-test evidence
+
+Before checkpoint 1, record:
+
+- platform and device model
+- OS/API version
+- tester
+- date/time
+- store distribution source
+- store-visible version/build
+- screenshot of TestFlight or Play internal-testing build identity
+- confirmation that an older Soul Codex build is not installed
+- network available for initial store delivery
+
+Do not begin the smoke if the installed build identity is not rc.2.
+
+## Result vocabulary
+
+Use only:
+
+- `PASS` — expected behavior observed
+- `FAIL` — reproducible release-blocking defect
+- `CRASH` — app terminated unexpectedly
+- `INCONCLUSIVE` — environment or unavailable path prevents a valid result
+- `NOT APPLICABLE` — checkpoint does not apply to the store-approved rc.2 configuration
+
+A `CRASH`, data loss, or blocked canonical journey is an overall FAIL until corrected and retested. `INCONCLUSIVE` does not count as PASS.
+
+# 11-point bounded hardware smoke
+
+## 1. Store install and first launch
+
+1. Open the store-delivery surface: TestFlight on iOS or the Google Play internal-testing install path on Android.
+2. Confirm rc.2 build identity before installation.
+3. Install Soul Codex from that store-delivery surface.
+4. Launch the app.
+5. Confirm the home/application shell renders and accepts input.
+
+**PASS**: store installation completes and the app reaches the usable home surface without crash or blocking error.
+
+Record installation source, visible build identity, launch screenshot, and any store/install warning.
+
+## 2. Local profile creation and persistence
+
+Goal: prove local profile state survives application restart without silently depending on server-backed profile recreation.
+
+1. Create a test profile using supported inputs.
+2. If the location picker/search requires network access, network use for that external lookup is allowed and must be recorded. Do not misclassify an online geocoder dependency as failure of local profile storage.
+3. Save the profile.
+4. Confirm the profile is visible.
+5. Disable network after the profile exists.
+6. Force-quit the app.
+7. Relaunch while offline.
+8. Confirm the same profile and entered birth inputs remain available.
+
+**PASS**: profile identity and entered data survive force-quit/relaunch while offline, with no replacement profile fabricated.
+
+## 3. Reading, evidence, limitations, and certainty language
+
+1. Open the test profile.
+2. Open the canonical reading path.
+3. Confirm the reading renders without crash or indefinite loading.
+4. Inspect evidence/confidence/coverage information exposed by the UI.
+5. Inspect limitations and unknown-time handling where applicable.
+6. Confirm the UI does not claim unavailable Moon/Rising/houses/planet data when birth-time/evidence support is absent.
+7. Confirm the reading avoids obvious placeholder/filler output and remains usable on the physical viewport.
+
+Do **not** require internal implementation keys such as `mirror.driver` to be user-visible unless the shipped UI intentionally exposes them.
+
+**PASS**: substantive reading renders, evidence/limitations are inspectable, and visible certainty does not exceed the supported evidence state.
+
+## 4. Timeline navigation
+
+1. Navigate to Timeline using the active profile.
+2. Confirm the page renders without recreating the profile.
+3. Scroll through available entries/time periods.
+4. Open one available detail entry when the UI provides one.
+5. Return to the previous surface.
+
+**PASS**: timeline remains responsive, profile context is preserved, and no crash/blocking layout failure occurs.
+
+If no timeline data is legitimately available for the test state, record `INCONCLUSIVE` with the exact UI state rather than inventing PASS.
+
+## 5. Compatibility journey
+
+1. Open Compatibility using the active profile.
+2. Enter the supported inputs for a second person/profile.
+3. Generate or open the supported comparison.
+4. Confirm the result stays within the Foundation compatibility contract.
+5. Inspect visible evidence/limitations.
+6. Confirm there is no fabricated universal soulmate/relationship probability.
+
+**PASS**: compatibility renders, uses the supported data boundary, exposes limitations, and does not overclaim unsupported systems.
+
+## 6. Explicit online astronomy verification
+
+1. Enable network.
+2. Use the actual shipped UI path for online astronomy verification.
+3. Confirm the action is explicit rather than a silent background upload.
+4. Confirm the request completes without TLS/certificate failure.
+5. Confirm the UI distinguishes verified results from local/symbolic or unavailable evidence.
+6. Confirm unknown birth time remains unknown rather than being silently guessed.
+
+**PASS**: explicit verification completes and the evidence state updates honestly without certificate/network-path failure.
+
+If rc.2 exposes no verification control for the current profile state, record `INCONCLUSIVE` and capture the surface shown.
+
+## 7. Offline relaunch and cached/local navigation
+
+1. Ensure profile and at least one previously viewed reading are available.
+2. Enable airplane mode and verify Wi-Fi/cellular are disabled.
+3. Force-quit the app.
+4. Relaunch.
+5. Open the existing profile and previously available local/cached reading surfaces.
+6. Navigate through available offline evidence/limitations.
+7. Attempt one operation that genuinely requires network.
+
+**PASS**: local/cached surfaces remain usable, network-required behavior fails gracefully, and no blocking network-error loop or crash occurs.
+
+Do not require fresh server-only content to materialize offline.
+
+## 8. Sign-in/account boundary
+
+1. Restore network.
+2. Navigate to the shipped sign-in/account path.
+3. Start the supported authentication flow.
+4. Either complete it with a designated test account or cancel it intentionally.
+5. Confirm the app returns to a coherent state.
+6. If authentication completes, force-quit/relaunch and confirm expected session state.
+
+**PASS**: supported sign-in flow launches and completion/cancellation/error handling does not crash or corrupt local profile state.
+
+A provider unavailable because of tester/account configuration is `INCONCLUSIVE`, not PASS.
+
+## 9. Premium/payment boundary — test the store-approved rc.2 configuration
+
+The rc.2 application code currently starts premium purchase through `/api/billing/checkout` and redirects to **Hosted Stripe Checkout**. Hardware validation must not invent an Apple StoreKit or Google Play Billing sheet that rc.2 does not implement.
+
+However, store policy approval is a Priority 1 prerequisite for exercising this checkpoint. Digital premium functionality may be subject to Apple/Google store-payment rules, storefront restrictions, or enrolled alternative/external-payment programs.
+
+Procedure:
+
+1. Use the exact premium/payment path that survived Priority 1 store ingestion for that platform/storefront.
+2. Confirm the UI describes the payment boundary accurately.
+3. Start checkout only far enough to prove the approved payment surface launches.
+4. **Do not complete a live charge** unless a dedicated sandbox/test purchase path is intentionally configured.
+5. Cancel/dismiss/return.
+6. Confirm Soul Codex returns to a coherent state and no premium entitlement is granted from cancellation alone.
+
+**PASS**: the **store-approved** payment boundary launches and can be safely cancelled without crash, unintended charge, or false entitlement.
+
+If the store rejects rc.2 because the current hosted Stripe path is not permitted for the submitted storefront/program configuration, this checkpoint is `NOT APPLICABLE` until the Priority 1 policy blocker is resolved. Do not call the hardware build FAIL for a store-ingestion policy rejection that prevented delivery.
+
+## 10. Rotation, background, resume, and state preservation
+
+1. Open a reading or other stateful core surface.
+2. Rotate the device where rotation is supported.
+3. Confirm content remains readable and operable.
+4. Return to the original orientation.
+5. Background the app.
+6. Wait at least five seconds.
+7. Resume from the app switcher/home surface.
+8. Confirm the user returns to a coherent application state with active profile/context preserved.
+
+**PASS**: no crash, black screen, destructive state loss, or unusable overflow occurs through lifecycle transitions.
+
+If a platform intentionally locks orientation, record that behavior and validate background/resume; do not fail solely because unsupported orientation does not rotate.
+
+## 11. Crash-free bounded completion
+
+Review checkpoints 1–10.
+
+Required evidence:
+
+- zero observed unhandled crashes
+- zero destructive profile/data loss
+- no blocking navigation dead-end in the canonical journey
+- screenshots for key surfaces and any anomaly
+- TestFlight/Play/device crash diagnostics when available
+
+A normal store-delivered build does not provide a developer debug console to the tester. Do not require “console logs show no errors” as a mandatory PASS criterion. Use observable behavior plus store/device diagnostics when available.
+
+**PASS**: the bounded sequence completes without crash or data loss and every required checkpoint is PASS. Any required `INCONCLUSIVE` item keeps the overall hardware gate open until resolved.
+
+# Failure handling
+
+When a checkpoint fails:
+
+1. Stop promotion of the hardware gate.
+2. Record platform, device, OS/API, store build identity, checkpoint, exact steps, observed result, timestamp, and screenshot/video if available.
+3. Reproduce once when safe.
+4. Open a focused defect linked to the rc.2 SHA and store build.
+5. Do not modify the receipt to PASS until the corrected build is store-delivered and the failed checkpoint plus bounded regression sequence are rerun.
+
+Do not quietly substitute a sideloaded build for the failed store-delivered build and retain the same hardware classification.
+
+# Scope exclusions
+
+This bounded smoke does not claim:
+
+- exhaustive feature QA
+- every supported device/OS combination
+- performance benchmarking
+- battery/thermal characterization
+- accessibility certification
+- internationalization/localization coverage
+- long-duration soak testing
+- store-policy acceptance
+- production deployment health
+
+Those require separate evidence when included in release scope.
+
+# Receipt handoff
+
+Record execution results in:
+
+`governance/release-audits/RC-2-HARDWARE-VALIDATION-RECEIPT.md`
+
+Required final fields:
+
+```text
+Release SHA: 2e02d1023ddeb4e453236c34f2d4d2b7f6948957
+
+iOS
+- Device/model:
+- OS:
+- TestFlight version/build: 4.0.0 (4000002)
+- Tester:
+- Test date:
+- Checkpoints 1-11:
+- Crash-free:
+- Data-loss-free:
+- Evidence links/attachments:
+- Result: PASS / FAIL / INCONCLUSIVE
+
+Android
+- Device/model:
+- OS/API:
+- Play version/code: 4.0.0-rc.2 (4000002)
+- Tester:
+- Test date:
+- Checkpoints 1-11:
+- Crash-free:
+- Data-loss-free:
+- Evidence links/attachments:
+- Result: PASS / FAIL / INCONCLUSIVE
+
+Overall hardware gate: PASS only when both platform results are PASS.
+```

--- a/governance/release-audits/PRIORITY-4-STORE-PROCESSING-REVIEW-PROCEDURES.md
+++ b/governance/release-audits/PRIORITY-4-STORE-PROCESSING-REVIEW-PROCEDURES.md
@@ -1,0 +1,255 @@
+# Priority 4: Store Processing and Review Procedures
+
+**Status**: Awaiting Priority 1 store-ingestion receipts  
+**Release Version**: `v4.0.0-rc.2`  
+**Release SHA**: `2e02d1023ddeb4e453236c34f2d4d2b7f6948957`  
+**Android version code**: `4000002`  
+**iOS version/build**: `4.0.0 (4000002)`
+
+---
+
+## Governing rule
+
+Store processing is not store acceptance, physical hardware validation, or production release.
+
+Priority 4 proves that the stores have processed the exact rc.2 binaries far enough for tester distribution and that tester access remains usable. Public production acceptance requires its own later receipt.
+
+Priority 4 must not be marked PASS from estimated timing. Only observed console/tester states count.
+
+---
+
+## Preconditions
+
+Priority 1 must already have produced store-ingestion evidence:
+
+### Google Play
+- `app-release.aab` accepted
+- version code `4000002` recognized
+- release exists on the Internal testing track
+
+### Apple
+- `Ultimate Soul Codex.ipa` accepted by App Store Connect
+- bundle ID `app.soulcodex.ios`
+- version `4.0.0`
+- build `4000002`
+- build has entered or completed Apple processing
+
+If either upload is rejected, Priority 4 is not started for that platform. Record the rejection in `RC-2-STORE-INGESTION-RECEIPT.md` and repair/resubmit under a new immutable build identity if the binary changes.
+
+---
+
+# Google Play Internal Testing
+
+## Contract
+
+Internal testing is the first distribution track for rc.2. It supports up to 100 testers and is intended for fast QA distribution through Google Play.
+
+Internal testing does **not** prove public Play Store listing, production approval, or search visibility. The canonical access proof is the internal-testing release plus a working tester opt-in/install path.
+
+Feedback from test users is treated as testing feedback and must not be conflated with the app's public rating.
+
+## Step 1: Confirm release state
+
+In Play Console:
+
+1. Open Soul Codex.
+2. Open **Testing → Internal testing**.
+3. Confirm version code `4000002` is attached to the rc.2 release.
+4. Record the exact console status shown.
+5. Record any blocking policy, signing, bundle, country, or account messages.
+
+**PASS condition**: release is accepted on Internal testing with no blocking validation error.
+
+## Step 2: Confirm tester access
+
+1. Confirm an internal tester list/group exists.
+2. Confirm at least one tester account is included.
+3. Obtain the tester opt-in/install link provided by Play Console.
+4. Open the link using an enrolled tester account.
+5. Confirm the tester can opt in or is already enrolled.
+6. Confirm Play offers the rc.2 build for installation.
+
+Do not require the app to appear in ordinary public Play Store search. Internal-test distribution is proven by the tester path, not public discoverability.
+
+**PASS condition**: tester can reach and install the internal build through Google Play.
+
+## Step 3: Observe initial health
+
+Record, when available:
+
+- tester/install count
+- crash/ANR signals
+- private tester feedback
+- device compatibility warnings
+- blocking policy notices
+
+A lack of telemetry immediately after first distribution is not itself a failure. A repeatable launch crash, install failure, or blocking policy message is a failure and must be routed to the appropriate gate.
+
+## Google result
+
+Record:
+
+```text
+Google Play Priority 4
+- Release SHA: 2e02d1023ddeb4e453236c34f2d4d2b7f6948957
+- Version code: 4000002
+- Track: Internal testing
+- Console status: [status]
+- Tester group configured: PASS/FAIL
+- Tester link works: PASS/FAIL
+- Store-delivered install available: PASS/FAIL
+- Crash/ANR blockers: [none/details]
+- Policy blockers: [none/details]
+- Timestamp: [ISO 8601]
+- Result: PASS/FAIL/MONITORING
+```
+
+Priority 4 Google PASS requires a usable internal-test distribution. It does not require public listing or production approval.
+
+---
+
+# Apple App Store Connect / TestFlight
+
+## Contract
+
+Apple processing timing is variable. This procedure intentionally defines no fixed SLA.
+
+TestFlight supports up to 100 **internal App Store Connect users with access to the app**. External testing supports up to 10,000 testers. External TestFlight builds may require TestFlight App Review; the first build submitted for external testing requires review, while later builds may not require the same full review.
+
+Internal TestFlight distribution is not production App Review and must not be recorded as App Store acceptance.
+
+## Step 1: Confirm build processing
+
+In App Store Connect:
+
+1. Open Soul Codex.
+2. Open the **TestFlight** area.
+3. Locate version `4.0.0`, build `4000002`.
+4. Record the exact Apple status shown.
+5. If Apple requests export-compliance or other metadata, record and complete only the required account-side action.
+6. Do not resubmit an identical binary merely because processing is taking longer than expected.
+
+**PASS condition for processing**: build `4000002` completes processing and is eligible to be assigned to an internal TestFlight group.
+
+## Step 2: Assign internal testers
+
+1. Create or select an internal TestFlight group.
+2. Add eligible App Store Connect users, up to the platform limit.
+3. Add build `4000002` to the group.
+4. Enter `What to Test` information when prompted.
+5. Confirm testers receive access through TestFlight.
+
+**PASS condition**: at least one eligible internal tester can see version `4.0.0` build `4000002` in TestFlight.
+
+## Step 3: Confirm store-delivered install path
+
+1. On a real iOS/iPadOS device, open TestFlight as the enrolled internal tester.
+2. Confirm Soul Codex is listed.
+3. Confirm version/build identity is `4.0.0 (4000002)`.
+4. Confirm Install/Update begins successfully.
+
+Actual app behavior after installation belongs to **Priority 2 physical hardware validation**. Priority 4 records only that TestFlight delivery is functioning.
+
+## Step 4: Optional external TestFlight
+
+External testing is optional and not required to close internal-processing Priority 4.
+
+If external testing is used:
+
+1. Create an external group.
+2. Add build `4000002`.
+3. Provide required beta-test information.
+4. Submit for TestFlight App Review when required.
+5. Record actual Apple review state.
+6. Do not assume or encode a fixed review-duration SLA.
+
+## Apple result
+
+Record:
+
+```text
+Apple Priority 4
+- Release SHA: 2e02d1023ddeb4e453236c34f2d4d2b7f6948957
+- Bundle ID: app.soulcodex.ios
+- Version: 4.0.0
+- Build: 4000002
+- Processing status: [status]
+- Internal group assigned: PASS/FAIL
+- Internal tester sees build: PASS/FAIL
+- TestFlight install available: PASS/FAIL
+- Export-compliance blockers: [none/details]
+- Apple processing/review blockers: [none/details]
+- Timestamp: [ISO 8601]
+- Result: PASS/FAIL/MONITORING
+```
+
+Priority 4 Apple PASS requires processed build plus usable internal TestFlight delivery. It does not mean production App Review has passed.
+
+---
+
+# Interaction with Priority 2 hardware validation
+
+Priority 4 and Priority 2 touch the same tester delivery path but prove different things:
+
+- **Priority 4** proves the store can deliver rc.2 to the tester.
+- **Priority 2** proves rc.2 works correctly after that store-delivered installation on real hardware.
+
+Once a tester can install the store-delivered build, Priority 2 may execute immediately. There is no reason to wait for a monitoring window before beginning the hardware smoke.
+
+A hardware crash discovered during Priority 2 is recorded as a hardware/runtime failure even though store processing itself may remain PASS.
+
+---
+
+# Interaction with store acceptance
+
+Neither Play Internal Testing nor internal TestFlight constitutes public store acceptance.
+
+## Android production path
+
+After internal and hardware validation, the release may advance through the testing/production path applicable to the developer account. Any closed-test production-access requirement is account-specific and must be verified in Play Console before promotion.
+
+## Apple production path
+
+After TestFlight and hardware validation, the selected build must still be submitted to production App Review and reach the required distribution state before App Store acceptance is earned.
+
+---
+
+# Pass / fail rules
+
+## PASS
+
+Priority 4 overall PASS requires both:
+
+- Google Play Internal testing can deliver version code `4000002` to an enrolled tester.
+- Apple TestFlight can deliver version `4.0.0` build `4000002` to an eligible internal tester.
+
+## MONITORING
+
+Use MONITORING when a store has accepted the binary but processing or tester assignment has not completed yet.
+
+## FAIL
+
+Use FAIL for a blocking condition such as:
+
+- store rejects the submitted binary
+- signing identity or upload key mismatch
+- processed build cannot be assigned/delivered to testers
+- tester opt-in/install path is broken
+- store policy blocks distribution
+
+Runtime crashes after successful store delivery belong primarily to Priority 2, although the Priority 4 receipt should cross-reference them.
+
+---
+
+# Evidence receipt
+
+Priority 4 evidence may be recorded in a dedicated `RC-2-STORE-PROCESSING-REVIEW-RECEIPT.md` or appended to the store-ingestion receipt, but the state names must remain separate:
+
+- INGESTED
+- PROCESSING
+- INTERNAL TESTING AVAILABLE
+- HARDWARE VALIDATED
+- PRODUCTION REVIEW
+- STORE ACCEPTED
+
+Never replace those states with a single word such as `shipped` until every final release gate has actually passed.

--- a/governance/release-audits/RC-2-DEPLOYMENT-RECEIPT.md
+++ b/governance/release-audits/RC-2-DEPLOYMENT-RECEIPT.md
@@ -1,0 +1,48 @@
+# RC.2 Deployment + Rollback Receipt
+
+**Release SHA**: `2e02d1023ddeb4e453236c34f2d4d2b7f6948957`  
+**RC Version**: `v4.0.0-rc.2`  
+**Status**: PENDING
+
+## Deploy 1 — RC.2 to staging
+
+- Deployment ID: PENDING
+- Timestamp: PENDING
+- `/health`: PENDING
+- Application shell: PENDING
+- Core journey smoke: PENDING
+- API 404 behavior: PENDING
+- Notes: PENDING
+
+**Result**: PENDING
+
+## Rollback — previous known-good staging deployment
+
+- Previous SHA/deployment: PENDING
+- Deployment ID: PENDING
+- Timestamp: PENDING
+- `/health`: PENDING
+- Application shell: PENDING
+- Core journey smoke: PENDING
+- API 404 behavior: PENDING
+- Notes: PENDING
+
+**Result**: PENDING
+
+## Redeploy — RC.2 to staging
+
+- Deployment ID: PENDING
+- Timestamp: PENDING
+- `/health`: PENDING
+- Application shell: PENDING
+- Core journey smoke: PENDING
+- API 404 behavior: PENDING
+- Notes: PENDING
+
+**Result**: PENDING
+
+## Gate result
+
+Deployment proof closes only when deploy → rollback → redeploy all PASS without manual repair between states.
+
+**Overall**: PENDING

--- a/governance/release-audits/RC-2-HARDWARE-VALIDATION-RECEIPT.md
+++ b/governance/release-audits/RC-2-HARDWARE-VALIDATION-RECEIPT.md
@@ -1,0 +1,71 @@
+# RC.2 Physical Hardware Validation Receipt
+
+**Release SHA**: `2e02d1023ddeb4e453236c34f2d4d2b7f6948957`  
+**RC Version**: `v4.0.0-rc.2`  
+**Status**: PENDING STORE-DELIVERED BUILDS
+
+## iOS device
+
+- Device model: PENDING
+- OS version: PENDING
+- Distribution source: TestFlight
+- App version/build: `4.0.0 (4000002)`
+- Tester: PENDING
+- Test date: PENDING
+
+### 11-point smoke
+
+1. Clean install + first launch: PENDING
+2. Local profile creation: PENDING
+3. Force quit/relaunch/profile persistence: PENDING
+4. Reading + evidence + limitations: PENDING
+5. Timeline: PENDING
+6. Compatibility: PENDING
+7. Online astronomy verification: PENDING
+8. Offline reload/local data access: PENDING
+9. Sign-in/account path: PENDING
+10. Premium/payment boundary without charge: PENDING
+11. Rotation/background/resume + crash-free completion: PENDING
+
+- Crash-free: PENDING
+- Data-loss-free: PENDING
+- Screenshots/log evidence: PENDING
+- Notes: PENDING
+
+**iOS hardware result**: PENDING
+
+## Android device
+
+- Device model: PENDING
+- OS/API version: PENDING
+- Distribution source: Google Play internal testing
+- App version/code: `4.0.0-rc.2 (4000002)`
+- Tester: PENDING
+- Test date: PENDING
+
+### 11-point smoke
+
+1. Clean install + first launch: PENDING
+2. Local profile creation: PENDING
+3. Force quit/relaunch/profile persistence: PENDING
+4. Reading + evidence + limitations: PENDING
+5. Timeline: PENDING
+6. Compatibility: PENDING
+7. Online astronomy verification: PENDING
+8. Offline reload/local data access: PENDING
+9. Sign-in/account path: PENDING
+10. Premium/payment boundary without charge: PENDING
+11. Rotation/background/resume + crash-free completion: PENDING
+
+- Crash-free: PENDING
+- Data-loss-free: PENDING
+- Screenshots/log evidence: PENDING
+- Notes: PENDING
+
+**Android hardware result**: PENDING
+
+## Gate result
+
+Physical hardware validation closes only when both platform sections PASS on store-delivered rc.2 builds.
+
+**Overall**: PENDING

--- a/governance/release-audits/RC-2-STORE-INGESTION-RECEIPT.md
+++ b/governance/release-audits/RC-2-STORE-INGESTION-RECEIPT.md
@@ -1,0 +1,44 @@
+# RC.2 Store Ingestion Receipt
+
+**Release SHA**: `2e02d1023ddeb4e453236c34f2d4d2b7f6948957`  
+**RC Version**: `v4.0.0-rc.2`  
+**Status**: PENDING
+
+## Android — Google Play Internal Testing
+
+- Artifact: `app-release.aab`
+- Artifact SHA-256: `14a07d97b27eb581471e57d83069f9eb60b4c6d05553b7f077c70dc662052fcd`
+- Version name: `4.0.0-rc.2`
+- Version code: `4000002`
+- Track: Internal testing
+- Upload timestamp: PENDING
+- Upload accepted: PENDING
+- Console release/build status: PENDING
+- Tester opt-in/install link available: PENDING
+- Blocking validation/policy messages: PENDING
+- Receipt evidence: PENDING
+
+**Android ingestion result**: PENDING
+
+## iOS — App Store Connect / TestFlight
+
+- Artifact: `Ultimate Soul Codex.ipa`
+- Artifact SHA-256: `8a8e33beb7931e2c0459129eebecff8cf0e457458867cfdb3b3a39826b8522f0`
+- Bundle ID: `app.soulcodex.ios`
+- Marketing version: `4.0.0`
+- Build number: `4000002`
+- Upload timestamp: PENDING
+- Upload accepted: PENDING
+- Apple processing state: PENDING
+- Build visible in App Store Connect/TestFlight: PENDING
+- Internal tester group assigned: PENDING
+- Blocking validation/export-compliance messages: PENDING
+- Receipt evidence: PENDING
+
+**iOS ingestion result**: PENDING
+
+## Gate result
+
+Store ingestion closes only when both platform sections are PASS.
+
+**Overall**: PENDING

--- a/governance/release-audits/RC-2-STORE-SUBMISSION-CONTRACTS.md
+++ b/governance/release-audits/RC-2-STORE-SUBMISSION-CONTRACTS.md
@@ -1,0 +1,293 @@
+# RC.2 Store Submission Contracts
+
+**Status**: Signed artifacts complete. Store ingestion is the next active gate. Physical hardware validation is pending store-delivered builds.  
+**Last Updated**: 2026-08-15  
+**Release SHA**: `2e02d1023ddeb4e453236c34f2d4d2b7f6948957`  
+**RC Version**: `v4.0.0-rc.2`
+
+---
+
+## Governing separation
+
+**Signed binaries prove that Soul Codex can build and sign distributable native artifacts. They do not prove store ingestion, store delivery, real-hardware runtime behavior, store acceptance, or production release.**
+
+| State | Proven | Not yet proven | Required receipt |
+|---|---|---|---|
+| **Signed artifacts** | Toolchain, signing identity, binary integrity | Store acceptance, installability, runtime behavior | Artifact digest + signer verification + release SHA |
+| **Store ingestion** | Store accepts the uploaded binary and associates it with Soul Codex | Real-device behavior, public review/acceptance | Console build record + version/build identity |
+| **Physical hardware** | Store-delivered build installs and passes bounded smoke on real hardware | Wider-device coverage, public review | Device/OS/build receipt + smoke evidence |
+| **Deployment proof** | Staging deploy/rollback/redeploy is reproducible | Store acceptance, production readiness | Three-cycle deployment receipt |
+| **Store acceptance** | Required store review/publication state is satisfied | Continued production health | Store status/listing receipt |
+| **Production release** | Exact released version is live and passes post-release smoke | Long-term support | Production deployment + smoke receipt |
+
+No future agent may collapse these states into one another.
+
+---
+
+## Signed artifacts: complete
+
+### Android
+
+- Artifact: `app-release.aab`
+- Size: `6,664,722` bytes
+- Release SHA: `2e02d1023ddeb4e453236c34f2d4d2b7f6948957`
+- Version name: `4.0.0-rc.2`
+- Version code: `4000002`
+- AAB SHA-256: `14a07d97b27eb581471e57d83069f9eb60b4c6d05553b7f077c70dc662052fcd`
+- GitHub artifact ID: `9256764910`
+- Artifact ZIP digest: `sha256:4eae8176145d8403ce611c32545d253e4f1cf5189def7b0f487dd950d285099e`
+- Upload keystore: decoded and verified
+- Alias/password: verified with `keytool`
+- Bundle signing: PASS
+- `jarsigner`: `jar verified`
+- Target API: `36`
+
+**Classification**: signed Android distributable artifact proven. Google Play ingestion and hardware validation remain separate.
+
+### iOS
+
+- Artifact: `Ultimate Soul Codex.ipa`
+- Release SHA: `2e02d1023ddeb4e453236c34f2d4d2b7f6948957`
+- Marketing version: `4.0.0`
+- Build number: `4000002`
+- IPA SHA-256: `8a8e33beb7931e2c0459129eebecff8cf0e457458867cfdb3b3a39826b8522f0`
+- GitHub artifact ID: `9254271930`
+- Artifact ZIP digest: `sha256:a77b4b3b2cb8f0943c5d51f0534cad19c5b68d35b7f3388cf0f0c766bcbc0ea0`
+- Apple Distribution certificate/private key: matched and current
+- App Store provisioning profile: team, bundle ID, profile class, and current distribution certificate verified
+- Xcode archive: PASS
+- IPA export: PASS
+
+**Classification**: signed iOS distributable artifact proven. App Store Connect/TestFlight ingestion and hardware validation remain separate.
+
+---
+
+## Priority 1: store ingestion
+
+### Android: Google Play internal testing
+
+**Goal**: prove that Google Play accepts the exact signed rc.2 AAB and serves it through the internal testing track.
+
+**Upload target**: Play Console → Testing → Internal testing.
+
+**Upload artifact**: `app-release.aab` from the verified rc.2 artifact package.
+
+**Expected identity after ingestion**:
+- package/bundle identity: existing Soul Codex Android application
+- version name: `4.0.0-rc.2`
+- version code: `4000002`
+
+**Success criteria**:
+- AAB accepted without signing/key mismatch
+- version code `4000002` recognized
+- release appears in the internal testing track
+- tester opt-in/install link becomes available
+- no blocking policy or bundle-validation error
+
+**Tester rule**: internal testing supports up to 100 testers. For personal developer accounts created after November 13, 2023, production access later requires a closed test with at least 12 testers continuously opted in for 14 days before applying for production access. That later production-access rule is not the internal-ingestion gate.
+
+**Receipt to record**:
+```text
+Android store ingestion
+- Release SHA: 2e02d1023ddeb4e453236c34f2d4d2b7f6948957
+- Track: Internal testing
+- Version name: 4.0.0-rc.2
+- Version code: 4000002
+- Console status: [status]
+- Upload accepted: PASS/FAIL
+- Tester link available: PASS/FAIL
+- Timestamp: [time]
+- Blocking messages: [none/messages]
+```
+
+### iOS: App Store Connect / TestFlight
+
+**Goal**: prove that App Store Connect accepts the exact signed rc.2 IPA, processes it, and exposes build `4000002` for TestFlight.
+
+**Upload artifact**: `Ultimate Soul Codex.ipa` from the verified rc.2 artifact package.
+
+**Supported upload paths**: Transporter, supported Xcode upload tooling, or another Apple-supported App Store Connect upload path.
+
+**Expected identity after ingestion**:
+- bundle ID: `app.soulcodex.ios`
+- marketing version: `4.0.0`
+- build number: `4000002`
+
+**Success criteria**:
+- upload accepted without certificate/provisioning/bundle validation error
+- Apple associates the build with Soul Codex
+- build `4000002` enters Apple processing
+- processing completes and the build appears in TestFlight/App Store Connect
+- internal tester group can be assigned the build
+
+Apple does not provide a fixed processing SLA in this contract. The governing receipt is the actual App Store Connect state, not an estimated 24–48 hour window.
+
+**Tester rule**: TestFlight supports up to 100 internal App Store Connect testers. External testing supports up to 10,000 testers and may require Beta App Review.
+
+**Receipt to record**:
+```text
+iOS store ingestion
+- Release SHA: 2e02d1023ddeb4e453236c34f2d4d2b7f6948957
+- Bundle ID: app.soulcodex.ios
+- Version: 4.0.0
+- Build: 4000002
+- Upload accepted: PASS/FAIL
+- Processing state: [state]
+- TestFlight visible: PASS/FAIL
+- Internal group assigned: PASS/FAIL
+- Timestamp: [time]
+- Blocking messages: [none/messages]
+```
+
+---
+
+## Priority 2: physical hardware validation
+
+**Precondition**: use the store-delivered build whenever possible. A sideloaded build can diagnose a store-ingestion failure but does not replace the final store-delivery receipt.
+
+Minimum evidence set: one real iOS device and one real Android device.
+
+### Bounded 11-point smoke
+
+Run on both platforms against the ingested rc.2 build:
+
+1. Clean install and first launch
+2. Local profile creation
+3. Force quit / relaunch / profile persistence
+4. Reading + evidence + limitations
+5. Timeline navigation
+6. Compatibility journey
+7. Explicit online astronomy verification
+8. Airplane-mode/offline reload and local reading access
+9. Sign-in/account path
+10. Premium/payment boundary without completing a charge
+11. Rotation/background/resume and crash-free completion
+
+**Pass rule**: all checkpoints pass without crash, silent data loss, fabricated evidence state, or a blocking network dependency where offline behavior is promised.
+
+### Hardware receipt
+
+Create `governance/release-audits/RC-2-HARDWARE-VALIDATION-RECEIPT.md`.
+
+```text
+Device 1: iOS
+- Model: [model]
+- OS: [version]
+- Distribution source: TestFlight
+- App version/build: 4.0.0 (4000002)
+- Tester: [name]
+- Date: [date]
+- 11-point smoke: PASS/FAIL
+- Crash/data-loss result: PASS/FAIL
+- Notes/evidence: [details]
+
+Device 2: Android
+- Model: [model]
+- OS/API: [version]
+- Distribution source: Google Play internal testing
+- App version/code: 4.0.0-rc.2 (4000002)
+- Tester: [name]
+- Date: [date]
+- 11-point smoke: PASS/FAIL
+- Crash/data-loss result: PASS/FAIL
+- Notes/evidence: [details]
+```
+
+---
+
+## Priority 3: staging deployment and rollback proof
+
+**Goal**: prove that rc.2 can be deployed, rolled back to the previous known-good deployment, and redeployed without manual repair.
+
+Sequence:
+1. Deploy exact rc.2 SHA to staging.
+2. Verify `/health` and bounded core journey.
+3. Roll back to the recorded previous known-good SHA/deployment.
+4. Repeat health + journey smoke.
+5. Redeploy exact rc.2 SHA.
+6. Repeat health + journey smoke.
+
+Create `governance/release-audits/RC-2-DEPLOYMENT-RECEIPT.md`.
+
+```text
+Deploy 1: rc.2
+- SHA: 2e02d1023ddeb4e453236c34f2d4d2b7f6948957
+- Deployment ID: [id]
+- Health: PASS/FAIL
+- Journey smoke: PASS/FAIL
+
+Rollback
+- SHA/deployment: [previous]
+- Deployment ID: [id]
+- Health: PASS/FAIL
+- Journey smoke: PASS/FAIL
+
+Redeploy: rc.2
+- SHA: 2e02d1023ddeb4e453236c34f2d4d2b7f6948957
+- Deployment ID: [id]
+- Health: PASS/FAIL
+- Journey smoke: PASS/FAIL
+
+Overall: PASS/FAIL
+```
+
+---
+
+## Priority 4: store review / acceptance
+
+Store ingestion and store acceptance are not the same gate.
+
+### Apple
+- Internal TestFlight can begin after Apple processing and internal-group assignment.
+- External TestFlight may require Beta App Review.
+- Public App Store release requires the applicable App Review/publication state.
+
+### Google Play
+- Internal testing is an early QA track, not public production acceptance.
+- If the developer account is a personal account created after November 13, 2023, satisfy the applicable closed-testing requirement before applying for production access.
+- Production publication is recorded separately from internal/closed testing.
+
+---
+
+## Xcode Cloud anomaly
+
+The GitHub-mirrored Xcode Cloud check for the rc.2 SHA has remained `in_progress`, while the independent GitHub macOS signing lane produced and verified the signed App Store IPA.
+
+**Operational decision**: this Xcode Cloud anomaly does not block Priority 1 store ingestion. The independently verified IPA may be submitted to App Store Connect.
+
+**Formal contract caveat**: the code-level function `canDeclareV4NativeDistributableCandidate(...)` still requires `xcodeCloudArchive=true`. Therefore, until that code contract is deliberately amended or the Xcode Cloud receipt completes, agents must not claim that this specific predicate has passed. Store-ingestion work may proceed independently.
+
+Do not modify the frozen rc.2 application SHA merely to change this evidence predicate.
+
+---
+
+## Release ladder
+
+```text
+IMPLEMENTED          ✅
+INTEGRATED           ✅
+EMULATOR-VALIDATED   ✅
+SIGNED ARTIFACTS     ✅
+
+STORE INGESTION      ⏭ active next gate
+PHYSICAL HARDWARE    ⏳ pending store-delivered builds
+DEPLOYMENT PROOF     ⏳ pending
+STORE ACCEPTANCE     ⏳ pending
+PRODUCTION RELEASE   ⏳ pending
+```
+
+---
+
+## Final declaration rule
+
+No agent may declare rc.2 **shipped**, **publicly released**, or **ready for users** until the required evidence for all applicable release gates is recorded.
+
+At minimum, final public-release evidence must include:
+- signed iOS and Android artifact receipts
+- successful store ingestion for both platforms
+- physical hardware validation on at least one real iOS and one real Android device
+- staging deploy/rollback/redeploy proof
+- applicable Apple/Google store acceptance/publication state
+- production deployment and post-deploy smoke receipt
+
+Anything less is a proof in progress, not a shipped release.


### PR DESCRIPTION
## Purpose
Promote the rc.2 store-submission ledger onto a branch based directly on the frozen rc.2 `main` SHA.

## Release SHA
`2e02d1023ddeb4e453236c34f2d4d2b7f6948957`

## What this locks
- signed artifacts are proven but are not store ingestion, hardware validation, store acceptance, or production release;
- Google Play internal-testing ingestion is the next Android gate;
- App Store Connect/TestFlight ingestion is the next iOS gate;
- physical validation requires store-delivered builds on at least one real iOS and one real Android device;
- staging deploy → rollback → redeploy remains a separate receipt;
- final public release requires store/publication and production smoke evidence.

## Existing signed receipts carried forward
- Android AAB SHA-256: `14a07d97b27eb581471e57d83069f9eb60b4c6d05553b7f077c70dc662052fcd`
- iOS IPA SHA-256: `8a8e33beb7931e2c0459129eebecff8cf0e457458867cfdb3b3a39826b8522f0`

## Corrections from the stale ledger branch
- fixes `Last Updated` to 2026-08-15;
- fixes exact IPA filename to `Ultimate Soul Codex.ipa`;
- removes unsupported fixed 24–48h Apple-processing SLA language;
- records TestFlight internal tester limit as 100, external as up to 10,000;
- makes Google Play's 12-testers/14-days production-access rule conditional on applicable newer personal developer accounts;
- clarifies that App Store/TestFlight build identity comes from the uploaded binary (`4.0.0` / `4000002`), not from an Apple-assigned new version number;
- records that Xcode Cloud's stuck check does not block store ingestion, while the existing code-level native-distributable predicate still requires `xcodeCloudArchive=true`.

No application code or release identity changes.