### PR TITLE
Railway: enforce Dockerfile-only production build path

### DIFF
--- a/.github/workflows/railway-dockerfile-only.yml
+++ b/.github/workflows/railway-dockerfile-only.yml
@@ -1,0 +1,45 @@
+name: Railway Dockerfile Only
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - "Dockerfile"
+      - "railway.json"
+      - "railway.toml"
+      - "Procfile"
+      - "nixpacks.toml"
+      - "nixpacks.json"
+      - "railpack.toml"
+      - "railpack.json"
+      - ".railway/**"
+      - "scripts/verify-railway-dockerfile-only.mjs"
+      - ".github/workflows/railway-dockerfile-only.yml"
+  push:
+    branches: [main]
+    paths:
+      - "Dockerfile"
+      - "railway.json"
+      - "railway.toml"
+      - "Procfile"
+      - "nixpacks.toml"
+      - "nixpacks.json"
+      - "railpack.toml"
+      - "railpack.json"
+      - ".railway/**"
+      - "scripts/verify-railway-dockerfile-only.mjs"
+      - ".github/workflows/railway-dockerfile-only.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  dockerfile-only:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout exact source
+        uses: actions/checkout@v4
+      - name: Enforce Dockerfile-only Railway contract
+        run: node scripts/verify-railway-dockerfile-only.mjs

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: NODE_ENV=production node dist/index.js

--- a/docs/RAILWAY_DOCKERFILE_ONLY_CONTRACT.md
+++ b/docs/RAILWAY_DOCKERFILE_ONLY_CONTRACT.md
@@ -1,0 +1,31 @@
+# Railway Dockerfile-Only Build Contract
+
+Soul Codex production Railway services must build from the repository root `Dockerfile` and from no other build system.
+
+## Repository contract
+
+The only accepted Railway build configuration is:
+
+- `Dockerfile` at repository root
+- `railway.json` with `build.builder = "DOCKERFILE"`
+- `railway.json` with `build.dockerfilePath = "Dockerfile"`
+
+Repository-level competing build/start fallbacks are forbidden, including `Procfile`, `nixpacks.toml`, `nixpacks.json`, `railpack.toml`, `railpack.json`, `railway.toml`, and equivalent `.railway/` fallbacks.
+
+`scripts/verify-railway-dockerfile-only.mjs` and the `Railway Dockerfile Only` workflow enforce this rule.
+
+## Railway dashboard contract
+
+A Railway service-level dashboard override can supersede repository configuration. For the production service behind `soulcodex.up.railway.app`:
+
+1. Effective builder must be **Dockerfile**, never Railpack or Nixpacks.
+2. The service must be connected to `Bboy9090/Ultimate-SoulCodex` and the intended production branch.
+3. The domain must be attached to that exact production service/environment.
+4. A release promotion must create/build a deployment for the intended commit SHA. A plain **Redeploy** of an older deployment is not evidence that Railway fetched a newer Git commit.
+5. Release acceptance requires the live `/health` identity and Compatibility probes to match the intended release. A dashboard status of `Deployed` by itself is insufficient evidence.
+
+## rc.3 incident note
+
+Issue #213 established why this contract is necessary: repeated production probes returned the same pre-rc.3 `{"status":"ok"}` payload because the service had not built the rc.3 commit, and the effective Railway service builder was reported as Railpack while the repository contract specified Dockerfile.
+
+The source/container candidate and the live deployment remain separate evidence layers. Do not close a live-integration issue until the live domain proves the expected release identity.

--- a/scripts/verify-railway-dockerfile-only.mjs
+++ b/scripts/verify-railway-dockerfile-only.mjs
@@ -1,0 +1,56 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const root = process.cwd();
+const requiredDockerfile = resolve(root, "Dockerfile");
+const railwayConfigPath = resolve(root, "railway.json");
+
+const forbiddenCompetingConfigs = [
+  "Procfile",
+  "nixpacks.toml",
+  "nixpacks.json",
+  "railpack.toml",
+  "railpack.json",
+  "railway.toml",
+  ".railway/Procfile",
+  ".railway/nixpacks.toml",
+  ".railway/railpack.toml",
+];
+
+function fail(message) {
+  console.error(`RAILWAY_DOCKERFILE_ONLY_FAIL: ${message}`);
+  process.exitCode = 1;
+}
+
+if (!existsSync(requiredDockerfile)) {
+  fail("root Dockerfile is missing");
+}
+
+if (!existsSync(railwayConfigPath)) {
+  fail("railway.json is missing");
+} else {
+  try {
+    const config = JSON.parse(readFileSync(railwayConfigPath, "utf8"));
+    if (config?.build?.builder !== "DOCKERFILE") {
+      fail(`railway.json build.builder must be DOCKERFILE, got ${JSON.stringify(config?.build?.builder)}`);
+    }
+    if (config?.build?.dockerfilePath !== "Dockerfile") {
+      fail(`railway.json build.dockerfilePath must be Dockerfile, got ${JSON.stringify(config?.build?.dockerfilePath)}`);
+    }
+  } catch (error) {
+    fail(`railway.json could not be parsed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+for (const path of forbiddenCompetingConfigs) {
+  if (existsSync(resolve(root, path))) {
+    fail(`competing Railway build/start configuration is forbidden: ${path}`);
+  }
+}
+
+if (!process.exitCode) {
+  console.log("RAILWAY_DOCKERFILE_ONLY_PASS");
+  console.log("builder=DOCKERFILE");
+  console.log("dockerfilePath=Dockerfile");
+  console.log("competing repo-level builder/start configs=none");
+}


### PR DESCRIPTION
## Purpose

Remove repository-level fallback paths that can compete with or obscure the production Dockerfile contract, and make future drift fail CI.

## Changes

- deletes the root `Procfile` fallback;
- keeps `railway.json` as the sole Railway repo config (`builder: DOCKERFILE`, `dockerfilePath: Dockerfile`);
- adds `scripts/verify-railway-dockerfile-only.mjs` to fail if Dockerfile/railway.json drift or competing Procfile/Nixpacks/Railpack/railway.toml configs reappear;
- adds the `Railway Dockerfile Only` workflow;
- documents the service/dashboard contract, including the fact that a dashboard-level Railpack setting can override repo config and that plain Redeploy can reuse a stale deployment rather than build a new commit.

## Incident relationship

Supports #213. This does **not** claim the live Railway service is fixed: the production dashboard override must still be changed from Railpack to Dockerfile and a new deployment must be built from the intended exact main SHA. Live `/health` identity + Compatibility probes remain the closure evidence.

## Release discipline

No Soul Codex application behavior is changed here. This is deployment-path hardening only.