### PR TITLE
Fix timezone-shifted Life Path calculations and repair saved profiles

### DIFF
--- a/client/src/lib/ActiveProfileRepository.ts
+++ b/client/src/lib/ActiveProfileRepository.ts
@@ -12,6 +12,7 @@
  * 5. Recovery messaging (missing, corrupted, wrong version)
  */
 
+import { calcLifePath } from "@soulcodex/core";
 import type { PlacementLike } from './placementVerification';
 
 export interface StoredProfile {
@@ -105,7 +106,9 @@ export function loadActiveProfile(): ProfileLoadResult {
     if (canonical.status === "loaded") {
       const validation = validateProfile(canonical.profile);
       if (validation.valid) {
-        return { status: "loaded", profile: canonical.profile };
+        const repaired = repairStoredLifePath(canonical.profile);
+        if (repaired !== canonical.profile) saveToKey(CANONICAL_KEY, repaired);
+        return { status: "loaded", profile: repaired };
       }
       return {
         status: validation.reason === "wrong-version" ? "wrong-version" : "corrupted",
@@ -288,12 +291,12 @@ function migrateLegacyProfile(profile: StoredProfile): {
   if (!profile.birthDate) return { success: false };
 
   const now = new Date().toISOString();
-  const migrated: StoredProfile = {
+  const migrated: StoredProfile = repairStoredLifePath({
     ...profile,
     schemaVersion: SCHEMA_VERSION,
     createdAt: profile.createdAt ?? now,
     updatedAt: now,
-  };
+  });
 
   saveToKey(CANONICAL_KEY, migrated);
   const readBack = readFromKey(CANONICAL_KEY);
@@ -304,6 +307,40 @@ function migrateLegacyProfile(profile: StoredProfile): {
 
   notifyProfileUpdated();
   return { success: true, profile: readBack.profile };
+}
+
+function repairStoredLifePath(profile: StoredProfile): StoredProfile {
+  const storedNumerology =
+    profile.numerologyData && typeof profile.numerologyData === "object"
+      ? profile.numerologyData
+      : undefined;
+  const hasStoredLifePath =
+    profile.lifePathNumber !== undefined || storedNumerology?.lifePath !== undefined;
+  if (!profile.birthDate || !hasStoredLifePath) return profile;
+
+  let expectedLifePath: number;
+  try {
+    expectedLifePath = calcLifePath(profile.birthDate);
+  } catch {
+    return profile;
+  }
+
+  if (
+    profile.lifePathNumber === expectedLifePath &&
+    (!storedNumerology || storedNumerology.lifePath === expectedLifePath)
+  ) {
+    return profile;
+  }
+
+  return {
+    ...profile,
+    lifePathNumber: expectedLifePath,
+    numerologyData: {
+      ...(storedNumerology ?? {}),
+      lifePath: expectedLifePath,
+    },
+    updatedAt: new Date().toISOString(),
+  };
 }
 
 function validateProfile(

--- a/client/src/lib/ActiveProfileRepository.ts
+++ b/client/src/lib/ActiveProfileRepository.ts
@@ -314,8 +314,9 @@ function repairStoredLifePath(profile: StoredProfile): StoredProfile {
     profile.numerologyData && typeof profile.numerologyData === "object"
       ? profile.numerologyData
       : undefined;
-  const hasStoredLifePath =
-    profile.lifePathNumber !== undefined || storedNumerology?.lifePath !== undefined;
+  const hasFlatLifePath = typeof profile.lifePathNumber === "number";
+  const hasNumericNestedLifePath = typeof storedNumerology?.lifePath === "number";
+  const hasStoredLifePath = hasFlatLifePath || hasNumericNestedLifePath;
   if (!profile.birthDate || !hasStoredLifePath) return profile;
 
   let expectedLifePath: number;
@@ -326,19 +327,18 @@ function repairStoredLifePath(profile: StoredProfile): StoredProfile {
   }
 
   if (
-    profile.lifePathNumber === expectedLifePath &&
-    (!storedNumerology || storedNumerology.lifePath === expectedLifePath)
+    (!hasFlatLifePath || profile.lifePathNumber === expectedLifePath) &&
+    (!hasNumericNestedLifePath || storedNumerology?.lifePath === expectedLifePath)
   ) {
     return profile;
   }
 
   return {
     ...profile,
-    lifePathNumber: expectedLifePath,
-    numerologyData: {
-      ...(storedNumerology ?? {}),
-      lifePath: expectedLifePath,
-    },
+    ...(hasFlatLifePath ? { lifePathNumber: expectedLifePath } : {}),
+    ...(hasNumericNestedLifePath
+      ? { numerologyData: { ...storedNumerology, lifePath: expectedLifePath } }
+      : {}),
     updatedAt: new Date().toISOString(),
   };
 }

--- a/client/src/lib/__tests__/ActiveProfileRepository.test.ts
+++ b/client/src/lib/__tests__/ActiveProfileRepository.test.ts
@@ -47,6 +47,28 @@ describe("ActiveProfileRepository", () => {
   });
 
   describe("Canonical profile lifecycle", () => {
+    it("repairs a timezone-shifted stored Life Path on load", () => {
+      localStorageMock.setItem(
+        "soulcodex.activeProfile.v1",
+        JSON.stringify({
+          birthDate: "1990-09-17",
+          lifePathNumber: 8,
+          numerologyData: { lifePath: 8, expression: 4 },
+          schemaVersion: 1,
+        }),
+      );
+
+      const loadResult = loadActiveProfile();
+
+      expect(loadResult.status).toBe("loaded");
+      expect(loadResult.profile?.lifePathNumber).toBe(9);
+      expect(loadResult.profile?.numerologyData).toEqual({ lifePath: 9, expression: 4 });
+      expect(
+        JSON.parse(localStorageMock.getItem("soulcodex.activeProfile.v1") ?? "{}")
+          .lifePathNumber,
+      ).toBe(9);
+    });
+
     it("should save and load a profile under canonical key", () => {
       const profile: StoredProfile = {
         birthDate: "1990-09-17",
@@ -55,7 +77,7 @@ describe("ActiveProfileRepository", () => {
         sunSign: "Virgo",
         moonSign: "Pisces",
         risingSign: "Scorpio",
-        lifePathNumber: 7,
+        lifePathNumber: 9,
         archetype: "The Analyst",
       };
 
@@ -221,7 +243,7 @@ describe("ActiveProfileRepository", () => {
         sunSign: "Virgo",
         moonSign: "Pisces",
         risingSign: "Scorpio",
-        lifePathNumber: 7,
+        lifePathNumber: 9,
         humanDesignType: "Manifestor",
         archetype: "The Analyst",
       };
@@ -240,7 +262,7 @@ describe("ActiveProfileRepository", () => {
       expect(profile.sunSign).toBe("Virgo");
       expect(profile.moonSign).toBe("Pisces");
       expect(profile.risingSign).toBe("Scorpio");
-      expect(profile.lifePathNumber).toBe(7);
+      expect(profile.lifePathNumber).toBe(9);
       expect(profile.humanDesignType).toBe("Manifestor");
       expect(Object.keys(profile).length).toBeGreaterThan(5);
     });

--- a/client/src/lib/__tests__/activeProfileLifePathRepair.node.test.ts
+++ b/client/src/lib/__tests__/activeProfileLifePathRepair.node.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { loadActiveProfile } from "../ActiveProfileRepository";
+
+test("active profile load repairs and persists timezone-shifted Life Path 8", () => {
+  const store = new Map<string, string>();
+  store.set(
+    "soulcodex.activeProfile.v1",
+    JSON.stringify({
+      birthDate: "1990-09-17",
+      lifePathNumber: 8,
+      numerologyData: { lifePath: 8, expression: 4 },
+      schemaVersion: 1,
+    }),
+  );
+
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => store.set(key, value),
+      removeItem: (key: string) => store.delete(key),
+    },
+  });
+
+  const result = loadActiveProfile();
+  const persisted = JSON.parse(store.get("soulcodex.activeProfile.v1") ?? "{}");
+
+  assert.equal(result.status, "loaded");
+  assert.equal(result.profile?.lifePathNumber, 9);
+  assert.deepEqual(result.profile?.numerologyData, { lifePath: 9, expression: 4 });
+  assert.equal(persisted.lifePathNumber, 9);
+  assert.equal(persisted.numerologyData.lifePath, 9);
+});

--- a/client/src/lib/__tests__/foundationOfflineCodexRepair.test.ts
+++ b/client/src/lib/__tests__/foundationOfflineCodexRepair.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  generateFoundationOfflineCodexProfile,
+  repairFoundationOfflineCodexProfile,
+} from "../foundationOfflineCodex";
+
+describe("repairFoundationOfflineCodexProfile", () => {
+  it("rebuilds stale Life Path 8 synthesis as 9 without removing verified astrology", () => {
+    const generatedAt = "2026-08-21T12:00:00.000Z";
+    const correct = generateFoundationOfflineCodexProfile(
+      {
+        name: "robert gonzalez",
+        birthDate: "1990-09-17",
+        birthTime: "11:11",
+        birthLocation: "Bronx, New York",
+        timezone: "America/New_York",
+        latitude: "40.8448",
+        longitude: "-73.8648",
+      },
+      { id: "local-test", generatedAt, currentYear: 2026 },
+    );
+    const stale = {
+      ...correct,
+      numerologyData: { ...correct.numerologyData, lifePath: 8 },
+      biography: correct.biography.replace("Life Path 9", "Life Path 8"),
+      verifiedAstrologyData: {
+        sun: { verificationStatus: "verified", sign: "Virgo" },
+        moon: { verificationStatus: "verified", sign: "Virgo" },
+        rising: { verificationStatus: "verified", sign: "Scorpio" },
+      },
+    };
+
+    const repaired = repairFoundationOfflineCodexProfile(stale, {
+      repairedAt: "2026-08-21T13:00:00.000Z",
+      currentYear: 2026,
+    });
+
+    assert.equal(repaired.numerologyData.lifePath, 9);
+    assert.match(repaired.biography, /Life Path 9/);
+    assert.match(repaired.archetypeData.description, /Life Path 9/);
+    assert.deepEqual(repaired.verifiedAstrologyData, stale.verifiedAstrologyData);
+  });
+
+  it("returns an already-correct profile unchanged", () => {
+    const correct = generateFoundationOfflineCodexProfile(
+      {
+        name: "robert gonzalez",
+        birthDate: "1990-09-17",
+        birthLocation: "Bronx, New York",
+        timezone: "America/New_York",
+      },
+      { id: "local-test", generatedAt: "2026-08-21T12:00:00.000Z", currentYear: 2026 },
+    );
+
+    assert.equal(repairFoundationOfflineCodexProfile(correct), correct);
+  });
+});

--- a/client/src/lib/foundationOfflineCodex.ts
+++ b/client/src/lib/foundationOfflineCodex.ts
@@ -264,3 +264,49 @@ export function generateFoundationOfflineCodexProfile(
     updatedAt: generatedAt,
   };
 }
+
+/**
+ * Repair deterministic local synthesis created by the former timezone-sensitive
+ * date parser. Online astronomy evidence is deliberately preserved verbatim.
+ */
+export function repairFoundationOfflineCodexProfile<T extends OfflineCodexProfile>(
+  profile: T,
+  options: { repairedAt?: string; currentYear?: number } = {},
+): T {
+  let expectedLifePath: number;
+  try {
+    expectedLifePath = calcLifePath(profile.birthDate);
+  } catch {
+    return profile;
+  }
+
+  if (profile.numerologyData?.lifePath === expectedLifePath) return profile;
+
+  const repairedAt = options.repairedAt ?? new Date().toISOString();
+  const rebuilt = generateFoundationOfflineCodexProfile(
+    {
+      name: profile.name,
+      birthDate: profile.birthDate,
+      birthTime: profile.birthTime ?? "",
+      birthLocation: profile.birthLocation,
+      timezone: profile.timezone,
+      latitude: profile.latitude ?? "",
+      longitude: profile.longitude ?? "",
+    },
+    {
+      id: profile.id,
+      generatedAt: repairedAt,
+      currentYear: options.currentYear,
+    },
+  );
+
+  return {
+    ...profile,
+    numerologyData: rebuilt.numerologyData,
+    archetypeData: rebuilt.archetypeData,
+    biography: rebuilt.biography,
+    dailyGuidance: rebuilt.dailyGuidance,
+    depthInterpretation: rebuilt.depthInterpretation,
+    updatedAt: repairedAt,
+  };
+}

--- a/client/src/lib/offlineProfileStore.ts
+++ b/client/src/lib/offlineProfileStore.ts
@@ -1,4 +1,5 @@
 import type { OfflineCodexProfile } from "@soulcodex/core";
+import { repairFoundationOfflineCodexProfile } from "./foundationOfflineCodex";
 
 const DB_NAME = "soulcodex-offline";
 const DB_VERSION = 1;
@@ -78,14 +79,29 @@ export async function saveOfflineProfile(profile: OfflineCodexProfile): Promise<
 }
 
 export async function loadOfflineProfile(id: string): Promise<OfflineCodexProfile | null> {
-  if (!hasIndexedDb()) return loadFallback(id);
+  if (!hasIndexedDb()) {
+    const stored = loadFallback(id);
+    if (!stored) return null;
+    const repaired = repairFoundationOfflineCodexProfile(stored);
+    if (repaired !== stored) saveFallback(repaired);
+    return repaired;
+  }
 
   try {
-    const profile = await withStore<OfflineCodexProfile | undefined>("readonly", (store) => store.get(id));
-    return profile ?? loadFallback(id);
+    const stored =
+      (await withStore<OfflineCodexProfile | undefined>("readonly", (store) => store.get(id))) ??
+      loadFallback(id);
+    if (!stored) return null;
+    const repaired = repairFoundationOfflineCodexProfile(stored);
+    if (repaired !== stored) await saveOfflineProfile(repaired);
+    return repaired;
   } catch (error) {
     console.warn("[offlineProfileStore] IndexedDB read failed; using localStorage fallback", error);
-    return loadFallback(id);
+    const stored = loadFallback(id);
+    if (!stored) return null;
+    const repaired = repairFoundationOfflineCodexProfile(stored);
+    if (repaired !== stored) saveFallback(repaired);
+    return repaired;
   }
 }
 

--- a/packages/astrology/numerology.ts
+++ b/packages/astrology/numerology.ts
@@ -1,6 +1,25 @@
 const digitSum = (n: number): number => 
   Math.abs(n).toString().split("").reduce((a, b) => a + Number(b), 0);
 
+const dateOnlyParts = (isoDOB: string) => {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(isoDOB);
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const candidate = new Date(Date.UTC(year, month - 1, day));
+
+  if (
+    candidate.getUTCFullYear() !== year ||
+    candidate.getUTCMonth() + 1 !== month ||
+    candidate.getUTCDate() !== day
+  ) {
+    return null;
+  }
+
+  return { year, month, day };
+};
+
 const reduceCore = (n: number): number => {
   while (![11, 22, 33].includes(n) && n > 9) {
     n = digitSum(n);
@@ -10,20 +29,23 @@ const reduceCore = (n: number): number => {
 
 export const lifePath = (isoDOB?: string): number | null => {
   if (!isoDOB) return null;
-  const d = new Date(isoDOB);
-  const total = digitSum(d.getFullYear()) + digitSum(d.getMonth() + 1) + digitSum(d.getDate());
+  const d = dateOnlyParts(isoDOB);
+  if (!d) return null;
+  const total = digitSum(d.year) + digitSum(d.month) + digitSum(d.day);
   return reduceCore(reduceCore(total));
 };
 
 export const birthDay = (isoDOB?: string): number | null => {
   if (!isoDOB) return null;
-  return reduceCore(new Date(isoDOB).getDate());
+  const d = dateOnlyParts(isoDOB);
+  return d ? reduceCore(d.day) : null;
 };
 
 export const personalYear = (isoDOB?: string, today = new Date()): number | null => {
   if (!isoDOB) return null;
-  const d = new Date(isoDOB);
-  const total = digitSum(d.getMonth() + 1) + digitSum(d.getDate()) + digitSum(today.getFullYear());
+  const d = dateOnlyParts(isoDOB);
+  if (!d) return null;
+  const total = digitSum(d.month) + digitSum(d.day) + digitSum(today.getFullYear());
   return reduceCore(total);
 };
 

--- a/packages/core/__tests__/numerology-date-only.test.ts
+++ b/packages/core/__tests__/numerology-date-only.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { calcLifePath } from '../compute/numerology.js';
+import { calcPersonalYear } from '../compute/personal-numbers.js';
+import { calcLifePathWithEvidence } from '../evidence-ledger/integrations.js';
+
+test('Bobby fixture resolves Life Path 9 in every host timezone', () => {
+  const originalTimezone = process.env.TZ;
+
+  try {
+    for (const timezone of ['UTC', 'America/New_York', 'Pacific/Honolulu', 'Asia/Tokyo']) {
+      process.env.TZ = timezone;
+      assert.equal(calcLifePath('1990-09-17'), 9, timezone);
+      assert.equal(calcPersonalYear('1990-09-17', 2026), 9, timezone);
+    }
+  } finally {
+    if (originalTimezone === undefined) delete process.env.TZ;
+    else process.env.TZ = originalTimezone;
+  }
+});
+
+test('Life Path evidence preserves the entered calendar date', () => {
+  const result = calcLifePathWithEvidence('1990-09-17');
+
+  assert.equal(result.value, 9);
+  assert.deepEqual(result.evidence.inputsUsed, [
+    'birth_month_9',
+    'birth_day_17',
+    'birth_year_1990',
+  ]);
+});
+
+test('date-only numerology rejects impossible calendar dates', () => {
+  assert.throws(() => calcLifePath('1990-02-30'), /real calendar date/);
+});

--- a/packages/core/compute/date-only.ts
+++ b/packages/core/compute/date-only.ts
@@ -1,0 +1,38 @@
+export type DateOnlyParts = {
+  year: number;
+  month: number;
+  day: number;
+};
+
+function isLeapYear(year: number): boolean {
+  return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+}
+
+export function parseDateOnly(dateISO: string): DateOnlyParts {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateISO);
+  if (!match) throw new RangeError("Date must use YYYY-MM-DD");
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const daysInMonth = [
+    31,
+    isLeapYear(year) ? 29 : 28,
+    31,
+    30,
+    31,
+    30,
+    31,
+    31,
+    30,
+    31,
+    30,
+    31,
+  ];
+
+  if (month < 1 || month > 12 || day < 1 || day > daysInMonth[month - 1]) {
+    throw new RangeError("Date must be a real calendar date");
+  }
+
+  return { year, month, day };
+}

--- a/packages/core/compute/numerology.ts
+++ b/packages/core/compute/numerology.ts
@@ -1,3 +1,5 @@
+import { parseDateOnly } from './date-only.js';
+
 function reduceToSingleDigit(num: number): number {
   while (num > 9 && num !== 11 && num !== 22 && num !== 33) {
     num = num
@@ -9,12 +11,9 @@ function reduceToSingleDigit(num: number): number {
 }
 
 export function calcLifePath(dateISO: string): number {
-  const date = new Date(dateISO);
-  const day = date.getDate();
-  const month = date.getMonth() + 1;
-  const year = date.getFullYear();
+  const { day, month, year } = parseDateOnly(dateISO);
 
-  let sum = day + month + year;
+  const sum = day + month + year;
   return reduceToSingleDigit(sum);
 }
 

--- a/packages/core/compute/personal-numbers.ts
+++ b/packages/core/compute/personal-numbers.ts
@@ -5,6 +5,8 @@
  * Used consistently across Today, Profile, Timeline, and Codex surfaces.
  */
 
+import { parseDateOnly } from './date-only.js';
+
 function reduceToSingleDigit(num: number): number {
   while (num > 9 && num !== 11 && num !== 22 && num !== 33) {
     num = num.toString().split('').reduce((sum, digit) => sum + parseInt(digit), 0);
@@ -21,9 +23,7 @@ function reduceToSingleDigit(num: number): number {
  * calcPersonalDay("1990-08-15", new Date("2026-07-06")) // July 6, 2026 for someone born Aug 15
  */
 export function calcPersonalDay(birthDate: string, targetDate: Date = new Date()): number {
-  const birth = new Date(birthDate);
-  const birthDay = birth.getDate();
-  const birthMonth = birth.getMonth() + 1;
+  const { day: birthDay, month: birthMonth } = parseDateOnly(birthDate);
   const targetDay = targetDate.getDate();
   const targetMonth = targetDate.getMonth() + 1;
   const targetYear = targetDate.getFullYear();
@@ -60,9 +60,9 @@ export function calcPersonalYear(
   // 1. (birthDate: string, targetYear: number)
   // 2. (birthMonth: number, birthDay: number, targetYear: number)
   if (typeof birthDateOrMonth === 'string') {
-    const birth = new Date(birthDateOrMonth);
-    birthMonth = birth.getMonth() + 1;
-    birthDay = birth.getDate();
+    const birth = parseDateOnly(birthDateOrMonth);
+    birthMonth = birth.month;
+    birthDay = birth.day;
     targetYear = targetYearOrDay || new Date().getFullYear();
   } else {
     // Legacy signature: (month, day, year)

--- a/packages/core/evidence-ledger/integrations.ts
+++ b/packages/core/evidence-ledger/integrations.ts
@@ -16,16 +16,18 @@ import {
 } from './index.js';
 import { calcPersonalDay, calcPersonalMonth, calcPersonalYear } from '../compute/personal-numbers.js';
 import { calcLifePath, calcExpression, calcSoulUrge, calcPersonality } from '../compute/numerology.js';
+import { parseDateOnly } from '../compute/date-only.js';
 
 type InputState = 'valid' | 'partial' | 'missing' | 'invalid';
 
 function isValidDate(dateStr: string): boolean {
   if (!dateStr || typeof dateStr !== 'string') return false;
-  const date = new Date(dateStr);
-  if (isNaN(date.getTime())) return false;
-  // Check format YYYY-MM-DD
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) return false;
-  return true;
+  try {
+    parseDateOnly(dateStr);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function isValidName(name: string): boolean {
@@ -106,9 +108,7 @@ export function calcPersonalDayWithEvidence(
   }
 
   const personalDay = calcPersonalDay(birthDate, targetDate);
-  const birth = new Date(birthDate);
-  const birthDay = birth.getDate();
-  const birthMonth = birth.getMonth() + 1;
+  const { day: birthDay, month: birthMonth } = parseDateOnly(birthDate);
   const targetDay = targetDate.getDate();
   const targetMonth = targetDate.getMonth() + 1;
   const targetYear = targetDate.getFullYear();
@@ -189,9 +189,7 @@ export function calcPersonalYearWithEvidence(
   }
 
   const personalYear = calcPersonalYear(birthDate, targetYear);
-  const birth = new Date(birthDate);
-  const birthMonth = birth.getMonth() + 1;
-  const birthDay = birth.getDate();
+  const { month: birthMonth, day: birthDay } = parseDateOnly(birthDate);
 
   const evidence = createEvidenceEntry(
     'numerology',
@@ -344,10 +342,11 @@ export function calcLifePathWithEvidence(
   }
 
   const lifePathValue = calcLifePath(birthDate);
-  const birth = new Date(birthDate);
-  const birthMonth = birth.getMonth() + 1;
-  const birthDay = birth.getDate();
-  const birthYear = birth.getFullYear();
+  const {
+    month: birthMonth,
+    day: birthDay,
+    year: birthYear,
+  } = parseDateOnly(birthDate);
 
   const evidence = createEvidenceEntry(
     'numerology',

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -8,6 +8,7 @@ export * from './accuracy/index.js';
 export * from './compute/synthesis.js';
 export * from './compute/archetype.js';
 export * from './compute/numerology.js';
+export * from './compute/date-only.js';
 export * from './compute/elements.js';
 export * from './compute/moral.js';
 export * from './compute/confidence.js';


### PR DESCRIPTION
## Summary
- parse `YYYY-MM-DD` birth dates as calendar-only values instead of converting through a host timezone
- apply the same date-only boundary to Life Path, Personal Day/Year, evidence receipts, and the astrology workspace helper
- automatically repair stale local and active profiles whose stored Life Path no longer matches the deterministic calculation
- rebuild numerology-derived biography, archetype, guidance, and depth interpretation while preserving verified online astrology evidence

## Root cause
In negative UTC offsets, `new Date("1990-09-17").getDate()` can produce September 16. The old calculation therefore used `16 + 9 + 1990 = 2015 → 8`. The entered date is September 17, so the correct result is `17 + 9 + 1990 = 2016 → 9`.

## Validation
- `npm test` — 435 passing
- `npm run check`
- `npm run check:workspaces`
- `npm run build:workspaces`
- `npm run build`
- date regression passes under UTC, America/New_York, Pacific/Honolulu, and Asia/Tokyo
- saved-profile repair regression confirms Life Path 8 becomes 9 and verified Sun/Moon/Rising evidence is retained

## Risk / rollback
The migration runs only when a stored Life Path disagrees with the deterministic date-only calculation. Invalid dates fail closed, and already-correct profiles retain object identity. Reverting this PR restores the former behavior, but would reintroduce timezone-dependent numerology.