### PR TITLE
Depth: full-chart readiness, inspectable systems, and PDF truth guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,10 @@ jobs:
           tests/billing-security.test.ts
           tests/local-first-privacy-contract.test.ts
           tests/location-resolution-contract.test.ts
+          tests/system-visibility-contract.test.ts
           tests/server-profile-ownership.test.ts
           tests/natal-report-contract.test.ts
+          tests/pdf-production-path-contract.test.ts
           tests/codex-tools-production-contract.test.ts
           tests/active-consumer-auth.test.ts
           tests/native-api-routing.test.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
           tests/release-identity.test.ts
           tests/billing-security.test.ts
           tests/local-first-privacy-contract.test.ts
+          tests/location-resolution-contract.test.ts
           tests/server-profile-ownership.test.ts
           tests/natal-report-contract.test.ts
           tests/codex-tools-production-contract.test.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
           tests/astrology-tolerance-policy.test.ts
           tests/astrology-production-verification.test.ts
           tests/ascendant-verification.test.ts
+          tests/ascendant-retry-contract.test.ts
           tests/bobby-big-three-golden.test.ts
           tests/human-design-trust.test.ts
           tests/profile-verification-reconciliation.test.ts

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -18,6 +18,7 @@ import CompatibilityPersonPage from "./pages/CompatibilityPersonPage";
 import CompatibilityRoute from "./pages/CompatibilityRoute";
 import TimelinePage from "./pages/TimelinePage";
 import CodexToolsPage from "./pages/CodexToolsPage";
+import SystemsDetailsPage from "./pages/SystemsDetailsPage";
 import PrivacyPage from "./pages/PrivacyPage";
 import TermsPage from "./pages/TermsPage";
 import SupportPage from "./pages/SupportPage";
@@ -67,6 +68,7 @@ function Router() {
       <Route path="/compatibility/compare" component={CompatibilityPersonPage} />
       <Route path="/timeline" component={TimelineRoute} />
       <Route path="/tools" component={CodexToolsPage} />
+      <Route path="/systems" component={SystemsDetailsPage} />
       <Route path="/reading/:id" component={ReadingRoute} />
       <Route path="/profile/:id" component={ProfileRoute} />
       <Route path="/privacy" component={PrivacyPage} />

--- a/client/src/components/navigation.tsx
+++ b/client/src/components/navigation.tsx
@@ -1,6 +1,7 @@
 import { Link, useLocation } from "wouter";
 import {
   Compass,
+  Database,
   Eye,
   HeartHandshake,
   Menu,
@@ -17,6 +18,7 @@ function isActive(pathname: string, href: string) {
   if (href.startsWith("/profile/")) return pathname.startsWith("/profile/");
   if (href === "/compatibility") return pathname.startsWith("/compatibility");
   if (href === "/settings") return pathname.startsWith("/settings") || pathname.startsWith("/diagnostics");
+  if (href === "/systems") return pathname.startsWith("/systems");
   return pathname === href || pathname.startsWith(`${href}/`);
 }
 
@@ -78,6 +80,22 @@ export default function Navigation() {
               })}
             </div>
 
+            {profile && (
+              <Link
+                href="/systems"
+                className={`grid h-9 w-9 place-items-center rounded-lg border no-underline transition-colors ${
+                  isActive(pathname, "/systems")
+                    ? "border-[rgba(114,216,197,.24)] bg-[rgba(114,216,197,.08)] text-[var(--sc-teal)]"
+                    : "border-white/[0.06] text-[var(--sc-stone)] hover:bg-white/[0.04] hover:text-[var(--sc-ivory)]"
+                }`}
+                aria-label="See underlying systems"
+                title="See underlying systems"
+                data-testid="link-underlying-systems"
+              >
+                <Database className="h-4 w-4" strokeWidth={1.8} />
+              </Link>
+            )}
+
             <Link
               href="/settings"
               className={`grid h-9 w-9 place-items-center rounded-lg border no-underline transition-colors ${
@@ -135,6 +153,12 @@ export default function Navigation() {
                       </Link>
                     );
                   })}
+                  {profile && (
+                    <Link href="/systems" data-testid="link-underlying-systems-mobile" className="flex min-h-12 items-center gap-3 rounded-xl border border-white/[0.055] bg-white/[0.018] px-3.5 text-sm font-semibold text-[var(--sc-ivory-soft)] no-underline">
+                      <Database className="h-4.5 w-4.5 text-[var(--sc-stone)]" strokeWidth={1.8} />
+                      Underlying systems
+                    </Link>
+                  )}
                   <Link href="/settings" className="flex min-h-12 items-center gap-3 rounded-xl border border-white/[0.055] bg-white/[0.018] px-3.5 text-sm font-semibold text-[var(--sc-ivory-soft)] no-underline">
                     <Settings className="h-4.5 w-4.5 text-[var(--sc-stone)]" strokeWidth={1.8} />
                     Settings

--- a/client/src/lib/profileVerificationReconciliation.ts
+++ b/client/src/lib/profileVerificationReconciliation.ts
@@ -83,8 +83,10 @@ function hasExactAscendantInputs(profile: ReconciledOfflineProfile): boolean {
       profile.timezone &&
       profile.latitude !== null &&
       profile.latitude !== undefined &&
+      String(profile.latitude).trim() &&
       profile.longitude !== null &&
-      profile.longitude !== undefined,
+      profile.longitude !== undefined &&
+      String(profile.longitude).trim(),
   );
 }
 
@@ -164,6 +166,15 @@ export function reconcileOfflineProfile(
   };
 }
 
+/**
+ * A profile still needs astronomy verification when:
+ * - Sun or Moon has not been independently verified; or
+ * - exact timed Ascendant inputs exist and Rising has not actually verified.
+ *
+ * Verification-version bookkeeping must never suppress a retry after a
+ * temporary reference/engine failure. Version 2 means the profile understands
+ * the Ascendant contract; it does not mean the Ascendant itself passed.
+ */
 export function profileNeedsOnlineVerification(
   profile: ReconciledOfflineProfile,
 ): boolean {
@@ -171,11 +182,8 @@ export function profileNeedsOnlineVerification(
     return true;
   }
 
-  const syncedVersion = profile.remoteSync?.verificationVersion ?? 1;
-  const needsAscendantMigration =
+  return Boolean(
     hasExactAscendantInputs(profile) &&
-    syncedVersion < CURRENT_ASTROLOGY_VERIFICATION_VERSION &&
-    !getVerifiedAstrologySign(profile.verifiedAstrologyData, "rising");
-
-  return needsAscendantMigration;
+      !getVerifiedAstrologySign(profile.verifiedAstrologyData, "rising"),
+  );
 }

--- a/client/src/pages/SystemsDetailsPage.tsx
+++ b/client/src/pages/SystemsDetailsPage.tsx
@@ -1,0 +1,281 @@
+import { Link } from "wouter";
+import {
+  Calculator,
+  CheckCircle2,
+  Clock3,
+  Database,
+  Eye,
+  Fingerprint,
+  Info,
+  MapPin,
+  ShieldAlert,
+  Sparkles,
+} from "lucide-react";
+import Navigation from "@/components/navigation";
+import { useActiveProfile } from "@/hooks/useActiveProfile";
+
+type Placement = {
+  sign?: string | null;
+  verificationStatus?: string;
+  status?: string;
+  reason?: string;
+  internalCandidate?: {
+    sign?: string;
+    longitude?: number;
+    source?: string;
+    engine?: string;
+    inputTimestamp?: string;
+  };
+  verificationFailure?: {
+    reason?: string;
+    attemptedAt?: string;
+  };
+};
+
+function textValue(value: unknown): string | null {
+  if (typeof value === "string" && value.trim()) return value.trim();
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  return null;
+}
+
+function PlacementRow({
+  label,
+  placement,
+  legacyValue,
+}: {
+  label: string;
+  placement?: Placement;
+  legacyValue?: unknown;
+}) {
+  const verified =
+    placement?.verificationStatus === "verified" && textValue(placement.sign);
+  const candidate = textValue(placement?.internalCandidate?.sign);
+  const legacy = textValue(legacyValue);
+
+  let value = "Unresolved";
+  let state = "Not available";
+  let stateClass = "text-[var(--sc-stone)]";
+  let explanation = placement?.reason || "No supported placement evidence is stored yet.";
+
+  if (verified) {
+    value = verified;
+    state = "Verified chart fact";
+    stateClass = "text-[var(--sc-teal)]";
+  } else if (candidate) {
+    value = candidate;
+    state = "Calculated candidate · not promoted";
+    stateClass = "text-[var(--sc-gold-bright)]";
+    explanation =
+      placement?.reason ||
+      "A calculation exists, but Soul Codex is waiting for the required independent evidence before using it as verified chart data.";
+  } else if (legacy) {
+    value = legacy;
+    state = label === "Sun" ? "Local symbolic value" : "Stored unverified value";
+    stateClass = "text-[var(--sc-violet)]";
+    explanation =
+      label === "Sun"
+        ? "This Sun sign is available from the local date-based Foundation calculation. It can support symbolic reflection but is not labeled independently verified here."
+        : "This value exists in saved profile data but does not carry the current verified placement contract, so it is not promoted as verified evidence.";
+  }
+
+  return (
+    <div className="rounded-2xl border border-[var(--sc-line)] bg-white/[0.025] p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[.14em] text-[var(--sc-stone)]">{label}</p>
+          <p className="mt-1 font-serif text-2xl font-medium text-[var(--sc-ivory)]">{value}</p>
+        </div>
+        <span className={`text-xs font-semibold ${stateClass}`}>{state}</span>
+      </div>
+      <p className="mt-3 text-xs leading-5 text-[var(--sc-stone)]">{explanation}</p>
+      {candidate && typeof placement?.internalCandidate?.longitude === "number" && (
+        <p className="mt-2 text-[11px] text-[var(--sc-stone)]">
+          Candidate longitude: {placement.internalCandidate.longitude.toFixed(4)}°
+        </p>
+      )}
+      {placement?.verificationFailure?.reason && (
+        <p className="mt-2 rounded-xl border border-amber-400/15 bg-amber-400/[0.04] px-3 py-2 text-[11px] leading-5 text-amber-100/70">
+          Last verification issue: {placement.verificationFailure.reason}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function NumberRow({ label, value }: { label: string; value: unknown }) {
+  const shown = textValue(value) ?? "Unresolved";
+  return (
+    <div className="rounded-xl border border-[var(--sc-line)] bg-white/[0.025] p-3">
+      <p className="text-[11px] uppercase tracking-[.12em] text-[var(--sc-stone)]">{label}</p>
+      <p className="mt-1 font-serif text-2xl font-medium text-[var(--sc-gold-bright)]">{shown}</p>
+    </div>
+  );
+}
+
+export default function SystemsDetailsPage() {
+  const { profile, status } = useActiveProfile();
+
+  if (!profile) {
+    return (
+      <div className="sc-app-shell">
+        <Navigation />
+        <main className="sc-page flex min-h-[75vh] items-center justify-center">
+          <div className="sc-panel max-w-lg p-8 text-center">
+            <Database className="mx-auto mb-4 h-9 w-9 text-[var(--sc-gold)]" />
+            <h1 className="font-serif text-3xl font-medium text-[var(--sc-ivory)]">No active profile to inspect</h1>
+            <p className="mt-3 text-sm leading-6 text-[var(--sc-stone)]">
+              Create or restore a profile first. The systems inspector reads the same local active profile used by Soul Codex; it does not create another identity record.
+            </p>
+            <Link href="/create" className="sc-button-primary mt-6 inline-flex">Create profile</Link>
+            <p className="mt-4 text-xs text-[var(--sc-stone)]">Repository status: {status}</p>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  const astrology = (profile.astrologyData ?? {}) as Record<string, any>;
+  const placements = (astrology.placements ?? {}) as Record<string, Placement>;
+  const sunPlacement = (astrology.sun ?? placements.sun) as Placement | undefined;
+  const moonPlacement = (astrology.moon ?? placements.moon) as Placement | undefined;
+  const risingPlacement = (astrology.rising ?? placements.rising) as Placement | undefined;
+  const numerology = (profile.numerologyData ?? profile.personalNumbers ?? {}) as Record<string, any>;
+  const humanDesign = (profile.humanDesignData ?? {}) as Record<string, any>;
+  const humanDesignStatus = textValue(humanDesign.status) ?? "unverified";
+  const humanDesignVerified = humanDesignStatus === "verified";
+
+  const latitude = textValue(profile.latitude);
+  const longitude = textValue(profile.longitude);
+  const exactTimedInputs = Boolean(
+    profile.birthTime && profile.timezone && latitude && longitude,
+  );
+
+  return (
+    <div className="sc-app-shell">
+      <Navigation />
+      <main className="sc-page pb-24">
+        <header className="mx-auto mb-7 max-w-4xl text-center">
+          <div className="sc-eyebrow mb-4 justify-center"><Eye className="h-3.5 w-3.5" /> Optional inspection layer</div>
+          <h1 className="sc-display sc-display-gradient text-4xl sm:text-6xl">See the underlying systems</h1>
+          <p className="sc-lede mx-auto mt-5 max-w-3xl">
+            Soul Codex keeps the main experience synthesis-first. This page is for the moment you think, “Wait, what did it calculate for my Moon, Rising, or Life Path?” It shows what was calculated, what was verified, what was withheld, and why.
+          </p>
+        </header>
+
+        <div className="mx-auto max-w-5xl space-y-5">
+          <section className="sc-panel p-5 sm:p-7">
+            <div className="mb-5 flex items-start gap-3">
+              <div className="sc-icon-well"><MapPin className="h-5 w-5" /></div>
+              <div>
+                <p className="font-semibold text-[var(--sc-ivory)]">Birth inputs used by the calculation layer</p>
+                <p className="mt-1 text-sm leading-6 text-[var(--sc-stone)]">These are inputs, not interpretations. Exact timed inputs make Moon/Rising calculable; verification determines whether a result is promoted as evidence.</p>
+              </div>
+            </div>
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {[
+                ["Name", profile.name ?? profile.codename ?? "Unresolved"],
+                ["Birth date", profile.birthDate ?? "Unresolved"],
+                ["Birth time", profile.birthTime || "Unknown"],
+                ["Birth location", profile.birthLocation ?? profile.birthplace?.city ?? "Unresolved"],
+                ["Timezone", profile.timezone ?? "Unresolved"],
+                ["Coordinates", latitude && longitude ? `${latitude}, ${longitude}` : "Unresolved"],
+              ].map(([label, value]) => (
+                <div key={label} className="rounded-xl border border-[var(--sc-line)] bg-white/[0.025] p-3">
+                  <p className="text-[11px] uppercase tracking-[.12em] text-[var(--sc-stone)]">{label}</p>
+                  <p className="mt-1 break-words text-sm font-semibold text-[var(--sc-ivory)]">{value}</p>
+                </div>
+              ))}
+            </div>
+            <div className={`mt-4 flex gap-3 rounded-2xl border p-4 ${exactTimedInputs ? "border-[rgba(114,216,197,.22)] bg-[rgba(114,216,197,.04)]" : "border-amber-400/15 bg-amber-400/[0.035]"}`}>
+              {exactTimedInputs ? <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-[var(--sc-teal)]" /> : <Clock3 className="mt-0.5 h-5 w-5 shrink-0 text-amber-200/80" />}
+              <div>
+                <p className="text-sm font-semibold text-[var(--sc-ivory)]">{exactTimedInputs ? "Timed chart inputs complete" : "Timed chart inputs incomplete"}</p>
+                <p className="mt-1 text-xs leading-5 text-[var(--sc-stone)]">
+                  {exactTimedInputs
+                    ? "Moon and Ascendant candidates can be calculated from the saved inputs. If either remains unresolved below, the remaining problem is evidence/verification, not missing birth data."
+                    : "Moon/Rising stay unresolved when exact time, birth-place timezone, or coordinates are missing. Soul Codex does not manufacture the missing precision."}
+                </p>
+              </div>
+            </div>
+          </section>
+
+          <section className="sc-panel p-5 sm:p-7">
+            <div className="mb-5 flex items-start gap-3">
+              <div className="sc-icon-well"><Sparkles className="h-5 w-5" /></div>
+              <div>
+                <p className="font-semibold text-[var(--sc-ivory)]">Astrology evidence</p>
+                <p className="mt-1 text-sm leading-6 text-[var(--sc-stone)]">A calculated candidate can be shown here without pretending it is independently verified. The main synthesis may use only the evidence tier permitted by its contract.</p>
+              </div>
+            </div>
+            <div className="grid gap-4 lg:grid-cols-3">
+              <PlacementRow label="Sun" placement={sunPlacement} legacyValue={profile.sunSign ?? astrology.sunSign} />
+              <PlacementRow label="Moon" placement={moonPlacement} legacyValue={profile.moonSign ?? astrology.moonSign} />
+              <PlacementRow label="Rising" placement={risingPlacement} legacyValue={profile.risingSign ?? astrology.risingSign} />
+            </div>
+          </section>
+
+          <section className="sc-panel p-5 sm:p-7">
+            <div className="mb-5 flex items-start gap-3">
+              <div className="sc-icon-well"><Calculator className="h-5 w-5" /></div>
+              <div>
+                <p className="font-semibold text-[var(--sc-ivory)]">Numerology calculations</p>
+                <p className="mt-1 text-sm leading-6 text-[var(--sc-stone)]">The arithmetic is deterministic under Soul Codex&apos;s documented reduction rules. The spiritual or psychological meaning remains symbolic.</p>
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+              <NumberRow label="Life Path" value={profile.lifePathNumber ?? numerology.lifePath} />
+              <NumberRow label="Expression" value={numerology.expression} />
+              <NumberRow label="Soul Urge" value={numerology.soulUrge} />
+              <NumberRow label="Personality" value={numerology.personality} />
+              <NumberRow label="Personal Year" value={numerology.personalYear} />
+            </div>
+            <div className="mt-4 rounded-2xl border border-[var(--sc-line)] bg-white/[0.02] p-4 text-xs leading-6 text-[var(--sc-stone)]">
+              <strong className="text-[var(--sc-ivory)]">Why another app might show a different Life Path:</strong> systems can differ in date normalization, reduction order, and treatment of master numbers. Soul Codex preserves 11, 22, and 33 where the current formula defines them instead of silently reducing them.
+            </div>
+          </section>
+
+          <section className="sc-panel p-5 sm:p-7">
+            <div className="mb-5 flex items-start gap-3">
+              <div className="sc-icon-well"><Fingerprint className="h-5 w-5" /></div>
+              <div>
+                <p className="font-semibold text-[var(--sc-ivory)]">Human Design</p>
+                <p className="mt-1 text-sm leading-6 text-[var(--sc-stone)]">Human Design stays a supporting layer unless its calculation contract is verified. It should add explanatory depth, not become another unsupported headline.</p>
+              </div>
+            </div>
+            {humanDesignVerified ? (
+              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                <NumberRow label="Type" value={humanDesign.type ?? profile.humanDesignType} />
+                <NumberRow label="Strategy" value={humanDesign.strategy} />
+                <NumberRow label="Authority" value={humanDesign.authority} />
+                <NumberRow label="Profile" value={humanDesign.profile} />
+              </div>
+            ) : (
+              <div className="flex gap-3 rounded-2xl border border-amber-400/15 bg-amber-400/[0.035] p-4">
+                <ShieldAlert className="mt-0.5 h-5 w-5 shrink-0 text-amber-200/80" />
+                <div>
+                  <p className="text-sm font-semibold text-[var(--sc-ivory)]">Not promoted as verified Human Design evidence</p>
+                  <p className="mt-1 text-xs leading-5 text-[var(--sc-stone)]">Stored status: {humanDesignStatus}. Candidate fields may exist internally, but this inspector will not relabel them as authoritative chart facts.</p>
+                </div>
+              </div>
+            )}
+          </section>
+
+          <section className="sc-panel border-[rgba(114,216,197,.18)] bg-[rgba(114,216,197,.025)] p-5 sm:p-7">
+            <div className="flex gap-3">
+              <Info className="mt-0.5 h-5 w-5 shrink-0 text-[var(--sc-teal)]" />
+              <div>
+                <p className="font-semibold text-[var(--sc-ivory)]">How these systems affect the main Soul Codex</p>
+                <p className="mt-2 text-sm leading-7 text-[var(--sc-stone)]">
+                  The main reading should use systems as supporting evidence only when they add a distinct, defensible insight. Repeated labels, weakly verified layers, and systems that merely restate the same theme stay out of the foreground. This inspector exists so nothing has to be hidden from a curious user just to keep the main experience clear.
+                </p>
+                <p className="mt-3 text-sm leading-7 text-[var(--sc-stone)]">
+                  Houses, Midheaven, nodes, Chiron, planetary house placements, palmistry computer vision, and astrocartography lines remain unavailable until their evidence contracts are production-grade. “Not ready” is preferable to decorative precision.
+                </p>
+              </div>
+            </div>
+          </section>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/client/src/pages/local-first-input-form.tsx
+++ b/client/src/pages/local-first-input-form.tsx
@@ -8,41 +8,81 @@ import { generateFoundationOfflineCodexProfile } from "@/lib/foundationOfflineCo
 import { apiRequest } from "@/lib/queryClient";
 import { saveOfflineProfile } from "@/lib/offlineProfileStore";
 import { loadActiveProfile, saveActiveProfile } from "@/lib/ActiveProfileRepository";
-import { reconcileActiveProfile, reconcileOfflineProfile } from "@/lib/profileVerificationReconciliation";
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import {
+  reconcileActiveProfile,
+  reconcileOfflineProfile,
+} from "@/lib/profileVerificationReconciliation";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import Navigation from "@/components/navigation";
 import { useToast } from "@/hooks/use-toast";
-import { ArrowRight, Calendar, Check, Clock, Compass, Database, Loader2, MapPin, ShieldCheck, Sparkles, User } from "lucide-react";
+import {
+  ArrowRight,
+  Calendar,
+  Check,
+  Clock,
+  Compass,
+  Database,
+  Loader2,
+  MapPin,
+  ShieldCheck,
+  Sparkles,
+  User,
+} from "lucide-react";
 
-const BUILT_IN_LOCATIONS: Record<string, { lat: string; lng: string; timezone: string }> = {
+const BUILT_IN_LOCATIONS: Record<
+  string,
+  { lat: string; lng: string; timezone: string }
+> = {
   "new york": { lat: "40.7128", lng: "-74.0060", timezone: "America/New_York" },
-  "manhattan": { lat: "40.7831", lng: "-73.9712", timezone: "America/New_York" },
-  "bronx": { lat: "40.8448", lng: "-73.8648", timezone: "America/New_York" },
-  "brooklyn": { lat: "40.6782", lng: "-73.9442", timezone: "America/New_York" },
-  "philadelphia": { lat: "39.9526", lng: "-75.1652", timezone: "America/New_York" },
+  manhattan: { lat: "40.7831", lng: "-73.9712", timezone: "America/New_York" },
+  bronx: { lat: "40.8448", lng: "-73.8648", timezone: "America/New_York" },
+  brooklyn: { lat: "40.6782", lng: "-73.9442", timezone: "America/New_York" },
+  philadelphia: { lat: "39.9526", lng: "-75.1652", timezone: "America/New_York" },
   "los angeles": { lat: "34.0522", lng: "-118.2437", timezone: "America/Los_Angeles" },
-  "chicago": { lat: "41.8781", lng: "-87.6298", timezone: "America/Chicago" },
-  "miami": { lat: "25.7617", lng: "-80.1918", timezone: "America/New_York" },
+  chicago: { lat: "41.8781", lng: "-87.6298", timezone: "America/Chicago" },
+  miami: { lat: "25.7617", lng: "-80.1918", timezone: "America/New_York" },
   "san juan": { lat: "18.4655", lng: "-66.1057", timezone: "America/Puerto_Rico" },
   "la vega": { lat: "19.2221", lng: "-70.5296", timezone: "America/Santo_Domingo" },
   "santo domingo": { lat: "18.4861", lng: "-69.9312", timezone: "America/Santo_Domingo" },
-  "london": { lat: "51.5074", lng: "-0.1278", timezone: "Europe/London" },
-  "paris": { lat: "48.8566", lng: "2.3522", timezone: "Europe/Paris" },
-  "tokyo": { lat: "35.6762", lng: "139.6503", timezone: "Asia/Tokyo" },
+  london: { lat: "51.5074", lng: "-0.1278", timezone: "Europe/London" },
+  paris: { lat: "48.8566", lng: "2.3522", timezone: "Europe/Paris" },
+  tokyo: { lat: "35.6762", lng: "139.6503", timezone: "Asia/Tokyo" },
 };
 
 function builtInLocation(value: string) {
   const normalized = value.trim().toLowerCase();
   const match = Object.entries(BUILT_IN_LOCATIONS)
-    .map(([name, location]) => ({ index: normalized.indexOf(name), name, location }))
+    .map(([name, location]) => ({
+      index: normalized.indexOf(name),
+      name,
+      location,
+    }))
     .filter(({ index }) => index >= 0)
-    .sort((left, right) => left.index - right.index || right.name.length - left.name.length)[0];
+    .sort(
+      (left, right) =>
+        left.index - right.index || right.name.length - left.name.length,
+    )[0];
   return match?.location ?? null;
 }
 
-async function requestVerificationWhenOnline(data: BirthData, localProfile: OfflineCodexProfile): Promise<void> {
+function hasValue(value: unknown): boolean {
+  return value !== undefined && value !== null && String(value).trim().length > 0;
+}
+
+async function requestVerificationWhenOnline(
+  data: BirthData,
+  localProfile: OfflineCodexProfile,
+): Promise<void> {
   if (typeof navigator !== "undefined" && !navigator.onLine) return;
+
   try {
     const response = await apiRequest("POST", "/api/verification/profile", {
       birthDate: data.birthDate,
@@ -56,16 +96,32 @@ async function requestVerificationWhenOnline(data: BirthData, localProfile: Offl
 
     const currentActive = loadActiveProfile().profile;
     if (currentActive) {
-      const activeSave = saveActiveProfile(reconcileActiveProfile(currentActive, verification, syncedAt));
-      if (!activeSave.success) throw new Error(activeSave.error || "Verified profile reconciliation failed.");
+      const activeSave = saveActiveProfile(
+        reconcileActiveProfile(currentActive, verification, syncedAt),
+      );
+      if (!activeSave.success) {
+        throw new Error(
+          activeSave.error || "Verified profile reconciliation failed.",
+        );
+      }
     }
 
-    await saveOfflineProfile(reconcileOfflineProfile(localProfile, verification, syncedAt));
+    await saveOfflineProfile(
+      reconcileOfflineProfile(localProfile, verification, syncedAt),
+    );
+
     if (typeof window !== "undefined") {
-      window.dispatchEvent(new CustomEvent("soulcodex:profile-updated", { detail: { localId: localProfile.id, verifiedAt: syncedAt } }));
+      window.dispatchEvent(
+        new CustomEvent("soulcodex:profile-updated", {
+          detail: { localId: localProfile.id, verifiedAt: syncedAt },
+        }),
+      );
     }
   } catch (error) {
-    console.warn("[local-first-create] Requested online verification could not complete; local profile remains available", error);
+    console.warn(
+      "[local-first-create] Requested online verification could not complete; local profile remains available",
+      error,
+    );
   }
 }
 
@@ -75,38 +131,84 @@ export default function LocalFirstInputForm() {
   const [isCreating, setIsCreating] = useState(false);
   const [isLocating, setIsLocating] = useState(false);
   const [verifyOnline, setVerifyOnline] = useState(false);
-  const browserTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
 
   const form = useForm<BirthData>({
     resolver: zodResolver(birthDataSchema),
-    defaultValues: { name: "", birthDate: "", birthTime: "", birthLocation: "", timezone: browserTimezone, latitude: "", longitude: "" },
+    defaultValues: {
+      name: "",
+      birthDate: "",
+      birthTime: "",
+      birthLocation: "",
+      timezone: "",
+      latitude: "",
+      longitude: "",
+    },
   });
+
+  const birthTime = form.watch("birthTime");
+  const timezone = form.watch("timezone");
+  const latitude = form.watch("latitude");
+  const longitude = form.watch("longitude");
+  const exactChartInputsReady = Boolean(
+    birthTime &&
+      timezone &&
+      hasValue(latitude) &&
+      hasValue(longitude),
+  );
 
   const resolveLocation = async () => {
     const location = form.getValues("birthLocation");
     if (!location.trim()) {
-      toast({ title: "Location required", description: "Enter the birth city before resolving coordinates.", variant: "destructive" });
+      toast({
+        title: "Location required",
+        description: "Enter the birth city before resolving coordinates.",
+        variant: "destructive",
+      });
       return;
     }
+
     setIsLocating(true);
     try {
       let result = builtInLocation(location);
-      if (!result && (typeof navigator === "undefined" || navigator.onLine)) {
-        const response = await fetch(`https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(location)}&limit=1`);
-        const matches = await response.json();
-        if (Array.isArray(matches) && matches[0]) result = { lat: String(matches[0].lat), lng: String(matches[0].lon), timezone: browserTimezone };
-      }
+
       if (!result) {
-        toast({ title: "Location not found offline", description: "Enter latitude, longitude, and timezone manually below. The reading can still be generated on this device.", variant: "destructive" });
-        return;
+        if (typeof navigator !== "undefined" && !navigator.onLine) {
+          toast({
+            title: "Location not found offline",
+            description:
+              "Enter latitude, longitude, and the birth location's IANA timezone manually. The reading can still be generated on this device.",
+            variant: "destructive",
+          });
+          return;
+        }
+
+        const response = await apiRequest("POST", "/api/location/resolve", {
+          place: location.trim(),
+        });
+        const resolved = await response.json();
+        result = {
+          lat: String(resolved.latitude),
+          lng: String(resolved.longitude),
+          timezone: String(resolved.timezone),
+        };
       }
+
       form.setValue("latitude", result.lat, { shouldValidate: true });
       form.setValue("longitude", result.lng, { shouldValidate: true });
       form.setValue("timezone", result.timezone, { shouldValidate: true });
-      toast({ title: "Location ready", description: "Coordinates and timezone were filled for local calculation." });
+
+      toast({
+        title: "Birth location ready",
+        description: `Coordinates and ${result.timezone} were resolved for the birth location.`,
+      });
     } catch (error) {
       console.warn("[local-first-create] Location lookup failed", error);
-      toast({ title: "Online lookup unavailable", description: "Use the manual coordinate fields. Profile generation itself still works offline.", variant: "destructive" });
+      toast({
+        title: "Online lookup unavailable",
+        description:
+          "Enter latitude, longitude, and the birth location's IANA timezone manually. Soul Codex will not substitute your current device timezone.",
+        variant: "destructive",
+      });
     } finally {
       setIsLocating(false);
     }
@@ -117,15 +219,35 @@ export default function LocalFirstInputForm() {
     try {
       const profile = generateFoundationOfflineCodexProfile(data);
       await saveOfflineProfile(profile);
+
       const activeSave = saveActiveProfile({
-        id: profile.id, name: profile.name, codename: profile.name, birthDate: profile.birthDate,
-        birthTime: profile.birthTime ?? undefined, birthLocation: profile.birthLocation, timezone: profile.timezone,
-        latitude: profile.latitude ?? undefined, longitude: profile.longitude ?? undefined, birthplace: { city: profile.birthLocation },
-        sunSign: profile.astrologyData.sunSign, moonSign: profile.astrologyData.moonSign, risingSign: profile.astrologyData.risingSign,
-        astrologyData: profile.astrologyData, lifePathNumber: profile.numerologyData.lifePath, numerologyData: profile.numerologyData,
-        archetype: profile.archetypeData.title, synthesis: profile.depthInterpretation, createdAt: profile.createdAt, updatedAt: profile.updatedAt,
+        id: profile.id,
+        name: profile.name,
+        codename: profile.name,
+        birthDate: profile.birthDate,
+        birthTime: profile.birthTime ?? undefined,
+        birthLocation: profile.birthLocation,
+        timezone: profile.timezone,
+        latitude: profile.latitude ?? undefined,
+        longitude: profile.longitude ?? undefined,
+        birthplace: { city: profile.birthLocation },
+        sunSign: profile.astrologyData.sunSign,
+        moonSign: profile.astrologyData.moonSign,
+        risingSign: profile.astrologyData.risingSign,
+        astrologyData: profile.astrologyData,
+        lifePathNumber: profile.numerologyData.lifePath,
+        numerologyData: profile.numerologyData,
+        archetype: profile.archetypeData.title,
+        synthesis: profile.depthInterpretation,
+        createdAt: profile.createdAt,
+        updatedAt: profile.updatedAt,
       });
-      if (!activeSave.success) throw new Error(activeSave.error || "The active profile could not be registered.");
+
+      if (!activeSave.success) {
+        throw new Error(
+          activeSave.error || "The active profile could not be registered.",
+        );
+      }
 
       if (verifyOnline) {
         void requestVerificationWhenOnline(data, profile);
@@ -134,28 +256,44 @@ export default function LocalFirstInputForm() {
       toast({
         title: "Soul Codex created on this device",
         description: verifyOnline
-          ? "Your local reading is ready. You chose astronomy verification; only the calculation inputs needed for that check are sent, and the evidence merges back into this same local profile."
-          : "Your local reading is ready. No profile data was uploaded for verification.",
+          ? "Your local reading is ready. Astronomy verification was requested; supported placements will merge back into this same local profile when the evidence check finishes."
+          : exactChartInputsReady
+            ? "Your exact chart inputs are saved locally. Moon and Rising candidates are calculable, but Soul Codex will not promote them as chart facts until you choose Verify online."
+            : "Your local reading is ready. No profile data was uploaded for verification.",
       });
       setLocation(`/profile/${profile.id}`);
     } catch (error) {
       console.error("Local profile creation failed", error);
-      toast({ title: "Unable to create profile", description: error instanceof Error ? error.message : "The local reading could not be generated.", variant: "destructive" });
+      toast({
+        title: "Unable to create profile",
+        description:
+          error instanceof Error
+            ? error.message
+            : "The local reading could not be generated.",
+        variant: "destructive",
+      });
     } finally {
       setIsCreating(false);
     }
   };
 
-  const inputClass = "h-12 rounded-xl border-[var(--sc-line)] bg-white/[0.045] px-4 text-[var(--sc-ivory)] shadow-inner placeholder:text-[var(--sc-stone)]/70 focus-visible:border-[var(--sc-gold)]/60 focus-visible:ring-[var(--sc-gold)]/20";
+  const inputClass =
+    "h-12 rounded-xl border-[var(--sc-line)] bg-white/[0.045] px-4 text-[var(--sc-ivory)] shadow-inner placeholder:text-[var(--sc-stone)]/70 focus-visible:border-[var(--sc-gold)]/60 focus-visible:ring-[var(--sc-gold)]/20";
 
   return (
     <div className="sc-app-shell">
       <Navigation />
       <main className="sc-page pb-20">
         <section className="mx-auto mb-10 max-w-3xl text-center">
-          <div className="sc-eyebrow justify-center mb-4"><Sparkles className="h-3.5 w-3.5" /> Build your identity map</div>
-          <h1 className="sc-display sc-display-gradient text-4xl sm:text-6xl">Start with the facts.<br />Then go deeper.</h1>
-          <p className="sc-lede mx-auto mt-5 max-w-2xl">Your birth information anchors the Codex. The first reading is created locally on this device. Online astronomy verification happens only when you explicitly choose it.</p>
+          <div className="sc-eyebrow mb-4 justify-center">
+            <Sparkles className="h-3.5 w-3.5" /> Build your identity map
+          </div>
+          <h1 className="sc-display sc-display-gradient text-4xl sm:text-6xl">
+            Start with the facts.<br />Then go deeper.
+          </h1>
+          <p className="sc-lede mx-auto mt-5 max-w-2xl">
+            Your birth information anchors the Codex. The first reading is created locally on this device. Online astronomy verification happens only when you explicitly choose it.
+          </p>
         </section>
 
         <div className="mx-auto grid max-w-6xl gap-5 lg:grid-cols-[minmax(0,1fr)_300px]">
@@ -163,35 +301,103 @@ export default function LocalFirstInputForm() {
             <div className="border-b border-[var(--sc-line)] px-5 py-5 sm:px-8">
               <div className="flex items-start gap-3">
                 <div className="sc-icon-well"><Compass className="h-5 w-5" /></div>
-                <div><p className="font-semibold text-[var(--sc-ivory)]">Birth coordinates</p><p className="mt-1 text-sm leading-6 text-[var(--sc-stone)]">Use the most accurate information you have. Unknown time is better than invented precision.</p></div>
+                <div>
+                  <p className="font-semibold text-[var(--sc-ivory)]">Birth coordinates</p>
+                  <p className="mt-1 text-sm leading-6 text-[var(--sc-stone)]">
+                    Use the most accurate information you have. Unknown time is better than invented precision.
+                  </p>
+                </div>
               </div>
             </div>
 
             <Form {...form}>
               <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-7 p-5 sm:p-8">
-                <FormField control={form.control} name="name" render={({ field }) => (
-                  <FormItem><FormLabel className="flex items-center gap-1.5 text-[var(--sc-ivory-soft)]"><User className="h-4 w-4" /> Full name</FormLabel><FormControl><Input {...field} className={inputClass} placeholder="Enter your full name" data-testid="input-name" /></FormControl><FormMessage /></FormItem>
-                )} />
+                <FormField
+                  control={form.control}
+                  name="name"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="flex items-center gap-1.5 text-[var(--sc-ivory-soft)]"><User className="h-4 w-4" /> Full name</FormLabel>
+                      <FormControl><Input {...field} className={inputClass} placeholder="Enter your full name" data-testid="input-name" /></FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
 
                 <div className="grid gap-5 sm:grid-cols-2">
-                  <FormField control={form.control} name="birthDate" render={({ field }) => (
-                    <FormItem><FormLabel className="flex items-center gap-1.5 text-[var(--sc-ivory-soft)]"><Calendar className="h-4 w-4" /> Birth date</FormLabel><FormControl><Input {...field} className={inputClass} type="date" data-testid="input-birth-date" /></FormControl><FormMessage /></FormItem>
-                  )} />
-                  <FormField control={form.control} name="birthTime" render={({ field }) => (
-                    <FormItem><FormLabel className="flex items-center gap-1.5 text-[var(--sc-ivory-soft)]"><Clock className="h-4 w-4" /> Birth time <span className="ml-auto text-[11px] font-normal text-[var(--sc-stone)]">optional when unknown</span></FormLabel><FormControl><Input {...field} className={inputClass} type="time" data-testid="input-birth-time" /></FormControl><FormMessage /><p className="text-xs leading-5 text-[var(--sc-stone)]">Leave this blank if you do not know it. Soul Codex accepts unknown time and keeps time-dependent layers unresolved rather than manufacturing precision.</p></FormItem>
-                  )} />
+                  <FormField
+                    control={form.control}
+                    name="birthDate"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel className="flex items-center gap-1.5 text-[var(--sc-ivory-soft)]"><Calendar className="h-4 w-4" /> Birth date</FormLabel>
+                        <FormControl><Input {...field} className={inputClass} type="date" data-testid="input-birth-date" /></FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="birthTime"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel className="flex items-center gap-1.5 text-[var(--sc-ivory-soft)]"><Clock className="h-4 w-4" /> Birth time <span className="ml-auto text-[11px] font-normal text-[var(--sc-stone)]">optional when unknown</span></FormLabel>
+                        <FormControl><Input {...field} className={inputClass} type="time" data-testid="input-birth-time" /></FormControl>
+                        <FormMessage />
+                        <p className="text-xs leading-5 text-[var(--sc-stone)]">Leave this blank if you do not know it. Exact time unlocks time-sensitive calculation candidates; it is never invented.</p>
+                      </FormItem>
+                    )}
+                  />
                 </div>
 
-                <FormField control={form.control} name="birthLocation" render={({ field }) => (
-                  <FormItem><FormLabel className="flex items-center gap-1.5 text-[var(--sc-ivory-soft)]"><MapPin className="h-4 w-4" /> Birth location</FormLabel><div className="flex flex-col gap-2 sm:flex-row"><FormControl><Input {...field} className={inputClass} placeholder="City, state/province, country" data-testid="input-birth-location" /></FormControl><button type="button" className="flex h-12 items-center justify-center rounded-xl border border-[var(--sc-line-gold)] bg-[rgba(217,182,111,.06)] px-5 text-sm font-semibold text-[var(--sc-gold-bright)] transition hover:bg-[rgba(217,182,111,.12)] disabled:opacity-60" onClick={resolveLocation} disabled={isLocating} data-testid="button-location-lookup">{isLocating ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <MapPin className="mr-2 h-4 w-4" />}Resolve place</button></div><FormMessage /><p className="text-xs leading-5 text-[var(--sc-stone)]">Resolve place uses the built-in city list first. If no built-in match exists and you are online, the entered place text may be sent to OpenStreetMap/Nominatim for coordinates. Manual coordinates avoid that lookup.</p></FormItem>
-                )} />
+                <FormField
+                  control={form.control}
+                  name="birthLocation"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="flex items-center gap-1.5 text-[var(--sc-ivory-soft)]"><MapPin className="h-4 w-4" /> Birth location</FormLabel>
+                      <div className="flex flex-col gap-2 sm:flex-row">
+                        <FormControl><Input {...field} className={inputClass} placeholder="City, state/province, country" data-testid="input-birth-location" /></FormControl>
+                        <button type="button" className="flex h-12 items-center justify-center rounded-xl border border-[var(--sc-line-gold)] bg-[rgba(217,182,111,.06)] px-5 text-sm font-semibold text-[var(--sc-gold-bright)] transition hover:bg-[rgba(217,182,111,.12)] disabled:opacity-60" onClick={resolveLocation} disabled={isLocating} data-testid="button-location-lookup">
+                          {isLocating ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <MapPin className="mr-2 h-4 w-4" />}Resolve place
+                        </button>
+                      </div>
+                      <FormMessage />
+                      <p className="text-xs leading-5 text-[var(--sc-stone)]">
+                        Built-in cities resolve on-device. Otherwise, pressing Resolve place sends only the entered place text to Soul Codex&apos;s location resolver; coordinates determine the birth location&apos;s IANA timezone. Your current device timezone is never substituted for a remote birthplace.
+                      </p>
+                    </FormItem>
+                  )}
+                />
 
                 <div className="rounded-2xl border border-[var(--sc-line)] bg-black/15 p-4 sm:p-5">
-                  <div className="mb-4 flex items-center justify-between gap-4"><div><p className="text-sm font-semibold text-[var(--sc-ivory)]">Calculation coordinates</p><p className="mt-1 text-xs text-[var(--sc-stone)]">Usually filled automatically after resolving the place.</p></div><span className="flex items-center gap-1.5 rounded-full border border-[var(--sc-line)] bg-white/[0.03] px-2.5 py-1 text-[11px] font-medium text-[var(--sc-stone)]"><Database className="h-3.5 w-3.5" /> inspectable</span></div>
+                  <div className="mb-4 flex items-center justify-between gap-4">
+                    <div>
+                      <p className="text-sm font-semibold text-[var(--sc-ivory)]">Calculation coordinates</p>
+                      <p className="mt-1 text-xs text-[var(--sc-stone)]">Resolve the birth place or enter these manually. They stay inspectable.</p>
+                    </div>
+                    <span className="flex items-center gap-1.5 rounded-full border border-[var(--sc-line)] bg-white/[0.03] px-2.5 py-1 text-[11px] font-medium text-[var(--sc-stone)]"><Database className="h-3.5 w-3.5" /> inspectable</span>
+                  </div>
                   <div className="grid gap-4 sm:grid-cols-3">
                     <FormField control={form.control} name="latitude" render={({ field }) => (<FormItem><FormLabel className="text-xs text-[var(--sc-stone)]">Latitude</FormLabel><FormControl><Input {...field} className={inputClass} placeholder="40.7128" /></FormControl><FormMessage /></FormItem>)} />
                     <FormField control={form.control} name="longitude" render={({ field }) => (<FormItem><FormLabel className="text-xs text-[var(--sc-stone)]">Longitude</FormLabel><FormControl><Input {...field} className={inputClass} placeholder="-74.0060" /></FormControl><FormMessage /></FormItem>)} />
-                    <FormField control={form.control} name="timezone" render={({ field }) => (<FormItem><FormLabel className="text-xs text-[var(--sc-stone)]">Timezone</FormLabel><FormControl><Input {...field} className={inputClass} placeholder="America/New_York" /></FormControl><FormMessage /></FormItem>)} />
+                    <FormField control={form.control} name="timezone" render={({ field }) => (<FormItem><FormLabel className="text-xs text-[var(--sc-stone)]">Birth-place timezone</FormLabel><FormControl><Input {...field} className={inputClass} placeholder="America/New_York" /></FormControl><FormMessage /></FormItem>)} />
+                  </div>
+                </div>
+
+                <div className={`rounded-2xl border p-4 ${exactChartInputsReady ? "border-[rgba(114,216,197,.28)] bg-[rgba(114,216,197,.05)]" : "border-[var(--sc-line)] bg-white/[0.02]"}`} data-testid="chart-input-readiness">
+                  <div className="flex gap-3">
+                    <ShieldCheck className={`mt-0.5 h-5 w-5 shrink-0 ${exactChartInputsReady ? "text-[var(--sc-teal)]" : "text-[var(--sc-stone)]"}`} />
+                    <div>
+                      <p className="text-sm font-semibold text-[var(--sc-ivory)]">
+                        {exactChartInputsReady ? "Exact chart inputs are ready" : "Chart input status"}
+                      </p>
+                      <p className="mt-1 text-xs leading-5 text-[var(--sc-stone)]">
+                        {exactChartInputsReady
+                          ? "You supplied birth time, birth-place timezone, latitude, and longitude. Soul Codex can calculate Moon and Rising candidates. Independent online verification is the only remaining step before those values are promoted as chart facts."
+                          : "Moon and Rising require an exact birth time plus the birth location's timezone and coordinates. Missing pieces stay unresolved rather than being guessed."}
+                      </p>
+                    </div>
                   </div>
                 </div>
 
@@ -206,18 +412,36 @@ export default function LocalFirstInputForm() {
                   />
                   <span>
                     <span className="block text-sm font-semibold text-[var(--sc-ivory)]">Verify supported placements online after creation</span>
-                    <span className="mt-1 block text-xs leading-5 text-[var(--sc-stone)]">Optional. If selected, Soul Codex sends only birth date, optional birth time, timezone, and coordinates to the astronomy verification endpoint. It does not create a server profile or invoke AI generation for this check. Leave this off to keep profile creation entirely on-device.</span>
+                    <span className="mt-1 block text-xs leading-5 text-[var(--sc-stone)]">
+                      Optional. Soul Codex sends only birth date, optional birth time, timezone, and coordinates to the astronomy verification endpoint. It does not create a server profile or invoke AI generation for this check.
+                    </span>
                   </span>
                 </label>
 
-                <button type="submit" className="sc-button-primary h-14 w-full justify-center text-[15px]" disabled={isCreating} data-testid="button-create-profile">{isCreating ? <><Loader2 className="mr-2 h-4 w-4 animate-spin" />Building your Codex...</> : <>Create my Soul Codex <ArrowRight className="ml-2 h-4 w-4" /></>}</button>
+                <button type="submit" className="sc-button-primary h-14 w-full justify-center text-[15px]" disabled={isCreating} data-testid="button-create-profile">
+                  {isCreating ? <><Loader2 className="mr-2 h-4 w-4 animate-spin" />Building your Codex...</> : <>Create my Soul Codex <ArrowRight className="ml-2 h-4 w-4" /></>}
+                </button>
               </form>
             </Form>
           </div>
 
           <aside className="space-y-4 lg:sticky lg:top-28 lg:self-start">
-            <div className="sc-panel p-5"><div className="mb-4 flex items-center gap-3"><div className="sc-icon-well" style={{ color: "var(--sc-teal)" }}><ShieldCheck className="h-5 w-5" /></div><div><p className="font-semibold text-[var(--sc-ivory)]">Local first</p><p className="text-xs text-[var(--sc-stone)]">Your reading does not wait on the cloud.</p></div></div><div className="space-y-3 text-sm text-[var(--sc-stone)]">{["Generated on this device", "Offline copy stays available", "Online verification is opt-in"].map((item) => <div key={item} className="flex gap-2"><Check className="mt-0.5 h-4 w-4 shrink-0 text-[var(--sc-teal)]" /><span>{item}</span></div>)}</div></div>
-            <div className="sc-panel p-5"><p className="sc-eyebrow mb-2">Accuracy rule</p><p className="font-serif text-xl font-medium leading-snug text-[var(--sc-ivory)]">Missing data stays missing.</p><p className="mt-3 text-sm leading-6 text-[var(--sc-stone)]">A useful Codex distinguishes verified facts, calculated results, symbolic interpretation, and unresolved information. Precision theater is still theater.</p></div>
+            <div className="sc-panel p-5">
+              <div className="mb-4 flex items-center gap-3">
+                <div className="sc-icon-well" style={{ color: "var(--sc-teal)" }}><ShieldCheck className="h-5 w-5" /></div>
+                <div><p className="font-semibold text-[var(--sc-ivory)]">Local first</p><p className="text-xs text-[var(--sc-stone)]">Your reading does not wait on the cloud.</p></div>
+              </div>
+              <div className="space-y-3 text-sm text-[var(--sc-stone)]">
+                {["Generated on this device", "Offline copy stays available", "Online verification is opt-in"].map((item) => <div key={item} className="flex gap-2"><Check className="mt-0.5 h-4 w-4 shrink-0 text-[var(--sc-teal)]" /><span>{item}</span></div>)}
+              </div>
+            </div>
+            <div className="sc-panel p-5">
+              <p className="sc-eyebrow mb-2">Accuracy rule</p>
+              <p className="font-serif text-xl font-medium leading-snug text-[var(--sc-ivory)]">Unknown is a status, not a result.</p>
+              <p className="mt-3 text-sm leading-6 text-[var(--sc-stone)]">
+                Complete inputs should become calculable. A calculated candidate should become visible as a candidate. Only independently verified evidence becomes a chart fact used as verified evidence.
+              </p>
+            </div>
           </aside>
         </div>
       </main>

--- a/client/src/pages/local-first-input-form.tsx
+++ b/client/src/pages/local-first-input-form.tsx
@@ -2,7 +2,12 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useLocation } from "wouter";
-import { birthDataSchema, type BirthData } from "@shared/schema";
+import {
+  birthDataSchema,
+  isCoordinateWithinRange,
+  isValidIanaTimezone,
+  type BirthData,
+} from "@shared/schema";
 import type { OfflineCodexProfile } from "@soulcodex/core";
 import { generateFoundationOfflineCodexProfile } from "@/lib/foundationOfflineCodex";
 import { apiRequest } from "@/lib/queryClient";
@@ -59,9 +64,20 @@ const BUILT_IN_LOCATIONS: Record<
 
 function builtInLocation(value: string) {
   const normalized = value.trim().toLowerCase();
+  const inputTokens = normalized.split(/[^a-z0-9]+/).filter(Boolean);
   const match = Object.entries(BUILT_IN_LOCATIONS)
     .map(([name, location]) => ({
-      index: normalized.indexOf(name),
+      index:
+        normalized === name
+          ? 0
+          : name.split(/[^a-z0-9]+/).filter(Boolean).length < 2
+            ? -1
+            : inputTokens.findIndex((_, start) =>
+                name
+                  .split(/[^a-z0-9]+/)
+                  .filter(Boolean)
+                  .every((token, offset) => inputTokens[start + offset] === token),
+              ),
       name,
       location,
     }))
@@ -71,10 +87,6 @@ function builtInLocation(value: string) {
         left.index - right.index || right.name.length - left.name.length,
     )[0];
   return match?.location ?? null;
-}
-
-function hasValue(value: unknown): boolean {
-  return value !== undefined && value !== null && String(value).trim().length > 0;
 }
 
 async function requestVerificationWhenOnline(
@@ -151,9 +163,9 @@ export default function LocalFirstInputForm() {
   const longitude = form.watch("longitude");
   const exactChartInputsReady = Boolean(
     birthTime &&
-      timezone &&
-      hasValue(latitude) &&
-      hasValue(longitude),
+      isValidIanaTimezone(timezone) &&
+      isCoordinateWithinRange(latitude, -90, 90) &&
+      isCoordinateWithinRange(longitude, -180, 180),
   );
 
   const resolveLocation = async () => {
@@ -414,6 +426,7 @@ export default function LocalFirstInputForm() {
                     <span className="block text-sm font-semibold text-[var(--sc-ivory)]">Verify supported placements online after creation</span>
                     <span className="mt-1 block text-xs leading-5 text-[var(--sc-stone)]">
                       Optional. Soul Codex sends only birth date, optional birth time, timezone, and coordinates to the astronomy verification endpoint. It does not create a server profile or invoke AI generation for this check.
+                      Leave this off to keep profile creation entirely on-device.
                     </span>
                   </span>
                 </label>

--- a/client/src/pages/local-first-input-form.tsx
+++ b/client/src/pages/local-first-input-form.tsx
@@ -49,6 +49,7 @@ const BUILT_IN_LOCATIONS: Record<
   "new york": { lat: "40.7128", lng: "-74.0060", timezone: "America/New_York" },
   manhattan: { lat: "40.7831", lng: "-73.9712", timezone: "America/New_York" },
   bronx: { lat: "40.8448", lng: "-73.8648", timezone: "America/New_York" },
+  "bronx new york": { lat: "40.8448", lng: "-73.8648", timezone: "America/New_York" },
   brooklyn: { lat: "40.6782", lng: "-73.9442", timezone: "America/New_York" },
   philadelphia: { lat: "39.9526", lng: "-75.1652", timezone: "America/New_York" },
   "los angeles": { lat: "34.0522", lng: "-118.2437", timezone: "America/Los_Angeles" },
@@ -63,7 +64,11 @@ const BUILT_IN_LOCATIONS: Record<
 };
 
 function builtInLocation(value: string) {
-  const normalized = value.trim().toLowerCase();
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
   const inputTokens = normalized.split(/[^a-z0-9]+/).filter(Boolean);
   const match = Object.entries(BUILT_IN_LOCATIONS)
     .map(([name, location]) => ({

--- a/geocoding.ts
+++ b/geocoding.ts
@@ -17,6 +17,7 @@ const LOCATION_DATABASE: { [key: string]: { lat: string; lon: string } } = {
   "manhattan": { lat: "40.7831", lon: "-73.9712" },
   "brooklyn": { lat: "40.6782", lon: "-73.9442" },
   "bronx": { lat: "40.8448", lon: "-73.8648" },
+  "bronx new york": { lat: "40.8448", lon: "-73.8648" },
   "the bronx": { lat: "40.8448", lon: "-73.8648" },
   "queens": { lat: "40.7282", lon: "-73.7949" },
   "staten island": { lat: "40.5795", lon: "-74.1502" },
@@ -169,7 +170,10 @@ export function geocodeLocation(location: string): GeocodeResult | null {
   }
 
   // Normalize the input
-  const normalized = location.toLowerCase().trim();
+  const normalized = location
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
   
   // Try exact match first
   if (LOCATION_DATABASE[normalized]) {

--- a/geocoding.ts
+++ b/geocoding.ts
@@ -181,9 +181,20 @@ export function geocodeLocation(location: string): GeocodeResult | null {
     };
   }
 
-  // Try partial matches (e.g., "New York, NY" should match "new york")
+  // Match multi-word city names only on complete, adjacent tokens. Single-word
+  // aliases (especially "la") are exact-only so an unrelated place such as
+  // "Glasgow, Scotland" cannot be silently resolved as Los Angeles. Ambiguous
+  // qualified single-word cities are deliberately deferred to the real
+  // geocoder, which can evaluate the region/country qualifier.
+  const inputTokens = normalized.split(/[^a-z0-9]+/).filter(Boolean);
   for (const [key, coords] of Object.entries(LOCATION_DATABASE)) {
-    if (normalized.includes(key) || key.includes(normalized)) {
+    const keyTokens = key.split(/[^a-z0-9]+/).filter(Boolean);
+    if (keyTokens.length < 2) continue;
+
+    const containsCompletePhrase = inputTokens.some((_, start) =>
+      keyTokens.every((token, offset) => inputTokens[start + offset] === token),
+    );
+    if (containsCompletePhrase) {
       return {
         lat: coords.lat,
         lon: coords.lon,

--- a/governance/release-audits/DEPTH-SYSTEMS-AND-FULL-CHART-CONTRACT.md
+++ b/governance/release-audits/DEPTH-SYSTEMS-AND-FULL-CHART-CONTRACT.md
@@ -1,0 +1,87 @@
+# Soul Codex Full-Chart + Supporting-Systems Contract
+
+## Product rule
+
+Soul Codex is synthesis-first. Specialist systems exist to add distinct explanatory depth, not to make the interface look more mystical or to repeat the same claim under different names.
+
+The main reading may use a system only when its evidence state satisfies `shared/system-visibility.ts`. Raw system details remain available through the optional **Underlying systems** inspector so a curious user can audit what was calculated, verified, withheld, or left unresolved.
+
+## Complete birth data is not the same as verified chart evidence
+
+Exact date + exact time + birth-place timezone + latitude + longitude mean a timed placement is **calculable**. They do not, by themselves, turn an internal calculation into independently verified evidence.
+
+The UI must therefore distinguish:
+
+1. **Inputs missing** — the placement cannot be calculated safely.
+2. **Calculated candidate** — a value exists, but the required independent verification is incomplete.
+3. **Verified chart fact** — the placement passed the approved verification contract.
+
+A calculated candidate may be shown only in the optional inspector with an explicit unverified label. It must not silently populate verified aliases, Compatibility evidence, or a truth-coded PDF field.
+
+## Birth-location timezone rule
+
+The timezone used for timed chart calculation must belong to the **birth coordinates**, not to the device currently running Soul Codex.
+
+`POST /api/location/resolve` is the online fallback used only when the user explicitly presses **Resolve place**. It accepts only the entered place string, resolves coordinates through the existing server geo layer, derives the IANA timezone with `geo-tz`, persists nothing, and invokes no AI generation.
+
+The create flow no longer calls Nominatim directly and never substitutes the browser/device timezone for a remote birthplace.
+
+## Ascendant retry rule
+
+A current verification-version receipt does not mean Rising passed. When exact timed inputs exist and Ascendant remains unverified, `profileNeedsOnlineVerification()` must continue to return `true` until Rising actually verifies.
+
+This prevents a temporary independent-reference failure from leaving a complete profile permanently stuck with an unresolved Rising value and no retry path.
+
+## Optional Underlying systems inspector
+
+Route: `/systems`
+
+The inspector is secondary navigation, not another primary dashboard. It may show:
+
+- saved birth inputs used by calculation;
+- verified Sun / Moon / Rising;
+- calculated-but-unverified placement candidates, clearly labeled;
+- deterministic Life Path, Expression, Soul Urge, Personality, and Personal Year values where present;
+- verified Human Design core fields;
+- an explicit explanation when Human Design or other systems are not eligible for authoritative use;
+- why a value can differ from another service, such as numerology reduction/master-number rules.
+
+The inspector does not create a new profile, upload data merely by opening, or upgrade evidence states.
+
+## Primary synthesis eligibility
+
+| System | Default role | May enrich synthesis when | Candidate inspectable? |
+|---|---|---|---|
+| Verified astrology core | supporting | placement is verified | yes |
+| Numerology | supporting | deterministic value exists | yes |
+| Human Design | inspectable/supporting | trust record is verified | yes |
+| User assessments | supporting | explicit assessment result exists | yes |
+| Houses / Midheaven | unavailable | not production-ready | no |
+| Nodes / Chiron / planetary houses | unavailable | not production-ready | no |
+| Astrocartography | unavailable | not production-ready | no |
+| Palmistry CV | unavailable | not production-ready | no |
+
+`shared/system-visibility.ts` is the executable policy source.
+
+## Elegant natal PDF
+
+The one production natal-report path is:
+
+`profile.tsx` → `NatalReportDownloadButton.tsx` → `GET /api/pdf/profile/:id` → `server/lib/natal-report-contract.ts` → `server/natalReportPdf.ts`
+
+The truth adapter permits verified astronomy and deterministic calculations while withholding unsupported houses, aspects, nodes, Chiron, Midheaven, and planetary-house claims.
+
+The old template generators under `services/pdf-generator.ts` and `packages/astrology/pdf-generator.ts` are legacy source only. Production `server/**` and `client/**` may not import them. `tests/pdf-production-path-contract.test.ts` locks that boundary.
+
+## Not yet a production claim
+
+This tranche does not declare completion of:
+
+- independently verified houses / Midheaven;
+- full verified planetary set and aspects;
+- verified nodes / Chiron / planetary house placements;
+- authoritative Human Design interpretation/Compatibility;
+- real astrocartography planetary-line calculation and map rendering;
+- palm-image computer vision.
+
+Those are engineering lanes, not empty UI slots. Until they have evidence-grade implementations, Soul Codex may explain that they are unavailable but must not substitute sample data, guessed values, or decorative output.

--- a/server/index.ts
+++ b/server/index.ts
@@ -9,6 +9,7 @@ import path from "node:path";
 import { existsSync } from "node:fs";
 import { registerRoutes } from "./routes.js";
 import { registerProfileVerificationRoutes } from "./routes/profile-verification.js";
+import { registerLocationResolutionRoutes } from "./routes/location-resolution.js";
 import { registerCodexToolRoutes } from "./routes/codex-tools.js";
 import compatibilityRouter from "./routes/compatibility.js";
 import { resolveReleaseIdentity } from "./lib/release-identity.js";
@@ -89,6 +90,10 @@ registerBillingRawRoutes(app);
 
 app.use(express.json({ limit: "256kb", strict: true }));
 app.use(express.urlencoded({ extended: false, limit: "64kb" }));
+
+// Explicit Resolve place requests are handled server-side so the IANA timezone
+// comes from the birth coordinates rather than the timezone of the current device.
+registerLocationResolutionRoutes(app);
 
 // Local-first users can request astronomy verification without creating a
 // server profile, invoking AI generation, or sending unrelated identity data.

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -21,7 +21,6 @@ import {
   generateBiography,
   generateDailyGuidance,
 } from "./services/openai-service";
-import { registerGalacticCodeRoutes } from "./routes/galactic-code";
 import { buildNatalReportPdf } from "./natalReportPdf";
 import {
   buildNatalReportInput,
@@ -230,6 +229,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // second naked-sign or Human Design compatibility path here: alternate routes
   // become alternate truth policies.
 
-  registerGalacticCodeRoutes(app);
+  // Galactic Code remains an internal deterministic service until a
+  // server-owned evidence adapter can supply verified astrology, deterministic
+  // numerology, assessed behavior, and a verified Human Design trust record.
+  // Do not mount its legacy caller-supplied route as a production synthesis
+  // boundary: clients cannot self-attest that candidate values are verified.
   return createServer(app);
 }

--- a/server/routes/location-resolution.ts
+++ b/server/routes/location-resolution.ts
@@ -1,0 +1,83 @@
+import type { Express } from "express";
+import { z } from "zod";
+import * as geoTz from "geo-tz";
+import { resolveGeo } from "../geo/index";
+
+const resolveLocationSchema = z
+  .object({
+    place: z.string().trim().min(2).max(200),
+  })
+  .strict();
+
+function isUsableTimezone(value: unknown): value is string {
+  if (typeof value !== "string" || !value.trim()) return false;
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: value }).format(new Date());
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Minimal location-resolution route for the local-first create flow.
+ *
+ * The user invokes this explicitly by pressing Resolve place. Only the entered
+ * place string is sent. The server resolves coordinates and derives the IANA
+ * timezone from those coordinates so a remote birth location can never inherit
+ * the timezone of the device currently filling out the form.
+ *
+ * Nothing is persisted and no profile is created.
+ */
+export function registerLocationResolutionRoutes(app: Express) {
+  app.post("/api/location/resolve", async (req, res) => {
+    const parsed = resolveLocationSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        message: "Location request is invalid",
+        code: "invalid_location_request",
+      });
+    }
+
+    try {
+      const geo = await resolveGeo(parsed.data.place);
+      if (!geo) {
+        return res.status(404).json({
+          message: "Birth location could not be resolved",
+          code: "location_not_found",
+        });
+      }
+
+      const timezoneCandidates = geoTz.find(geo.lat, geo.lon);
+      const timezone = timezoneCandidates.find(isUsableTimezone) ?? null;
+      if (!timezone) {
+        return res.status(422).json({
+          message: "Coordinates were found, but an IANA timezone could not be resolved safely",
+          code: "timezone_unresolved",
+          latitude: geo.lat,
+          longitude: geo.lon,
+          normalizedPlace: geo.normalizedPlace,
+        });
+      }
+
+      return res.json({
+        normalizedPlace: geo.normalizedPlace,
+        latitude: geo.lat,
+        longitude: geo.lon,
+        timezone,
+        provider: geo.provider,
+        processing: {
+          persistedProfile: false,
+          aiGeneration: false,
+          purpose: "birth_location_resolution_only",
+        },
+      });
+    } catch (error) {
+      console.error("[LocationResolution] Failed safely:", error);
+      return res.status(503).json({
+        message: "Location resolution is temporarily unavailable",
+        code: "location_resolution_unavailable",
+      });
+    }
+  });
+}

--- a/server/services/galactic-code/__tests__/galactic-code.test.ts
+++ b/server/services/galactic-code/__tests__/galactic-code.test.ts
@@ -19,6 +19,7 @@ const testInput: GalacticCodeInput = {
   birthTime: '05:15',
   birthLocation: 'Detroit, Michigan',
   astrology: {
+    evidenceState: 'verified',
     sun: 'Virgo',
     moon: 'Capricorn',
     rising: 'Scorpio',
@@ -32,6 +33,7 @@ const testInput: GalacticCodeInput = {
     coverage: 'complete',
   },
   humanDesign: {
+    evidenceState: 'verified',
     type: 'Generator',
     strategy: 'To Respond',
     authority: 'Sacral',
@@ -44,6 +46,7 @@ const testInput: GalacticCodeInput = {
     coverage: 'complete',
   },
   numerology: {
+    evidenceState: 'deterministic',
     lifePath: 7,
     birthdayNumber: 5,
     expressionNumber: 8,
@@ -53,6 +56,7 @@ const testInput: GalacticCodeInput = {
     coverage: 'partial',
   },
   behavior: {
+    evidenceState: 'assessed',
     traits: ['analytical', 'reserved', 'methodical', 'strategic'],
     decisionStyle: 'Data-driven',
     stressPattern: 'Over-analysis paralysis',
@@ -140,6 +144,7 @@ test('Galactic Code: System Coverage & Confidence', async (t) => {
     const sunOnlyInput: GalacticCodeInput = {
       profileId: 'sun-only',
       astrology: {
+        evidenceState: 'verified',
         sun: 'Virgo',
         coverage: 'complete',
       } as any,
@@ -235,6 +240,7 @@ test('Galactic Code: Changed inputs produce different fingerprints', async (t) =
     const changedInput: GalacticCodeInput = {
       ...testInput,
       humanDesign: {
+        evidenceState: 'verified',
         ...testInput.humanDesign,
         authority: 'Emotional',
       },
@@ -248,6 +254,7 @@ test('Galactic Code: Changed inputs produce different fingerprints', async (t) =
     const changedInput: GalacticCodeInput = {
       ...testInput,
       numerology: {
+        evidenceState: 'deterministic',
         ...testInput.numerology,
         lifePath: 3,
       },
@@ -337,13 +344,14 @@ test('Normalization: Stability', async (t) => {
 });
 
 test('Galactic Code: Coverage vs Verification (Diamond Doctrine)', async (t) => {
-  await t.test('complete coverage does not imply verification', () => {
+  await t.test('qualified evidence and coverage remain separate states', () => {
     const completeCoverageInput: GalacticCodeInput = {
       profileId: 'coverage-test',
       birthDate: '1995-06-15',
       birthTime: '10:30',
       birthLocation: 'Portland, Oregon',
       astrology: {
+        evidenceState: 'verified',
         sun: 'Gemini',
         moon: 'Libra',
         rising: 'Aquarius',
@@ -357,6 +365,7 @@ test('Galactic Code: Coverage vs Verification (Diamond Doctrine)', async (t) => 
         coverage: 'complete',
       },
       humanDesign: {
+        evidenceState: 'verified',
         type: 'Projector',
         strategy: 'To Be Invited',
         authority: 'Mental',
@@ -369,6 +378,7 @@ test('Galactic Code: Coverage vs Verification (Diamond Doctrine)', async (t) => 
         coverage: 'complete',
       },
       numerology: {
+        evidenceState: 'deterministic',
         lifePath: 3,
         birthdayNumber: 6,
         expressionNumber: 9,
@@ -378,6 +388,7 @@ test('Galactic Code: Coverage vs Verification (Diamond Doctrine)', async (t) => 
         coverage: 'partial',
       },
       behavior: {
+        evidenceState: 'assessed',
         traits: ['creative', 'communicative', 'analytical', 'collaborative', 'adaptable'],
         decisionStyle: 'Intuitive',
         stressPattern: 'Perfectionism',
@@ -425,5 +436,31 @@ test('Galactic Code: Coverage vs Verification (Diamond Doctrine)', async (t) => 
     assert.throws(() => generateGalacticCode(input), /requires at least 2 of 3 systems/);
 
     // The point: coverage measures data availability, not independent verification status
+  });
+
+  await t.test('unverified Human Design cannot change production synthesis', () => {
+    const candidateA: GalacticCodeInput = {
+      ...testInput,
+      humanDesign: {
+        ...testInput.humanDesign,
+        evidenceState: 'candidate',
+        type: 'Generator',
+        profile: '2/4',
+      },
+    };
+    const candidateB: GalacticCodeInput = {
+      ...candidateA,
+      humanDesign: {
+        ...candidateA.humanDesign,
+        type: 'Reflector',
+        profile: '6/2',
+      },
+    };
+
+    const resultA = generateGalacticCode(candidateA);
+    const resultB = generateGalacticCode(candidateB);
+    assert.strictEqual(resultA.fingerprint, resultB.fingerprint);
+    assert.strictEqual(resultA.sourceCoverage.humanDesign, 'missing');
+    assert.ok(resultA.evidence.every((value) => !value.startsWith('HD ')));
   });
 });

--- a/server/services/galactic-code/generator.ts
+++ b/server/services/galactic-code/generator.ts
@@ -14,6 +14,42 @@ import { normalizeGalacticInput, extractHashableInput } from './normalize';
 import { createGalacticFingerprint } from './fingerprint';
 import { scoreAxes, getTopAxes } from './scoring';
 import { createDeterministicInterpretation } from './prompts';
+import { maySystemInfluenceSynthesis } from '../../../shared/system-visibility';
+
+function synthesisEligibleInput(input: GalacticCodeInput): GalacticCodeInput {
+  const astrologyAllowed = maySystemInfluenceSynthesis(
+    'astrologyCore',
+    input.astrology.evidenceState || 'candidate',
+  );
+  const humanDesignAllowed = maySystemInfluenceSynthesis(
+    'humanDesign',
+    input.humanDesign.evidenceState || 'candidate',
+  );
+  const numerologyAllowed = maySystemInfluenceSynthesis(
+    'numerology',
+    input.numerology.evidenceState || 'candidate',
+  );
+  const behaviorAllowed = maySystemInfluenceSynthesis(
+    'personalityAssessments',
+    input.behavior.evidenceState || 'candidate',
+  );
+
+  return {
+    ...input,
+    astrology: astrologyAllowed
+      ? input.astrology
+      : { coverage: 'missing', evidenceState: input.astrology.evidenceState || 'candidate' },
+    humanDesign: humanDesignAllowed
+      ? input.humanDesign
+      : { coverage: 'missing', evidenceState: input.humanDesign.evidenceState || 'candidate' },
+    numerology: numerologyAllowed
+      ? input.numerology
+      : { coverage: 'missing', evidenceState: input.numerology.evidenceState || 'candidate' },
+    behavior: behaviorAllowed
+      ? input.behavior
+      : { traits: [], evidenceState: input.behavior.evidenceState || 'candidate' },
+  };
+}
 
 const TEXTURE_WORDS = [
   'Obsidian',
@@ -45,11 +81,13 @@ const FUNCTION_WORDS = [
 ];
 
 export function generateGalacticCode(input: GalacticCodeInput): GalacticCodeResult {
+  const eligibleInput = synthesisEligibleInput(input);
+
   // Step 1: Validate minimum system coverage
-  const hasAstrology = input.astrology.coverage !== 'missing' && input.astrology.sun;
-  const hasHD = input.humanDesign.coverage !== 'missing' && input.humanDesign.type;
-  const hasNumerology = input.numerology.coverage !== 'missing' && input.numerology.lifePath;
-  const traitCount = (input.behavior.traits || []).length;
+  const hasAstrology = eligibleInput.astrology.coverage !== 'missing' && eligibleInput.astrology.sun;
+  const hasHD = eligibleInput.humanDesign.coverage !== 'missing' && eligibleInput.humanDesign.type;
+  const hasNumerology = eligibleInput.numerology.coverage !== 'missing' && eligibleInput.numerology.lifePath;
+  const traitCount = (eligibleInput.behavior.traits || []).length;
 
   const systemCount = [hasAstrology, hasHD, hasNumerology].filter(Boolean).length;
 
@@ -58,7 +96,7 @@ export function generateGalacticCode(input: GalacticCodeInput): GalacticCodeResu
   }
 
   // Step 2: Normalize
-  const normalized = normalizeGalacticInput(input);
+  const normalized = normalizeGalacticInput(eligibleInput);
 
   // Step 3: Fingerprint
   const hashableInput = extractHashableInput(normalized);
@@ -76,7 +114,7 @@ export function generateGalacticCode(input: GalacticCodeInput): GalacticCodeResu
   const primaryFunction = topThreeAxes[0]?.label || 'Architect';
   const secondaryFunction = topThreeAxes[1]?.label || 'Guardian';
   const legacyFunction = determineLegacyFunction(
-    input.numerology.lifePath?.toString(),
+    eligibleInput.numerology.lifePath?.toString(),
     normalized.behavior.builderMode
   );
 
@@ -89,9 +127,9 @@ export function generateGalacticCode(input: GalacticCodeInput): GalacticCodeResu
 
   // Step 7: Create frequency
   const frequency = createFrequency(
-    input.birthDate,
-    input.birthTime,
-    input.numerology.lifePath?.toString()
+    eligibleInput.birthDate,
+    eligibleInput.birthTime,
+    eligibleInput.numerology.lifePath?.toString()
   );
 
   // Step 8: Element matrix

--- a/server/services/galactic-code/normalize.ts
+++ b/server/services/galactic-code/normalize.ts
@@ -10,6 +10,7 @@
  */
 
 import type { GalacticCodeInput, NormalizedGalacticInput, SourceCoverageState } from '../../../shared/galactic-code/types';
+import type { SoulCodexEvidenceState } from '../../../shared/system-visibility';
 
 function normalizeText(value?: string): string | null {
   if (!value) return null;
@@ -32,6 +33,12 @@ function normalizeCoverage(coverage?: SourceCoverageState): SourceCoverageState 
   return coverage;
 }
 
+function normalizeEvidenceState(
+  evidenceState?: SoulCodexEvidenceState,
+): SoulCodexEvidenceState {
+  return evidenceState || 'candidate';
+}
+
 export function normalizeGalacticInput(input: GalacticCodeInput): NormalizedGalacticInput {
   return {
     profileId: input.profileId.trim(),
@@ -39,6 +46,7 @@ export function normalizeGalacticInput(input: GalacticCodeInput): NormalizedGala
     birthTime: normalizeText(input.birthTime),
     birthLocation: normalizeText(input.birthLocation),
     astrology: {
+      evidenceState: normalizeEvidenceState(input.astrology.evidenceState),
       sun: normalizeText(input.astrology.sun),
       moon: normalizeText(input.astrology.moon),
       rising: normalizeText(input.astrology.rising),
@@ -52,6 +60,7 @@ export function normalizeGalacticInput(input: GalacticCodeInput): NormalizedGala
       coverage: normalizeCoverage(input.astrology.coverage),
     },
     humanDesign: {
+      evidenceState: normalizeEvidenceState(input.humanDesign.evidenceState),
       type: normalizeText(input.humanDesign.type),
       strategy: normalizeText(input.humanDesign.strategy),
       authority: normalizeText(input.humanDesign.authority),
@@ -65,6 +74,7 @@ export function normalizeGalacticInput(input: GalacticCodeInput): NormalizedGala
       coverage: normalizeCoverage(input.humanDesign.coverage),
     },
     numerology: {
+      evidenceState: normalizeEvidenceState(input.numerology.evidenceState),
       lifePath: normalizeText(String(input.numerology.lifePath ?? '')),
       birthdayNumber: normalizeText(String(input.numerology.birthdayNumber ?? '')),
       expressionNumber: normalizeText(String(input.numerology.expressionNumber ?? '')),
@@ -74,6 +84,7 @@ export function normalizeGalacticInput(input: GalacticCodeInput): NormalizedGala
       coverage: normalizeCoverage(input.numerology.coverage),
     },
     behavior: {
+      evidenceState: normalizeEvidenceState(input.behavior.evidenceState),
       traits: normalizeArray(input.behavior.traits),
       decisionStyle: normalizeText(input.behavior.decisionStyle),
       stressPattern: normalizeText(input.behavior.stressPattern),
@@ -96,6 +107,7 @@ export function extractHashableInput(normalized: NormalizedGalacticInput): unkno
     profileId: normalized.profileId,
     birthDate: normalized.birthDate,
     astrology: {
+      evidenceState: normalized.astrology.evidenceState,
       sun: normalized.astrology.sun,
       moon: normalized.astrology.moon,
       rising: normalized.astrology.rising,
@@ -106,6 +118,7 @@ export function extractHashableInput(normalized: NormalizedGalacticInput): unkno
       dominantModalities: normalized.astrology.dominantModalities,
     },
     humanDesign: {
+      evidenceState: normalized.humanDesign.evidenceState,
       type: normalized.humanDesign.type,
       strategy: normalized.humanDesign.strategy,
       authority: normalized.humanDesign.authority,
@@ -115,11 +128,13 @@ export function extractHashableInput(normalized: NormalizedGalacticInput): unkno
       incarnationCross: normalized.humanDesign.incarnationCross,
     },
     numerology: {
+      evidenceState: normalized.numerology.evidenceState,
       lifePath: normalized.numerology.lifePath,
       birthdayNumber: normalized.numerology.birthdayNumber,
       expressionNumber: normalized.numerology.expressionNumber,
     },
     behavior: {
+      evidenceState: normalized.behavior.evidenceState,
       traits: normalized.behavior.traits,
       decisionStyle: normalized.behavior.decisionStyle,
       stressPattern: normalized.behavior.stressPattern,

--- a/shared/galactic-code/types.ts
+++ b/shared/galactic-code/types.ts
@@ -5,6 +5,8 @@
  * behavioral traits, and symbolic archetypes into a stable identity fingerprint.
  */
 
+import type { SoulCodexEvidenceState } from '../system-visibility';
+
 /**
  * Coverage states represent data completeness, not verification status.
  * Complete data ≠ verified data (Diamond Doctrine principle).
@@ -13,6 +15,7 @@ export type SourceCoverageState = 'complete' | 'partial' | 'missing';
 export type GalacticCoverageState = 'high' | 'partial' | 'insufficient';
 
 export interface GalacticAstrologyInput {
+  evidenceState?: SoulCodexEvidenceState;
   sun?: string;
   moon?: string;
   rising?: string;
@@ -27,6 +30,7 @@ export interface GalacticAstrologyInput {
 }
 
 export interface GalacticHumanDesignInput {
+  evidenceState?: SoulCodexEvidenceState;
   type?: string;
   strategy?: string;
   authority?: string;
@@ -43,6 +47,7 @@ export interface GalacticHumanDesignInput {
 }
 
 export interface GalacticNumerologyInput {
+  evidenceState?: SoulCodexEvidenceState;
   lifePath?: number | string;
   birthdayNumber?: number | string;
   expressionNumber?: number | string;
@@ -53,6 +58,7 @@ export interface GalacticNumerologyInput {
 }
 
 export interface GalacticBehaviorInput {
+  evidenceState?: SoulCodexEvidenceState;
   traits: string[];
   decisionStyle?: string;
   stressPattern?: string;
@@ -130,6 +136,7 @@ export interface NormalizedGalacticInput {
   birthTime: string | null;
   birthLocation: string | null;
   astrology: {
+    evidenceState: SoulCodexEvidenceState;
     sun: string | null;
     moon: string | null;
     rising: string | null;
@@ -143,6 +150,7 @@ export interface NormalizedGalacticInput {
     coverage: SourceCoverageState;
   };
   humanDesign: {
+    evidenceState: SoulCodexEvidenceState;
     type: string | null;
     strategy: string | null;
     authority: string | null;
@@ -156,6 +164,7 @@ export interface NormalizedGalacticInput {
     coverage: SourceCoverageState;
   };
   numerology: {
+    evidenceState: SoulCodexEvidenceState;
     lifePath: string | null;
     birthdayNumber: string | null;
     expressionNumber: string | null;
@@ -165,6 +174,7 @@ export interface NormalizedGalacticInput {
     coverage: SourceCoverageState;
   };
   behavior: {
+    evidenceState: SoulCodexEvidenceState;
     traits: string[];
     decisionStyle: string | null;
     stressPattern: string | null;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -120,6 +120,26 @@ const birthTimeSchema = z.union([
   z.string().regex(/^\d{2}:\d{2}$/, "Birth time must use HH:MM when provided"),
 ]);
 
+export function isValidIanaTimezone(value: unknown): value is string {
+  if (typeof value !== "string" || !value.trim()) return false;
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: value.trim() }).format(new Date());
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function isCoordinateWithinRange(
+  value: unknown,
+  minimum: number,
+  maximum: number,
+): boolean {
+  if (value === undefined || value === null || String(value).trim() === "") return false;
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric >= minimum && numeric <= maximum;
+}
+
 export const birthDataSchema = z.object({
   name: z.string().min(1, "Name is required"),
   birthDate: z.string().min(1, "Birth date is required"),
@@ -127,7 +147,7 @@ export const birthDataSchema = z.object({
   // invent a clock time just to satisfy validation.
   birthTime: birthTimeSchema,
   birthLocation: z.string().min(1, "Birth location is required"),
-  timezone: z.string().min(1, "Timezone is required"),
+  timezone: z.string(),
   latitude: z.union([z.string(), z.number()]).optional(),
   longitude: z.union([z.string(), z.number()]).optional(),
   fatherSign: z.string().optional(),
@@ -152,6 +172,44 @@ export const birthDataSchema = z.object({
   socialEnergy: z.string().optional(),
   nonNegotiables: z.array(z.string()).optional(),
   goals: z.array(z.string()).optional(),
+}).superRefine((data, context) => {
+  const timezone = data.timezone.trim();
+  if (timezone && !isValidIanaTimezone(timezone)) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["timezone"],
+      message: "Timezone must be a valid IANA timezone",
+    });
+  }
+  if (data.birthTime && !timezone) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["timezone"],
+      message: "Timezone is required when birth time is provided",
+    });
+  }
+  if (
+    data.latitude !== undefined &&
+    String(data.latitude).trim() !== "" &&
+    !isCoordinateWithinRange(data.latitude, -90, 90)
+  ) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["latitude"],
+      message: "Latitude must be a finite number between -90 and 90",
+    });
+  }
+  if (
+    data.longitude !== undefined &&
+    String(data.longitude).trim() !== "" &&
+    !isCoordinateWithinRange(data.longitude, -180, 180)
+  ) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["longitude"],
+      message: "Longitude must be a finite number between -180 and 180",
+    });
+  }
 });
 
 export const signupSchema = z.object({

--- a/shared/system-visibility.ts
+++ b/shared/system-visibility.ts
@@ -11,6 +11,13 @@ export type SoulCodexEvidenceRequirement =
   | "user-assessment"
   | "not-production-ready";
 
+export type SoulCodexEvidenceState =
+  | "verified"
+  | "deterministic"
+  | "assessed"
+  | "candidate"
+  | "unavailable";
+
 export interface SoulCodexSystemPolicy {
   id: string;
   label: string;
@@ -103,6 +110,42 @@ export const SOUL_CODEX_SYSTEM_POLICIES = {
     rule: "No generated palm claims without an actual image-analysis contract and explicit image consent.",
   },
 } as const satisfies Record<string, SoulCodexSystemPolicy>;
+
+export type SoulCodexSystemKey = keyof typeof SOUL_CODEX_SYSTEM_POLICIES;
+
+export function maySystemInfluenceSynthesis(
+  system: SoulCodexSystemKey,
+  evidenceState: SoulCodexEvidenceState,
+): boolean {
+  const policy = SOUL_CODEX_SYSTEM_POLICIES[system];
+  if (!policy.mayInfluencePrimarySynthesis || policy.visibility === "unavailable") {
+    return false;
+  }
+
+  switch (policy.evidenceRequirement) {
+    case "deterministic":
+      return evidenceState === "deterministic" || evidenceState === "verified";
+    case "verified-astronomy":
+    case "verified-system-contract":
+      return evidenceState === "verified";
+    case "user-assessment":
+      return evidenceState === "assessed" || evidenceState === "verified";
+    case "not-production-ready":
+      return false;
+  }
+}
+
+export function mayInspectSystem(
+  system: SoulCodexSystemKey,
+  evidenceState: SoulCodexEvidenceState,
+): boolean {
+  const policy = SOUL_CODEX_SYSTEM_POLICIES[system];
+  if (policy.visibility === "unavailable") return false;
+  if (evidenceState === "verified" || evidenceState === "deterministic" || evidenceState === "assessed") {
+    return true;
+  }
+  return policy.inspectableWhenUnverified && evidenceState === "candidate";
+}
 
 export function systemsAllowedToInfluenceSynthesis(): SoulCodexSystemPolicy[] {
   return Object.values(SOUL_CODEX_SYSTEM_POLICIES).filter(

--- a/shared/system-visibility.ts
+++ b/shared/system-visibility.ts
@@ -1,0 +1,117 @@
+export type SoulCodexSystemVisibility =
+  | "primary"
+  | "supporting"
+  | "inspectable"
+  | "unavailable";
+
+export type SoulCodexEvidenceRequirement =
+  | "deterministic"
+  | "verified-astronomy"
+  | "verified-system-contract"
+  | "user-assessment"
+  | "not-production-ready";
+
+export interface SoulCodexSystemPolicy {
+  id: string;
+  label: string;
+  visibility: SoulCodexSystemVisibility;
+  evidenceRequirement: SoulCodexEvidenceRequirement;
+  mayInfluencePrimarySynthesis: boolean;
+  inspectableWhenUnverified: boolean;
+  rule: string;
+}
+
+/**
+ * Canonical product rule for specialist systems.
+ *
+ * The primary Soul Codex is synthesis-first. Specialist systems may enrich the
+ * synthesis when their evidence contract is strong enough, while raw labels
+ * remain available in the optional inspector. An implementation is never
+ * promoted merely because a calculator or legacy route exists.
+ */
+export const SOUL_CODEX_SYSTEM_POLICIES = {
+  astrologyCore: {
+    id: "astrology-core",
+    label: "Astrology · Sun / Moon / Rising",
+    visibility: "supporting",
+    evidenceRequirement: "verified-astronomy",
+    mayInfluencePrimarySynthesis: true,
+    inspectableWhenUnverified: true,
+    rule: "Verified placements may enrich synthesis. Internal candidates may be inspected with an explicit unverified label but never relabeled as chart facts.",
+  },
+  numerology: {
+    id: "numerology",
+    label: "Numerology",
+    visibility: "supporting",
+    evidenceRequirement: "deterministic",
+    mayInfluencePrimarySynthesis: true,
+    inspectableWhenUnverified: true,
+    rule: "Arithmetic values are deterministic under the documented formula; psychological or spiritual meaning remains symbolic.",
+  },
+  humanDesign: {
+    id: "human-design",
+    label: "Human Design",
+    visibility: "inspectable",
+    evidenceRequirement: "verified-system-contract",
+    mayInfluencePrimarySynthesis: true,
+    inspectableWhenUnverified: true,
+    rule: "Calculated candidates remain inspectable only. Human Design may influence synthesis only after its trust record is verified.",
+  },
+  personalityAssessments: {
+    id: "personality-assessments",
+    label: "Personality assessments",
+    visibility: "supporting",
+    evidenceRequirement: "user-assessment",
+    mayInfluencePrimarySynthesis: true,
+    inspectableWhenUnverified: true,
+    rule: "Assessment results may support reflection when based on explicit user responses; they are tendencies within a model, not diagnoses.",
+  },
+  housesMidheaven: {
+    id: "houses-midheaven",
+    label: "Houses / Midheaven",
+    visibility: "unavailable",
+    evidenceRequirement: "not-production-ready",
+    mayInfluencePrimarySynthesis: false,
+    inspectableWhenUnverified: false,
+    rule: "Withheld until the house/MC calculation and independent verification contract is release-grade.",
+  },
+  nodesChiron: {
+    id: "nodes-chiron",
+    label: "Nodes / Chiron / planetary house placements",
+    visibility: "unavailable",
+    evidenceRequirement: "not-production-ready",
+    mayInfluencePrimarySynthesis: false,
+    inspectableWhenUnverified: false,
+    rule: "No production interpretation until astronomical evidence and placement verification are approved.",
+  },
+  astrocartography: {
+    id: "astrocartography",
+    label: "Astrocartography",
+    visibility: "unavailable",
+    evidenceRequirement: "not-production-ready",
+    mayInfluencePrimarySynthesis: false,
+    inspectableWhenUnverified: false,
+    rule: "No sample power places or decorative planetary lines. Release requires real line calculation, mapping, and evidence tests.",
+  },
+  palmistry: {
+    id: "palmistry",
+    label: "Palmistry",
+    visibility: "unavailable",
+    evidenceRequirement: "not-production-ready",
+    mayInfluencePrimarySynthesis: false,
+    inspectableWhenUnverified: false,
+    rule: "No generated palm claims without an actual image-analysis contract and explicit image consent.",
+  },
+} as const satisfies Record<string, SoulCodexSystemPolicy>;
+
+export function systemsAllowedToInfluenceSynthesis(): SoulCodexSystemPolicy[] {
+  return Object.values(SOUL_CODEX_SYSTEM_POLICIES).filter(
+    (policy) => policy.mayInfluencePrimarySynthesis,
+  );
+}
+
+export function unavailableProductionSystems(): SoulCodexSystemPolicy[] {
+  return Object.values(SOUL_CODEX_SYSTEM_POLICIES).filter(
+    (policy) => policy.visibility === "unavailable",
+  );
+}

--- a/shared/system-visibility.ts
+++ b/shared/system-visibility.ts
@@ -113,11 +113,15 @@ export const SOUL_CODEX_SYSTEM_POLICIES = {
 
 export type SoulCodexSystemKey = keyof typeof SOUL_CODEX_SYSTEM_POLICIES;
 
+function policyFor(system: SoulCodexSystemKey): SoulCodexSystemPolicy {
+  return SOUL_CODEX_SYSTEM_POLICIES[system];
+}
+
 export function maySystemInfluenceSynthesis(
   system: SoulCodexSystemKey,
   evidenceState: SoulCodexEvidenceState,
 ): boolean {
-  const policy = SOUL_CODEX_SYSTEM_POLICIES[system];
+  const policy = policyFor(system);
   if (!policy.mayInfluencePrimarySynthesis || policy.visibility === "unavailable") {
     return false;
   }
@@ -139,9 +143,13 @@ export function mayInspectSystem(
   system: SoulCodexSystemKey,
   evidenceState: SoulCodexEvidenceState,
 ): boolean {
-  const policy = SOUL_CODEX_SYSTEM_POLICIES[system];
+  const policy = policyFor(system);
   if (policy.visibility === "unavailable") return false;
-  if (evidenceState === "verified" || evidenceState === "deterministic" || evidenceState === "assessed") {
+  if (
+    evidenceState === "verified" ||
+    evidenceState === "deterministic" ||
+    evidenceState === "assessed"
+  ) {
     return true;
   }
   return policy.inspectableWhenUnverified && evidenceState === "candidate";

--- a/tests/ascendant-retry-contract.test.ts
+++ b/tests/ascendant-retry-contract.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { generateOfflineCodexProfile } from "../packages/core/offline-codex/index.ts";
+import {
+  CURRENT_ASTROLOGY_VERIFICATION_VERSION,
+  profileNeedsOnlineVerification,
+  type ReconciledOfflineProfile,
+} from "../client/src/lib/profileVerificationReconciliation.ts";
+
+function exactProfile(): ReconciledOfflineProfile {
+  const local = generateOfflineCodexProfile(
+    {
+      name: "Retry Example",
+      birthDate: "1990-09-17",
+      birthTime: "11:11",
+      birthLocation: "Bronx, New York",
+      timezone: "America/New_York",
+      latitude: "40.8448",
+      longitude: "-73.8648",
+    },
+    { id: "local-retry", generatedAt: "2026-08-20T12:00:00.000Z", currentYear: 2026 },
+  );
+
+  return {
+    ...local,
+    verifiedAstrologyData: {
+      sun: { verificationStatus: "verified", sign: "Virgo" },
+      moon: { verificationStatus: "verified", sign: "Virgo" },
+      rising: {
+        verificationStatus: "pending_independent_verification",
+        sign: null,
+      },
+      verification: {
+        verifiedBodies: ["Sun", "Moon"],
+        unresolvedBodies: ["Ascendant"],
+      },
+    },
+    remoteSync: {
+      remoteId: "local-retry",
+      syncedAt: "2026-08-20T12:01:00.000Z",
+      status: "verified-online",
+      verificationVersion: CURRENT_ASTROLOGY_VERIFICATION_VERSION,
+    },
+  };
+}
+
+test("current verification version does not hide retry while exact-input Rising is unresolved", () => {
+  const profile = exactProfile();
+  assert.equal(profile.remoteSync?.verificationVersion, CURRENT_ASTROLOGY_VERIFICATION_VERSION);
+  assert.equal(profileNeedsOnlineVerification(profile), true);
+});
+
+test("verified Rising completes the exact-input verification requirement", () => {
+  const profile = exactProfile();
+  profile.verifiedAstrologyData = {
+    ...profile.verifiedAstrologyData,
+    rising: { verificationStatus: "verified", sign: "Scorpio" },
+  };
+  assert.equal(profileNeedsOnlineVerification(profile), false);
+});
+
+test("missing exact Ascendant coordinates do not create an endless retry loop", () => {
+  const profile = exactProfile();
+  profile.latitude = null;
+  profile.longitude = null;
+  assert.equal(profileNeedsOnlineVerification(profile), false);
+});

--- a/tests/location-resolution-contract.test.ts
+++ b/tests/location-resolution-contract.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import * as geoTz from "geo-tz";
+
+const createFlow = readFileSync(
+  new URL("../client/src/pages/local-first-input-form.tsx", import.meta.url),
+  "utf8",
+);
+const routeSource = readFileSync(
+  new URL("../server/routes/location-resolution.ts", import.meta.url),
+  "utf8",
+);
+
+test("coordinate-derived timezone resolution identifies known birth locations", () => {
+  assert.ok(geoTz.find(40.7128, -74.006).includes("America/New_York"));
+  assert.ok(geoTz.find(35.6762, 139.6503).includes("Asia/Tokyo"));
+  assert.ok(geoTz.find(18.4655, -66.1057).includes("America/Puerto_Rico"));
+});
+
+test("create flow never substitutes the current device timezone for a remote birthplace", () => {
+  assert.match(createFlow, /\/api\/location\/resolve/);
+  assert.match(createFlow, /timezone:\s*""/);
+  assert.match(createFlow, /Your current device timezone is never substituted/);
+  assert.doesNotMatch(createFlow, /nominatim\.openstreetmap\.org/);
+  assert.doesNotMatch(createFlow, /browserTimezone/);
+  assert.doesNotMatch(createFlow, /timezone:\s*browserTimezone/);
+});
+
+test("complete timed chart inputs are explained as verification-ready, not missing", () => {
+  assert.match(createFlow, /data-testid="chart-input-readiness"/);
+  assert.match(createFlow, /Exact chart inputs are ready/);
+  assert.match(createFlow, /calculate Moon and Rising candidates/);
+  assert.match(createFlow, /Independent online verification is the only remaining step/);
+});
+
+test("location resolution remains minimal-purpose and non-persistent", () => {
+  assert.match(routeSource, /resolveGeo\(parsed\.data\.place\)/);
+  assert.match(routeSource, /geoTz\.find\(geo\.lat, geo\.lon\)/);
+  assert.match(routeSource, /persistedProfile:\s*false/);
+  assert.match(routeSource, /aiGeneration:\s*false/);
+  assert.match(routeSource, /birth_location_resolution_only/);
+  assert.doesNotMatch(routeSource, /storage\./);
+  assert.doesNotMatch(routeSource, /generateBiography|generateDailyGuidance|OpenAI/);
+});

--- a/tests/location-resolution-contract.test.ts
+++ b/tests/location-resolution-contract.test.ts
@@ -48,6 +48,11 @@ test("location resolution remains minimal-purpose and non-persistent", () => {
 test("static geocoding rejects substring collisions and ambiguous qualified cities", () => {
   assert.equal(geocodeLocation("Glasgow, Scotland"), null);
   assert.equal(geocodeLocation("Camden, New Jersey"), null);
+  assert.deepEqual(geocodeLocation("Bronx, New York"), {
+    lat: "40.8448",
+    lon: "-73.8648",
+    location: "Bronx, New York",
+  });
   assert.equal(geocodeLocation("Los Angeles, California")?.lat, "34.0522");
   assert.equal(geocodeLocation("LA")?.lat, "34.0522");
 });

--- a/tests/location-resolution-contract.test.ts
+++ b/tests/location-resolution-contract.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 import * as geoTz from "geo-tz";
+import { geocodeLocation } from "../geocoding.ts";
 
 const createFlow = readFileSync(
   new URL("../client/src/pages/local-first-input-form.tsx", import.meta.url),
@@ -42,4 +43,11 @@ test("location resolution remains minimal-purpose and non-persistent", () => {
   assert.match(routeSource, /birth_location_resolution_only/);
   assert.doesNotMatch(routeSource, /storage\./);
   assert.doesNotMatch(routeSource, /generateBiography|generateDailyGuidance|OpenAI/);
+});
+
+test("static geocoding rejects substring collisions and ambiguous qualified cities", () => {
+  assert.equal(geocodeLocation("Glasgow, Scotland"), null);
+  assert.equal(geocodeLocation("Camden, New Jersey"), null);
+  assert.equal(geocodeLocation("Los Angeles, California")?.lat, "34.0522");
+  assert.equal(geocodeLocation("LA")?.lat, "34.0522");
 });

--- a/tests/pdf-production-path-contract.test.ts
+++ b/tests/pdf-production-path-contract.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+const root = new URL("..", import.meta.url);
+const serverRoutes = readFileSync(new URL("../server/routes.ts", import.meta.url), "utf8");
+const serverIndex = readFileSync(new URL("../server/index.ts", import.meta.url), "utf8");
+const button = readFileSync(new URL("../client/src/components/NatalReportDownloadButton.tsx", import.meta.url), "utf8");
+const truthAdapter = readFileSync(new URL("../server/lib/natal-report-contract.ts", import.meta.url), "utf8");
+const elegantRenderer = readFileSync(new URL("../server/natalReportPdf.ts", import.meta.url), "utf8");
+
+function filesUnder(relative: string): string[] {
+  const start = new URL(`../${relative}`, import.meta.url);
+  const startPath = start.pathname;
+  const files: string[] = [];
+  const walk = (directory: string) => {
+    for (const entry of readdirSync(directory)) {
+      const full = join(directory, entry);
+      const stat = statSync(full);
+      if (stat.isDirectory()) walk(full);
+      else if (/\.(ts|tsx|js|mjs)$/.test(entry)) files.push(full);
+    }
+  };
+  walk(startPath);
+  return files;
+}
+
+test("production PDF route uses the truth adapter and elegant PDFKit renderer", () => {
+  assert.match(serverRoutes, /\/api\/pdf\/profile\/:id/);
+  assert.match(serverRoutes, /buildNatalReportInput/);
+  assert.match(serverRoutes, /buildNatalReportPdf/);
+  assert.match(truthAdapter, /verificationStatus === "verified"/);
+  assert.match(truthAdapter, /houses:\s*\[\]/);
+  assert.match(truthAdapter, /aspects:\s*\[\]/);
+  assert.match(elegantRenderer, /PREMIUM_THEME/);
+  assert.match(elegantRenderer, /drawNatalWheel/);
+});
+
+test("client verifies MIME type and PDF signature before download", () => {
+  assert.match(button, /\/api\/pdf\/profile\//);
+  assert.match(button, /application\/pdf/);
+  assert.match(button, /signature !== "%PDF"/);
+  assert.match(button, /Download natal chart PDF/);
+});
+
+test("production server and client do not import legacy template PDF generators", () => {
+  const forbidden = [
+    "services/pdf-generator",
+    "packages/astrology/pdf-generator",
+  ];
+
+  for (const file of [...filesUnder("server"), ...filesUnder("client/src")]) {
+    const source = readFileSync(file, "utf8");
+    for (const path of forbidden) {
+      assert.equal(source.includes(path), false, `${file} must not import ${path}`);
+    }
+  }
+
+  // The production entry point is server/index.ts -> server/routes.ts. The old
+  // repository-root routes.ts may remain as legacy source while retirement is
+  // completed, but it is not allowed to become the production entry point.
+  assert.match(serverIndex, /from "\.\/routes\.js"/);
+  assert.doesNotMatch(serverIndex, /\.\.\/routes\.js/);
+});
+
+test("verified evidence is separated from symbolic narrative in the PDF adapter", () => {
+  assert.match(truthAdapter, /deterministic numerology calculation/);
+  assert.match(truthAdapter, /symbolic interpretation/);
+  assert.match(truthAdapter, /Human Design is not independently verified/);
+  assert.match(truthAdapter, /House emphasis, Midheaven, nodes, Chiron/);
+});

--- a/tests/pdf-production-path-contract.test.ts
+++ b/tests/pdf-production-path-contract.test.ts
@@ -3,7 +3,6 @@ import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
 
-const root = new URL("..", import.meta.url);
 const serverRoutes = readFileSync(new URL("../server/routes.ts", import.meta.url), "utf8");
 const serverIndex = readFileSync(new URL("../server/index.ts", import.meta.url), "utf8");
 const button = readFileSync(new URL("../client/src/components/NatalReportDownloadButton.tsx", import.meta.url), "utf8");
@@ -11,8 +10,7 @@ const truthAdapter = readFileSync(new URL("../server/lib/natal-report-contract.t
 const elegantRenderer = readFileSync(new URL("../server/natalReportPdf.ts", import.meta.url), "utf8");
 
 function filesUnder(relative: string): string[] {
-  const start = new URL(`../${relative}`, import.meta.url);
-  const startPath = start.pathname;
+  const startPath = new URL(`../${relative}`, import.meta.url).pathname;
   const files: string[] = [];
   const walk = (directory: string) => {
     for (const entry of readdirSync(directory)) {

--- a/tests/system-visibility-contract.test.ts
+++ b/tests/system-visibility-contract.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 import {
   SOUL_CODEX_SYSTEM_POLICIES,
@@ -6,6 +7,15 @@ import {
   maySystemInfluenceSynthesis,
   unavailableProductionSystems,
 } from "../shared/system-visibility.ts";
+
+const productionRoutes = readFileSync(
+  new URL("../server/routes.ts", import.meta.url),
+  "utf8",
+);
+const galacticGenerator = readFileSync(
+  new URL("../server/services/galactic-code/generator.ts", import.meta.url),
+  "utf8",
+);
 
 test("unverified astrology candidates are inspectable but cannot influence primary synthesis", () => {
   assert.equal(mayInspectSystem("astrologyCore", "candidate"), true);
@@ -34,4 +44,10 @@ test("unfinished systems cannot leak into production synthesis or inspection as 
     assert.equal(maySystemInfluenceSynthesis(key, "verified"), false);
     assert.equal(mayInspectSystem(key, "candidate"), false);
   }
+});
+
+test("production synthesis cannot accept caller-attested specialist evidence", () => {
+  assert.doesNotMatch(productionRoutes, /registerGalacticCodeRoutes\(app\)/);
+  assert.match(galacticGenerator, /maySystemInfluenceSynthesis/);
+  assert.match(galacticGenerator, /input\.humanDesign\.evidenceState \|\| 'candidate'/);
 });

--- a/tests/system-visibility-contract.test.ts
+++ b/tests/system-visibility-contract.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  SOUL_CODEX_SYSTEM_POLICIES,
+  mayInspectSystem,
+  maySystemInfluenceSynthesis,
+  unavailableProductionSystems,
+} from "../shared/system-visibility.ts";
+
+test("unverified astrology candidates are inspectable but cannot influence primary synthesis", () => {
+  assert.equal(mayInspectSystem("astrologyCore", "candidate"), true);
+  assert.equal(maySystemInfluenceSynthesis("astrologyCore", "candidate"), false);
+  assert.equal(maySystemInfluenceSynthesis("astrologyCore", "verified"), true);
+});
+
+test("deterministic numerology may support synthesis while its meaning remains symbolic by policy", () => {
+  assert.equal(maySystemInfluenceSynthesis("numerology", "deterministic"), true);
+  assert.match(SOUL_CODEX_SYSTEM_POLICIES.numerology.rule, /meaning remains symbolic/i);
+});
+
+test("Human Design candidate stays inspectable-only until its trust record verifies", () => {
+  assert.equal(mayInspectSystem("humanDesign", "candidate"), true);
+  assert.equal(maySystemInfluenceSynthesis("humanDesign", "candidate"), false);
+  assert.equal(maySystemInfluenceSynthesis("humanDesign", "verified"), true);
+});
+
+test("unfinished systems cannot leak into production synthesis or inspection as fake results", () => {
+  for (const policy of unavailableProductionSystems()) {
+    assert.equal(policy.mayInfluencePrimarySynthesis, false, policy.id);
+    assert.equal(policy.inspectableWhenUnverified, false, policy.id);
+  }
+
+  for (const key of ["housesMidheaven", "nodesChiron", "astrocartography", "palmistry"] as const) {
+    assert.equal(maySystemInfluenceSynthesis(key, "verified"), false);
+    assert.equal(mayInspectSystem(key, "candidate"), false);
+  }
+});

--- a/tests/unknown-time-input-contract.test.ts
+++ b/tests/unknown-time-input-contract.test.ts
@@ -16,6 +16,36 @@ test("blank birth time is accepted as an explicit unknown state", () => {
   assert.equal(parsed.birthTime, "");
 });
 
+test("untimed local profiles do not require a timezone", () => {
+  const parsed = birthDataSchema.parse({
+    ...base,
+    birthTime: "",
+    timezone: "",
+    latitude: "",
+    longitude: "",
+  });
+  assert.equal(parsed.timezone, "");
+});
+
+test("timed profiles require a valid timezone and bounded coordinates", () => {
+  assert.throws(
+    () => birthDataSchema.parse({ ...base, birthTime: "11:11", timezone: "" }),
+    /Timezone is required when birth time is provided/,
+  );
+  assert.throws(
+    () => birthDataSchema.parse({ ...base, birthTime: "11:11", timezone: "local" }),
+    /valid IANA timezone/,
+  );
+  assert.throws(
+    () => birthDataSchema.parse({ ...base, birthTime: "11:11", latitude: "abc" }),
+    /Latitude must be a finite number/,
+  );
+  assert.throws(
+    () => birthDataSchema.parse({ ...base, birthTime: "11:11", longitude: "200" }),
+    /Longitude must be a finite number/,
+  );
+});
+
 test("a provided birth time must use HH:MM instead of accepting arbitrary text", () => {
   assert.throws(() => birthDataSchema.parse({ ...base, birthTime: "not-a-time" }), /Birth time must use HH:MM/);
   assert.equal(birthDataSchema.parse({ ...base, birthTime: "11:11" }).birthTime, "11:11");


### PR DESCRIPTION
## Purpose
Fix the complete-birth-data confusion, keep specialist systems mostly behind the synthesis layer, add an optional auditable system-details surface, and lock the elegant natal PDF as the sole production renderer.

## Confirmed defects addressed
- Remote birth locations could inherit the **current device timezone** after direct client-side Nominatim lookup. The create flow now uses a server resolver that derives the IANA timezone from the birth coordinates with `geo-tz`.
- Exact timed inputs could still look simply “unknown.” The create flow now distinguishes **inputs missing** from **calculation-ready / verification pending**.
- Ascendant verification retry could disappear after verification version 2 even when Rising remained unresolved. Exact timed inputs now keep Rising retryable until it actually verifies.

## Product architecture
- Adds optional `/systems` inspector. It shows verified values, explicitly labeled calculated candidates, deterministic numerology, Human Design trust state, and unresolved reasons without promoting them.
- Adds executable `shared/system-visibility.ts`: candidates can be inspectable while remaining ineligible for primary synthesis; unfinished systems remain production-ineligible.
- Keeps primary Soul Codex synthesis-first rather than adding more front-page system dashboards.

## Natal PDF
- Existing elegant path remains canonical: `NatalReportDownloadButton` → `GET /api/pdf/profile/:id` → truth adapter → `server/natalReportPdf.ts`.
- Adds a production-path test that forbids `server/**` / `client/**` from importing legacy template PDF generators.
- No unsupported houses, aspects, nodes, Chiron, Midheaven, or Human Design candidates are promoted just to make the PDF look fuller.

## Tests added
- birth-location timezone/readiness contract
- Ascendant current-version retry contract
- system visibility/synthesis eligibility contract
- production PDF path contract

## Remaining work
Tracked in #221. Unverified houses/MC, nodes/Chiron, authoritative Human Design, astrocartography lines, and palm CV remain unavailable until they earn their own evidence-grade implementation.

## Separate ca17084 handoff
The described local `ca17084...` intelligence tranche is **not recreated here**. Its commit is absent from the connected GitHub repo and the patch bytes are not available in this session; it remains a separate reconciliation lane until the actual artifact is available.